### PR TITLE
Separate scripts to be installed on puppetmaster from those that are installed on foreman server

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,6 +49,5 @@ class foreman::config {
   }
 
   if $foreman::params::reports { include foreman::config::reports }
-  if $foreman::params::enc     { include foreman::config::enc }
   if $foreman::params::passenger  { include foreman::config::passenger }
 }

--- a/manifests/config/reports.pp
+++ b/manifests/config/reports.pp
@@ -1,14 +1,5 @@
 class foreman::config::reports {
 
-  # foreman reporter
-  file {"${foreman::params::puppet_basedir}/reports/foreman.rb":
-    mode     => '0444',
-    owner    => 'puppet',
-    group    => 'puppet',
-    content  => template('foreman/foreman-report.rb.erb'),
-    # notify => Service["puppetmaster"],
-  }
-
   cron { 'expire_old_reports':
     command => "(cd ${foreman::params::app_root} && rake reports:expire)",
     minute  => '30',

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -1,0 +1,16 @@
+# This class includes the necessary scripts for Foreman on the puppetmaster and is intented to be added to your puppetmaster
+class foreman::puppetmaster {
+  include foreman::params
+
+  if $foreman::params::reports {   # foreman reporter
+    file {"${foreman::params::puppet_basedir}/reports/foreman.rb":
+      mode     => '0444',
+      owner    => 'puppet',
+      group    => 'puppet',
+      content  => template('foreman/foreman-report.rb.erb'),
+      # notify => Service["puppetmaster"],
+    }
+  }
+
+  if $foreman::params::enc     { include foreman::config::enc }
+}


### PR DESCRIPTION
We shouldn't make the assumption that foreman runs on the same hosts as the
puppetmaster.
So this patch separates the scripts that are to be installed on the
puppetmaster (enc & report script) into the class foreman::puppetmaster
that can be added to the puppetmaster.
