### PR TITLE
Add --no-environment option to node.rb

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -122,6 +122,7 @@ end
 
 # Actual code starts here
 begin
+  no_env = ARGV.delete("--no-environment")
   if ARGV.delete("--push-facts")
     # push all facts files to Foreman and don't act as an ENC
     upload_all_facts
@@ -145,7 +146,14 @@ begin
       # Read from cache, we got some sort of an error.
       result = read_cache(certname)
     ensure
-      puts result
+      if no_env
+        require 'yaml'
+        yaml = YAML.load(result)
+        yaml.delete('environment')
+        puts yaml.to_yaml
+      else
+        puts result
+      end
     end
   end
 rescue => e


### PR DESCRIPTION
This allows us to circumvent bug http://projects.puppetlabs.com/issues/3910 on puppet 2.7.

When using node.rb with --no-environment, yaml does not contains any environment and thus client is always authoritative.
