### PR TITLE
Include foreman's default port in foreman_url

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 class foreman::params {
 
 # Basic configurations
-  $foreman_url  = "http://${::fqdn}"
+  $foreman_url  = "http://${::fqdn}:3000"
   # Should foreman act as an external node classifier (manage puppet class
   # assignments)
   $enc          = true


### PR DESCRIPTION
by default the foreman-installer runs foreman on port 3000 however the foreman module's params.pp sets foreman_url to _only_ the FQDN of the host and not the port… this then has a knock on effect to any of the file templates, including /etc/puppet/node.rb
