### PR TITLE
Set FOREMAN_USE_PASSENGER / START when using passenger to disable init s...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,23 @@ class foreman::config {
     require => User[$foreman::user],
   }
 
+  case $::operatingsystem {
+    Debian,Ubuntu: {
+      $init_config = "/etc/default/foreman"
+      $init_config_tmpl = "foreman.default"
+    }
+    default: {
+      $init_config = "/etc/sysconfig/foreman"
+      $init_config_tmpl = "foreman.sysconfig"
+    }
+  }
+  file { $init_config:
+    ensure  => present,
+    content => template("foreman/${init_config_tmpl}.erb"),
+    require => Class['foreman::install'],
+    before  => Class['foreman::service'],
+  }
+
   file { $foreman::app_root:
     ensure  => directory,
   }

--- a/templates/foreman.default.erb
+++ b/templates/foreman.default.erb
@@ -1,0 +1,19 @@
+# Start foreman on boot?
+START=<%= scope.lookupvar('::foreman::passenger') ? 'no' : 'yes' %>
+
+# the location where foreman is installed
+FOREMAN_HOME=<%= scope.lookupvar('::foreman::app_root') %>
+
+# the network interface which foreman web server is running at
+#FOREMAN_IFACE=0.0.0.0
+
+# the port which foreman web server is running at
+# note that if the foreman user is not root, it has to be a > 1024
+# For non-root port 80, consider using Apache+Passenger
+#FOREMAN_PORT=3000
+
+# the user which runs the web interface
+FOREMAN_USER=<%= scope.lookupvar('::foreman::user') %>
+
+# the rails environment in which foreman runs
+FOREMAN_ENV=<%= scope.lookupvar('::foreman::environment') %>

--- a/templates/foreman.sysconfig.erb
+++ b/templates/foreman.sysconfig.erb
@@ -1,0 +1,21 @@
+# the location where foreman is installed
+FOREMAN_HOME=<%= scope.lookupvar('::foreman::app_root') %>
+
+# the port which foreman web server is running at
+# note that if the foreman user is not root, it has to be a > 1024
+#FOREMAN_PORT=3000
+
+# the user which runs the web interface
+FOREMAN_USER=<%= scope.lookupvar('::foreman::user') %>
+
+# the rails environment in which foreman runs
+FOREMAN_ENV=<%= scope.lookupvar('::foreman::environment') %>
+
+# if we're using passenger or not
+# if set to 1, init script will do a railsrestart on 'restart' and will refuse
+# 'start' and 'stop' completely and remind the operator that passenger is in
+# use.
+FOREMAN_USE_PASSENGER=<%= scope.lookupvar('::foreman::passenger') ? '1' : '0' %>
+
+# set to 1 if you're using thin as a server
+#FOREMAN_USE_THIN=0


### PR DESCRIPTION
Set FOREMAN_USE_PASSENGER / START when using passenger to disable init script.

[root@foreman production]# service foreman start
Foreman is running under passenger                         [PASSED]
