### PR TITLE
fixes #2155 - add --push-facts arg to ENC scripts

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -13,21 +13,24 @@ SETTINGS = {
   :ssl_key      => "<%= @ssl_key -%>"
 }
 
+# Script usually acts as an ENC for a single host, with the certname supplied as argument
+#   if 'facts' is true, the YAML facts for the host are uploaded
+#   ENC output is printed and cached
+#
+# If --push-facts is given as the only arg, it uploads facts for all hosts and then exits.
+# Useful in scenarios where the ENC isn't used.
+
 ### Do not edit below this line
 
 def url
   SETTINGS[:url] || raise("Must provide URL - please edit file")
 end
 
-def certname
-  ARGV[0] || raise("Must provide certname as an argument")
-end
-
 def puppetdir
   SETTINGS[:puppetdir] || raise("Must provide puppet base directory - please edit file")
 end
 
-def stat_file
+def stat_file(certname)
   FileUtils.mkdir_p "#{puppetdir}/yaml/foreman/"
   "#{puppetdir}/yaml/foreman/#{certname}.yaml"
 end
@@ -41,10 +44,17 @@ require 'net/https'
 require 'fileutils'
 require 'timeout'
 
-def upload_facts
+def upload_all_facts
+  Dir["#{puppetdir}/yaml/facts/*.yaml"].each do |f|
+    certname = File.basename(f, ".yaml")
+    upload_facts(certname, f)
+  end
+end
+
+def upload_facts(certname, filename)
   # Temp file keeping the last run time
-  last_run = File.exists?(stat_file) ? File.stat(stat_file).mtime.utc : Time.now - 365*24*60*60
-  filename = "#{puppetdir}/yaml/facts/#{certname}.yaml"
+  stat = stat_file(certname)
+  last_run = File.exists?(stat) ? File.stat(stat).mtime.utc : Time.now - 365*24*60*60
   last_fact = File.stat(filename).mtime.utc
   if last_fact > last_run
     fact = File.read(filename)
@@ -73,17 +83,17 @@ def upload_facts
   end
 end
 
-def cache result
-  File.open(stat_file, 'w') {|f| f.write(result) }
+def cache(certname, result)
+  File.open(stat_file(certname), 'w') {|f| f.write(result) }
 end
 
-def read_cache
-  File.read(stat_file)
+def read_cache(certname)
+  File.read(stat_file(certname))
 rescue => e
   raise "Unable to read from Cache file: #{e}"
 end
 
-def enc
+def enc(certname)
   foreman_url      = "#{url}/node/#{certname}?format=yml"
   uri              = URI.parse(foreman_url)
   req              = Net::HTTP::Get.new(foreman_url)
@@ -109,25 +119,31 @@ end
 
 # Actual code starts here
 begin
-  # send facts to Foreman - optional uncomment 'upload_facts' to activate.
-  # if you use this option below, make sure that you don't send facts to foreman via the rake task or push facts alternatives.
-  #
-  if SETTINGS[:facts] && !SETTINGS[:storeconfigs]
-    upload_facts
-  end
-  #
-  # query External node
-  begin
-    result = ""
-    timeout(tsecs) do
-      result = enc
-      cache result
+  if ARGV.delete("--push-facts")
+    # push all facts files to Foreman and don't act as an ENC
+    upload_all_facts
+  else
+    certname = ARGV[0] || raise("Must provide certname as an argument")
+    # send facts to Foreman - enable 'facts' setting to activate
+    # if you use this option below, make sure that you don't send facts to foreman via the rake task or push facts alternatives.
+    #
+    if SETTINGS[:facts] && !SETTINGS[:storeconfigs]
+      upload_facts certname, "#{puppetdir}/yaml/facts/#{certname}.yaml"
     end
-  rescue TimeoutError, SocketError, Errno::EHOSTUNREACH
-    # Read from cache, we got some sort of an error.
-    result = read_cache
-  ensure
-    puts result
+    #
+    # query External node
+    begin
+      result = ""
+      timeout(tsecs) do
+        result = enc(certname)
+        cache(certname, result)
+      end
+    rescue TimeoutError, SocketError, Errno::EHOSTUNREACH
+      # Read from cache, we got some sort of an error.
+      result = read_cache(certname)
+    ensure
+      puts result
+    end
   end
 rescue => e
   warn e


### PR DESCRIPTION
Extends ENC to be able to upload facts for all hosts, replacing the old
push_facts.rb script and keeping comms logic in the same place.
