### PR TITLE
Fix db install for sqlite

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class foreman (
   $ssl             = $foreman::params::ssl,
   $custom_repo     = $foreman::params::custom_repo,
   $use_testing     = $foreman::params::use_testing,
+  $use_sqlite      = $foreman::params::use_sqlite,
   $railspath       = $foreman::params::railspath,
   $app_root        = $foreman::params::app_root,
   $user            = $foreman::params::user,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,20 +11,24 @@ class foreman::install {
     default => Foreman::Install::Repos['foreman'],
   }
 
-  package {'foreman-sqlite3':
-    name => $osfamily ? {
-      RedHat => "foreman-sqlite",
-      Debian => "foreman-sqlite3"
-    },
-    ensure  => latest,
-    require => $repo,
-    notify  => [Class['foreman::service'],Package['foreman']],
-  }
-
   package {'foreman':
     ensure  => present,
     require => $repo,
     notify  => Class['foreman::service'],
+  }
+
+  if $foreman::use_sqlite {
+    $sqlite = $osfamily ? {
+      RedHat => "foreman-sqlite",
+      Debian => "foreman-sqlite3"
+    }
+
+    package {'foreman-sqlite3':
+      name => $sqlite
+      ensure  => latest,
+      require => $repo,
+      notify  => [Class['foreman::service'],Package['foreman']],
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class foreman::params {
   $app_root    = "${railspath}/foreman"
   $user        = 'foreman'
   $environment = 'production'
+  $use_sqlite  = true
 
   # Package source can be one of 'stable', 'testing', or 'nightly'
   $package_source = 'stable'


### PR DESCRIPTION
Properly select the right sqlite package based on OS.

Specially for @iNecas - the installation of sqlite3 is now optional. It's under Advanced and defaults to true.
