### PR TITLE
Fix Debian paths for Puppet3

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class foreman::params {
       }
     }
     Debian,Ubuntu: {
-      $puppet_basedir  = '/usr/lib/ruby/1.8/puppet'
+      $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
       $apache_conf_dir = '/etc/apache2/conf.d'
     }
     default:              {

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -9,13 +9,18 @@ class foreman::puppetmaster (
 ) inherits foreman::params {
 
   if $foreman::params::reports {   # foreman reporter
+    exec { "Create Puppet Reports dir":
+      command   => "/bin/mkdir -p ${puppet_basedir}/reports",
+      creates => "${puppet_basedir}/reports"
+    }
     file {"${puppet_basedir}/reports/foreman.rb":
       mode     => '0444',
       owner    => 'puppet',
       group    => 'puppet',
       content  => template('foreman/foreman-report.rb.erb'),
-      require  => Class['::puppet::server::install'],
-      # notify => Service["puppetmaster"],
+      require  => [Exec["Create Puppet Reports dir"],
+      Class['::puppet::server::install']
+      ],
     }
   }
 


### PR DESCRIPTION
Paths have changed in the Puppet3 debian packages from apt.puppetlabs.com
