### PR TITLE
Don't enforce permissions on ${puppet_home}/yaml

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -16,13 +16,11 @@ class foreman::config::enc (
   file { "${puppet_home}/yaml":
     ensure  => directory,
     recurse => true,
-    mode    => '0640',
     owner   => 'puppet',
     group   => 'puppet',
   }
   file { "${puppet_home}/yaml/foreman":
     ensure  => directory,
-    mode    => '0640',
     owner   => 'puppet',
     group   => 'puppet',
   }


### PR DESCRIPTION
Puppet installs them using good enough permissions so no need to enforce
stricter permissions. This only creates noise.
