### PR TITLE
Ensure ERB template file is parseable by Ruby for non-installer users

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -1,19 +1,18 @@
-<% @header = ''
-   ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file))), nil, nil, "@header").result(binding) -%>
 #!/usr/bin/env ruby
-<%= @header %>
+#<%= @header = ''; ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file))), nil, nil, "@header").result(binding); @header -%>
 
+# If copying this template by hand, replace the settings below including the angle brackets
 SETTINGS = {
-  :url          => "<%= @foreman_url %>",
-  :puppetdir    => "<%= @puppet_home %>",
-  :facts        => <%= @facts %>,
-  :storeconfigs => <%= @storeconfigs %>,
+  :url          => "<%= @foreman_url %>",  # e.g. https://foreman.example.com
+  :puppetdir    => "<%= @puppet_home %>",  # e.g. /var/lib/puppet
+  :facts        => <%= @facts %>,          # true/false to upload facts
+  :storeconfigs => <%= @storeconfigs %>,   # true/false if sharing ActiveRecord-storeconfigs
   :timeout      => 3,
   # if CA is specified, remote Foreman host will be verified
-  :ssl_ca       => "<%= @ssl_ca -%>",
+  :ssl_ca       => "<%= @ssl_ca -%>",      # e.g. /var/lib/puppet/ssl/certs/ca.pem
   # ssl_cert and key are required if require_ssl_puppetmasters is enabled in Foreman
-  :ssl_cert     => "<%= @ssl_cert -%>",
-  :ssl_key      => "<%= @ssl_key -%>"
+  :ssl_cert     => "<%= @ssl_cert -%>",    # e.g. /var/lib/puppet/ssl/certs/FQDN.pem
+  :ssl_key      => "<%= @ssl_key -%>"      # e.g. /var/lib/puppet/ssl/private_keys/FQDN.pem
 }
 
 # Script usually acts as an ENC for a single host, with the certname supplied as argument

--- a/templates/foreman-report.rb.erb
+++ b/templates/foreman-report.rb.erb
@@ -1,4 +1,4 @@
-<%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
+# <%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
 # copy this file to your report dir - e.g. /usr/lib/ruby/1.8/puppet/reports/
 # add this report in your puppetmaster reports - e.g, in your puppet.conf add:
 # reports=log, foreman # (or any other reports you want)


### PR DESCRIPTION
Users keep getting tripped up by the new headers as we suggest non-installer users download the templates.  I've prefixed the ERB with comments so the files are actually valid Ruby.
