### PR TITLE
Puppet master without foreman

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -5,6 +5,8 @@ class foreman::config::enc (
   $puppet_home  = $foreman::params::puppet_home
 ) inherits foreman::params {
 
+  File { require => Class['::puppet::server::install']}
+
   file { '/etc/puppet/node.rb':
     content => template('foreman/external_node.rb.erb'),
     mode    => '0550',

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -14,6 +14,7 @@ class foreman::puppetmaster (
       owner    => 'puppet',
       group    => 'puppet',
       content  => template('foreman/foreman-report.rb.erb'),
+      require  => Class['::puppet::server::install'],
       # notify => Service["puppetmaster"],
     }
   }


### PR DESCRIPTION
If I want to deploy a machine with only Puppet master your module fails because try to create some files and folders with user/group "puppet", and that one not exists because the package is not yet installed.

I don't think so much about the best solution because dont know  foreman module in-depth. 

Thanks in advance.
