### PR TITLE
Storeconfigs typo. && precedence fix

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -112,7 +112,7 @@ begin
   # send facts to Foreman - optional uncomment 'upload_facts' to activate.
   # if you use this option below, make sure that you don't send facts to foreman via the rake task or push facts alternatives.
   #
-  if ( SETTINGS[:facts] ) and not ( SETTINGS[:storeconfig] )
+  if SETTINGS[:facts] && !SETTINGS[:storeconfigs]
     upload_facts
   end
   #


### PR DESCRIPTION
There was a typo where :storeconfigs was written as :storeconfig. 

The 'and not' was changed for the ampersand and bang because of this: https://github.com/bbatsov/ruby-style-guide .

"and" (control flow) and "&&" (boolean) are not the same, the second one has more precedence and using the former might lead to weird errors. Example:

> > a = true
> > b = false
> > b and a ? 'hello' : '**silence**'
> > => false  # oops. should be **_silence**_
