### PR TITLE
Parameterize puppetmaster

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -1,5 +1,9 @@
-class foreman::config::enc {
-  include foreman::params
+class foreman::config::enc (
+  $foreman_url  = $foreman::params::foreman_url,
+  $facts        = $foreman::params::facts,
+  $storeconfigs = $foreman::params::storeconfigs,
+  $puppet_home  = $foreman::params::puppet_home
+) inherits foreman::params {
 
   file { '/etc/puppet/node.rb':
     content => template('foreman/external_node.rb.erb'),
@@ -7,14 +11,14 @@ class foreman::config::enc {
     owner   => 'puppet',
     group   => 'puppet',
   }
-  file { "${foreman::params::puppet_home}/yaml":
+  file { "${puppet_home}/yaml":
     ensure  => directory,
     recurse => true,
     mode    => '0640',
     owner   => 'puppet',
     group   => 'puppet',
   }
-  file { "${foreman::params::puppet_home}/yaml/foreman":
+  file { "${puppet_home}/yaml/foreman":
     ensure  => directory,
     mode    => '0640',
     owner   => 'puppet',

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -1,10 +1,15 @@
 # This class includes the necessary scripts for Foreman on the puppetmaster and
 # is intented to be added to your puppetmaster
-class foreman::puppetmaster {
-  include foreman::params
+class foreman::puppetmaster (
+  $foreman_url    = $foreman::params::foreman_url,
+  $facts          = $foreman::params::facts,
+  $storeconfigs   = $foreman::params::storeconfigs,
+  $puppet_home    = $foreman::params::puppet_home,
+  $puppet_basedir = $foreman::params::puppet_basedir
+) inherits foreman::params {
 
   if $foreman::params::reports {   # foreman reporter
-    file {"${foreman::params::puppet_basedir}/reports/foreman.rb":
+    file {"${puppet_basedir}/reports/foreman.rb":
       mode     => '0444',
       owner    => 'puppet',
       group    => 'puppet',
@@ -13,5 +18,12 @@ class foreman::puppetmaster {
     }
   }
 
-  if $foreman::params::enc     { include foreman::config::enc }
+  if $foreman::params::enc     {
+    class {'foreman::config::enc':
+      foreman_url  => $foreman_url,
+      facts        => $facts,
+      storeconfigs => $storeconfigs,
+      puppet_home  => $puppet_home,
+    }
+  }
 }

--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -1,10 +1,10 @@
 #! /usr/bin/env ruby
 
 SETTINGS = {
-  :url          => "<%= scope.lookupvar('foreman::params::foreman_url')%>",
-  :puppetdir    => "<%= scope.lookupvar('foreman::params::puppet_home')%>",
-  :facts        => <%= scope.lookupvar('foreman::params::facts')%>,
-  :storeconfigs => <%= scope.lookupvar('foreman::params::storeconfigs')%>,
+  :url          => "<%= @foreman_url %>",
+  :puppetdir    => "<%= @puppet_home %>",
+  :facts        => <%= @facts %>,
+  :storeconfigs => <%= @storeconfigs %>,
   :timeout      => 3,
 }
 

--- a/templates/foreman-report.rb.erb
+++ b/templates/foreman-report.rb.erb
@@ -3,7 +3,7 @@
 # reports=log, foreman # (or any other reports you want)
 
 # URL of your Foreman installation
-$foreman_url='<%= scope.lookupvar("foreman::params::foreman_url") %>'
+$foreman_url='<%= @foreman_url %>'
 
 require 'puppet'
 require 'net/http'


### PR DESCRIPTION
This should make it easier to override the puppet master in cases where the puppet master and foreman server are split.
