### PR TITLE
Remove IP address from virtual host configurations

### DIFF
--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -1,6 +1,6 @@
 <%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
 
-<VirtualHost <%= ipaddress %>:80>
+<VirtualHost *:80>
   ServerName <%= fqdn %>
   ServerAlias foreman
   DocumentRoot <%= scope.lookupvar 'foreman::app_root' %>/public
@@ -11,7 +11,7 @@
 
 </VirtualHost>
 
-<VirtualHost <%= ipaddress %>:443>
+<VirtualHost *:443>
   ServerName <%= fqdn %>
   ServerAlias foreman
 


### PR DESCRIPTION
Was there a reason why IPs were used here? 

Just ran into an issue this afternoon where using the machine's IP doesn't allow the puppet master to retrieve node information if the puppet master and the foreman server are the same machine (since the request comes in on 127.0.0.1).

Apache seems to recommend against it (noting that it was required with mod_ssl in apache before 2.2.12): http://httpd.apache.org/docs/2.2/vhosts/name-based.html#namevip
