### PR TITLE
puppet 2.6 compatibility

### DIFF
--- a/manifests/install/repos.pp
+++ b/manifests/install/repos.pp
@@ -1,5 +1,5 @@
 define foreman::install::repos(
-  $use_testing    = false,
+  $use_testing    = false
 ) {
   case $::operatingsystem {
     redhat,centos,fedora,Scientific: {


### PR DESCRIPTION
Puppet 2.6 doesn't allow a trailing comma after the last argument.
