### PR TITLE
All packages should be 'present', or upgrades ensue

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,7 +23,7 @@ class foreman::install {
     }
 
     package {'foreman-sqlite3':
-      ensure  => latest,
+      ensure  => present,
       name    => $sqlite,
       require => $repo,
       notify  => [Class['foreman::service'], Package['foreman']],

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -21,7 +21,7 @@ describe 'foreman', :type => :class  do
       ## install
       it { should include_class('foreman::install') }
       it { should contain_package('foreman').with_ensure('present') }
-      it { should contain_package('foreman-sqlite3').with_ensure('latest') }
+      it { should contain_package('foreman-sqlite3').with_ensure('present') }
       # TODO: Test repos and require Repo.
 
       ## config


### PR DESCRIPTION
"foreman" was present, but "foreman-sqlite" was latest, which triggers an upgrade of all of Foreman due to package interdependencies.
