### PR TITLE
Ignore selinux defaults for puppet yaml files

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -17,10 +17,11 @@ class foreman::config::enc (
     group   => 'puppet',
   }
   file { "${puppet_home}/yaml":
-    ensure  => directory,
-    recurse => true,
-    owner   => 'puppet',
-    group   => 'puppet',
+    ensure                  => directory,
+    recurse                 => true,
+    owner                   => 'puppet',
+    group                   => 'puppet',
+    selinux_ignore_defaults => true,
   }
   file { "${puppet_home}/yaml/foreman":
     ensure  => directory,


### PR DESCRIPTION
On my system files in /var/lib/puppet/yaml are created with unconfined_u while
the system expects them as system_u. This creates noise in every puppet run and
ensures the system will stay active in the foreman dashboard.
