### PR TITLE
Foreman user provider

### DIFF
--- a/lib/puppet/provider/foreman_user/ruby.rb
+++ b/lib/puppet/provider/foreman_user/ruby.rb
@@ -1,0 +1,130 @@
+begin
+  ENV["RAILS_ENV"] = 'production'
+  require File.expand_path("config/boot", '/usr/share/foreman')
+  require File.expand_path("config/application", '/usr/share/foreman')
+  Rails.application.require_environment!
+rescue LoadError
+end
+
+Puppet::Type.type(:foreman_user).provide(:ruby) do
+
+  def self.instances
+    resources = []
+    begin
+      User.all.each do |user|
+        resources << new(
+          :name          => user[:login],
+          :ensure        => :present,
+          :login         => user[:login],
+          :admin         => user[:admin] ? :true : :false,
+          :firstname     => user[:firstname],
+          :lastname      => user[:lastname],
+          :mail          => user[:mail]
+        )
+      end
+    rescue => e
+      raise "Could not get users from Foreman: #{e}"
+    end
+    resources
+  end
+
+  def self.prefetch(resources)
+    users = instances
+    resources.keys.each do |name|
+      if provider = users.find{ |u| u.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present 
+  end
+
+  def create
+    user = User.new(
+      :login       => resource[:login],
+      :firstname   => resource[:firstname],
+      :lastname    => resource[:lastname],
+      :mail        => resource[:mail],
+      :auth_source => AuthSourceInternal.first,
+      :password    => resource[:password]
+    )
+    user.update_attribute :admin, resource[:admin]  == :true ? true : false
+    old_current = User.current
+    User.current = User.admin
+    user.save!
+  ensure
+    User.current = old_current
+  end
+
+  def destroy
+    @property_hash[:ensure] = :absent
+    old_current = User.current
+    User.current = User.admin
+    User.find_by_login(@property_hash[:login]).destroy
+  ensure
+    User.current = old_current
+  end
+
+  def admin
+    @property_hash[:admin]
+  end
+
+  def admin=(value)
+    @property_hash[:admin] = value
+    user = User.find_by_login(@property_hash[:login])
+    user.update_attribute :admin, value == :true ? true : false
+    old_current = User.current
+    User.current = User.admin
+    user.save!
+  ensure
+    User.current = old_current
+  end
+
+  def firstname
+    @property_hash[:firstname]
+  end
+
+  def firstname=(value)
+    @property_hash[:firstname] = value
+    user = User.find_by_login(@property_hash[:login])
+    user.update_attribute :firstname, value
+    old_current = User.current
+    User.current = User.admin
+    user.save!
+  ensure
+    User.current = old_current
+  end
+
+  def lastname
+    @property_hash[:lastname]
+  end
+
+  def lastname=(value)
+    @property_hash[:lastname] = value
+    user = User.find_by_login(@property_hash[:login])
+    user.update_attribute :lastname, value
+    old_current = User.current
+    User.current = User.admin
+    user.save!
+  ensure
+    User.current = old_current
+  end
+
+  def mail
+    @property_hash[:mail]
+  end
+
+  def mail=(value)
+    @property_hash[:mail] = value
+    user = User.find_by_login(@property_hash[:login])
+    user.update_attribute :mail, value
+    old_current = User.current
+    User.current = User.admin
+    user.save!
+  ensure
+    User.current = old_current
+  end
+
+end

--- a/lib/puppet/type/foreman_user.rb
+++ b/lib/puppet/type/foreman_user.rb
@@ -1,0 +1,54 @@
+Puppet::Type.newtype(:foreman_user) do
+  desc 'foreman_user creates a user in foreman database.'
+
+  ensurable
+
+  def munge_boolean(value)
+    case value
+    when true, "true", :true
+      :true
+    when false, "false", :false
+      :false                                                                                
+    else
+      fail("munge_boolean only takes booleans")                                             
+    end
+  end 
+
+  newparam(:login, :namevar => true) do
+    desc 'The Login to user to connect to foreman.'
+
+    newvalues(/^[0-9A-Za-z_]+$/)
+  end
+
+  newparam(:password) do
+    desc 'Password to use at user creation.'
+
+    defaultto 'changeme'
+  end
+
+  newproperty(:admin) do
+    desc 'Wether user should be admin or not.'
+
+    defaultto :false
+    newvalues(:true, :false)
+
+    munge do |value|                                                                        
+      @resource.munge_boolean(value)                                                        
+    end
+  end
+
+  newproperty(:firstname) do
+    desc 'User\'s first name'
+  end
+
+  newproperty(:lastname) do
+    desc 'User\'s last name'
+  end
+
+  newproperty(:mail) do
+    desc 'User\'s mail'
+
+    newvalues(/^[_A-Za-z0-9-]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*(\.[A-Za-z]{2,4})$/)
+  end
+
+end

--- a/spec/unit/puppet/type/foreman_user_spec.rb
+++ b/spec/unit/puppet/type/foreman_user_spec.rb
@@ -1,0 +1,65 @@
+require 'puppet'
+require 'puppet/type/foreman_user'
+
+describe Puppet::Type.type(:foreman_user) do
+  subject { Puppet::Type.type(:foreman_user).new(:login => 'foo') }
+
+  it 'should accept ensure' do
+    subject[:ensure] = :present
+    subject[:ensure].should == :present
+  end
+
+  it 'should fail for invalid login' do
+    expect{subject[:login] = 'foo 123'}.to raise_error(Puppet::Error)
+    expect{subject[:login] = 'foo#123'}.to raise_error(Puppet::Error)
+    expect{subject[:login] = 'foo.123'}.to raise_error(Puppet::Error)
+    expect{subject[:login] = 'foo@123'}.to raise_error(Puppet::Error)
+  end
+
+  it 'should accept a valid login' do
+    subject[:login] = 'foo_123'
+    subject[:login].should == 'foo_123'
+  end
+
+  it 'should fail for invalid admin right' do
+    expect{subject[:admin] = :foo}.to raise_error(Puppet::Error)
+  end
+
+  it 'should accept a valid admin right' do
+    subject[:admin] = :true
+    subject[:admin].should == :true
+    subject[:admin] = :false
+    subject[:admin].should == :false
+  end
+
+  it 'should accept a firstname' do
+    subject[:firstname] = 'John'
+    subject[:firstname].should == 'John'
+  end
+
+  it 'should accept a lastname' do
+    subject[:lastname] = 'Doe'
+    subject[:lastname].should == 'Doe'
+  end
+
+  it 'should fail for invalid e-mail' do
+    expect{subject[:mail] = 'john.doe@example'}.to raise_error(Puppet::Error)
+    expect{subject[:mail] = 'john.doe@example.dotcom'}.to raise_error(Puppet::Error)
+    expect{subject[:mail] = 'john.doe@example@com'}.to raise_error(Puppet::Error)
+    expect{subject[:mail] = 'john.doë@example.com'}.to raise_error(Puppet::Error)
+    expect{subject[:mail] = '.john.doe@example.com'}.to raise_error(Puppet::Error)
+    expect{subject[:mail] = 'john.doe@.example.com'}.to raise_error(Puppet::Error)
+  end
+
+  it 'should accept a valid e-mail' do
+    subject[:mail] = 'john.doe@example.com'
+    subject[:mail].should == 'john.doe@example.com'
+    subject[:mail] = 'John.Doe@Example.Com'
+    subject[:mail].should == 'John.Doe@Example.Com'
+    subject[:mail] = 'john.doe@mx.example.com'
+    subject[:mail].should == 'john.doe@mx.example.com'
+    subject[:mail] = 'john.doe@mx-1.example.com'
+    subject[:mail].should == 'john.doe@mx-1.example.com'
+  end
+
+end


### PR DESCRIPTION
This is just a Proof of concept.

This is my first puppet type/provider so feel free to comments and criticize.
My idea is to implement most/all the foreman api with puppet types.

It's working for me but I'm sure there are lot of things to improve.

To create a user you can do:

``` puppet
foreman_user { 'foo':
  ensure    => present,
  firstname => 'foo',
  lastname  => 'bar',
  mail      => 'foo.bar@example.com',
  admin     => true,
  password  => 'foobar',
}
```

To delete a user:

``` puppet
foreman_user {'foo':
  ensure => absent,
}
```
