### PR TITLE
Revert "Use the RC repo for now"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class foreman::params {
   # set it to some custom location.
   $custom_repo = false
   # this can be stable, rc, or nightly
-  $repo        = 'rc'
+  $repo        = 'stable'
   $railspath   = '/usr/share'
   $app_root    = "${railspath}/foreman"
   $user        = 'foreman'


### PR DESCRIPTION
Now that 1.1 is released there's no longer a reason to use the RC repo.

This reverts commit 4098163a8e03843d2e87698f6d310c4c8b26528b.
