### PR TITLE
add ability to specify which interface/ipaddress passenger uses

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,5 +47,10 @@ class foreman::config {
     ensure  => absent,
   }
 
-  if $foreman::passenger  { include foreman::config::passenger }
+  if $foreman::passenger  {
+    class{"foreman::config::passenger":
+      listen_on_interface => $foreman::passenger_interface,
+    }
+  }
+
 }

--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -1,6 +1,20 @@
-class foreman::config::passenger {
+class foreman::config::passenger(
+
+  # specifiy which interface to bind passenger to eth0, eth1, ...
+  $listen_on_interface = ''
+
+
+) {
   include apache::ssl
   include ::passenger
+
+  # Check the value in case the interface doesn't exist, otherwise listen on all interfaces
+  if inline_template("<%= interfaces.split(',').include?(listen_on_interface) %>") == "true" {
+    $listen_interface = inline_template("<%= ipaddress_${listen_on_interface} %>")
+  }
+  else{
+    $listen_interface = '*'
+  }
 
   $foreman_conf = $foreman::use_vhost ? {
     false   => 'foreman/foreman-apache.conf.erb',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,8 @@ class foreman (
   $apache_conf_dir        = $foreman::params::apache_conf_dir,
   $puppet_home            = $foreman::params::puppet_home,
   $locations_enabled      = $foreman::params::locations_enabled,
-  $organizations_enabled  = $foreman::params::organizations_enabled
+  $organizations_enabled  = $foreman::params::organizations_enabled,
+  $passenger_interface    = $foreman::params::passenger_interface
 ) inherits foreman::params {
   class { 'foreman::install': } ~>
   class { 'foreman::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,8 @@ class foreman::params {
   $use_vhost    = true
   # force SSL (note: requires passenger)
   $ssl          = true
-
+  #define which interface passenger should listen on, undef means all interfaces
+  $passenger_interface = ''
   # Choose whether you want to enable locations and organizations.
   $locations_enabled      = false
   $organizations_enabled  = false

--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -1,6 +1,6 @@
 <%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
 
-<VirtualHost <%= ipaddress %>:80>
+<VirtualHost <%= listen_interface %>:80>
   ServerName <%= fqdn %>
   ServerAlias foreman
   DocumentRoot <%= scope.lookupvar 'foreman::app_root' %>/public
@@ -11,7 +11,7 @@
 
 </VirtualHost>
 
-<VirtualHost <%= ipaddress %>:443>
+<VirtualHost <%= listen_interface %>:443>
   ServerName <%= fqdn %>
   ServerAlias foreman
 


### PR DESCRIPTION
By default, passenger will listen on all interfaces, unless specified otherwise.  Failure to enter a valid interface will default to all interfaces.
