### PR TITLE
Add database management support

### DIFF
--- a/lib/puppet/parser/functions/cache_data.rb
+++ b/lib/puppet/parser/functions/cache_data.rb
@@ -1,0 +1,31 @@
+require 'fileutils'
+require 'yaml'
+
+# Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist
+#
+# Useful for having data that's randomly generated once on the master side (e.g. a password), but
+# then stays the same on subsequent runs.
+#
+# Usage: cache_data(name, initial_data)
+# Example: $password = cache_data("mysql_password", random_password(32))
+module Puppet::Parser::Functions
+  newfunction(:cache_data, :type => :rvalue) do |args|
+    raise Puppet::ParseError, 'Usage: cache_data(name, initial_data)' unless args.size == 2
+
+    name = args[0]
+    raise Puppet::ParseError, 'Must provide data name' unless name
+    initial_data = args[1]
+
+    cache_dir = File.join(Puppet[:vardir], 'foreman_cache_data')
+    cache = File.join(cache_dir, name)
+    if File.exists? cache
+      YAML.load(File.read(cache))
+    else
+      FileUtils.mkdir_p cache_dir unless File.exists? cache_dir
+      File.open(cache, 'w', 0600) do |c|
+        c.write(YAML.dump(initial_data))
+      end
+      initial_data
+    end
+  end
+end

--- a/lib/puppet/parser/functions/random_password.rb
+++ b/lib/puppet/parser/functions/random_password.rb
@@ -1,0 +1,87 @@
+#
+# random_password.rb
+#
+# Copyright 2012 Krzysztof Wilczynski
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Puppet::Parser::Functions
+  newfunction(:random_password, :type => :rvalue, :doc => <<-EOS
+Returns a string of arbitrary length that contains randomly selected characters.
+
+Prototype:
+
+    random_password(n)
+
+Where n is a non-negative numeric value that denotes length of the desired password.
+
+For example:
+
+  Given the following statements:
+
+    $a = 4
+    $b = 8
+    $c = 16
+
+    notice random_password($a)
+    notice random_password($b)
+    notice random_password($c)
+
+  The result will be as follows:
+
+    notice: Scope(Class[main]): fNDC
+    notice: Scope(Class[main]): KcKDLrjR
+    notice: Scope(Class[main]): FtvfvkS9j9wXLsd6
+    EOS
+  ) do |*arguments|
+    #
+    # This is to ensure that whenever we call this function from within
+    # the Puppet manifest or alternatively form a template it will always
+    # do the right thing ...
+    #
+    arguments = arguments.shift if arguments.first.is_a?(Array)
+
+    raise Puppet::ParseError, "random_password(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)" if arguments.size < 1
+
+    size = arguments.shift
+
+    # This should cover all the generic numeric types present in Puppet ...
+    unless size.class.ancestors.include?(Numeric) or size.is_a?(String)
+      raise Puppet::ParseError, 'random_password(): Requires a numeric ' +
+        'type to work with'
+    end
+
+    # Numbers in Puppet are often string-encoded which is troublesome ...
+    if size.is_a?(String) and size.match(/^\d+$/)
+      size = size.to_i
+    else
+      raise Puppet::ParseError, 'random_password(): Requires a non-negative ' +
+        'integer value to work with'
+    end
+
+    # These are quite often confusing ...
+    ambiguous_characters = %w(0 1 O I l)
+
+    # Get allowed characters set ...
+    set = ('a' .. 'z').to_a + ('A' .. 'Z').to_a + ('0' .. '9').to_a
+    set = set - ambiguous_characters
+
+    # Shuffle characters in the set at random and return desired number of them ...
+    size.times.collect {|i| set[rand(set.size)] }.join
+  end
+end
+
+# vim: set ts=2 sw=2 et :
+# encoding: utf-8

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,11 +5,19 @@ class foreman::config {
     environment => "RAILS_ENV=${foreman::environment}",
   }
 
-  file {'/etc/foreman/settings.yaml':
+  file { '/etc/foreman/settings.yaml':
     content => template('foreman/settings.yaml.erb'),
     notify  => Class['foreman::service'],
-    owner   => $foreman::user,
+    owner   => 'root',
     require => User[$foreman::user],
+  }
+
+  file { '/etc/foreman/database.yml':
+    owner   => 'root',
+    group   => $foreman::group,
+    mode    => 640,
+    content => template('foreman/database.yml.erb'),
+    notify  => Class['foreman::service'],
   }
 
   case $::operatingsystem {

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,0 +1,14 @@
+class foreman::database {
+  if $foreman::db_manage {
+    $db_class = "foreman::database::${foreman::db_type}"
+
+    class { $db_class: } ~>
+    exec { "dbmigrate":
+      command     => "${foreman::app_root}/extras/dbmigrate",
+      user        => $foreman::user,
+      environment => "HOME=${foreman::app_root}",
+      logoutput   => 'on_failure',
+      refreshonly => true,
+    }
+  }
+}

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -1,0 +1,12 @@
+class foreman::database::mysql {
+  $dbname = $foreman::db_database ? {
+    'UNSET' => 'foreman',
+    default => $foreman::db_database,
+  }
+
+  include mysql, mysql::server, mysql::server::account_security
+  mysql::db { $dbname:
+    user     => $foreman::db_username,
+    password => $foreman::db_password,
+  }
+}

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -1,0 +1,17 @@
+class foreman::database::postgresql {
+  $dbname = $foreman::db_database ? {
+    'UNSET' => 'foreman',
+    default => $foreman::db_database,
+  }
+
+  # Prevents errors if run from /root etc.
+  Postgresql_psql {
+    cwd => "/",
+  }
+
+  include postgresql::client, postgresql::server
+  postgresql::db { $dbname:
+    user     => $foreman::db_username,
+    password => postgresql_password($foreman::db_username, $foreman::db_password),
+  }
+}

--- a/manifests/database/sqlite.pp
+++ b/manifests/database/sqlite.pp
@@ -1,0 +1,3 @@
+class foreman::database::sqlite {
+  # no-op
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,15 @@ class foreman (
   $ssl                    = $foreman::params::ssl,
   $custom_repo            = $foreman::params::custom_repo,
   $repo                   = $foreman::params::repo,
-  $use_sqlite             = $foreman::params::use_sqlite,
+  $db_manage              = $foreman::params::db_manage,
+  $db_type                = $foreman::params::db_type,
+  $db_adapter             = 'UNSET',
+  $db_host                = 'UNSET',
+  $db_port                = 'UNSET',
+  $db_database            = 'UNSET',
+  $db_username            = $foreman::params::db_username,
+  $db_password            = $foreman::params::db_password,
+  $db_sslmode             = 'UNSET',
   $railspath              = $foreman::params::railspath,
   $app_root               = $foreman::params::app_root,
   $user                   = $foreman::params::user,
@@ -25,5 +33,6 @@ class foreman (
 ) inherits foreman::params {
   class { 'foreman::install': } ~>
   class { 'foreman::config': } ~>
+  class { 'foreman::database': } ~>
   class { 'foreman::service': }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,24 +10,23 @@ class foreman::install {
     default => Foreman::Install::Repos['foreman'],
   }
 
-  package {'foreman':
+  case $foreman::db_type {
+    sqlite: {
+      case $::operatingsystem {
+        Debian,Ubuntu: { $package = 'foreman-sqlite3' }
+        default:       { $package = 'foreman-sqlite' }
+      }
+    }
+    postgresql: {
+      $package = 'foreman-postgresql'
+    }
+    mysql: {
+      $package = 'foreman-mysql'
+    }
+  }
+
+  package { $package:
     ensure  => present,
     require => $repo,
-    notify  => Class['foreman::service'],
   }
-
-  if $foreman::use_sqlite {
-    case $::operatingsystem {
-      Debian,Ubuntu: { $sqlite = 'foreman-sqlite3' }
-      default:       { $sqlite = 'foreman-sqlite' }
-    }
-
-    package {'foreman-sqlite3':
-      ensure  => present,
-      name    => $sqlite,
-      require => $repo,
-      notify  => [Class['foreman::service'], Package['foreman']],
-    }
-  }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,8 +39,17 @@ class foreman::params {
   $railspath   = '/usr/share'
   $app_root    = "${railspath}/foreman"
   $user        = 'foreman'
+  $group       = 'foreman'
   $environment = 'production'
-  $use_sqlite  = true
+
+  # if enabled, will install and configure the database server on this host
+  $db_manage   = true
+  # Database 'production' settings
+  $db_type     = 'postgresql'
+  $db_username = 'foreman'
+  # Generate and cache the password on the master once
+  # In multi-puppetmaster setups, the user should specify their own
+  $db_password = cache_data("db_password", random_password(32))
 
   # OS specific paths
   $ruby_major = regsubst($::rubyversion, '^(\d+\.\d+).*', '\1')

--- a/templates/database.yml.erb
+++ b/templates/database.yml.erb
@@ -1,0 +1,52 @@
+<%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
+
+# SQLite version 3.x
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+
+<%
+  type     = scope.lookupvar("::foreman::db_type")
+  adapter  = scope.lookupvar("::foreman::db_adapter")
+  adapter  = (type == 'sqlite') ? 'sqlite3' : type if adapter == 'UNSET'
+  host     = scope.lookupvar("::foreman::db_host")
+  host     = scope.lookupvar("::fqdn") if type == 'mysql' && adapter == 'UNSET'
+  database = scope.lookupvar("::foreman::db_database")
+  database = (type == 'sqlite') ? 'db/production.sqlite3' : 'foreman' if database == 'UNSET'
+-%>
+<% unless scope.lookupvar("::foreman::db_manage") == 'UNSET' -%>
+# Database is managed by foreman::database::<%= type %>
+<% end -%>
+production:
+  adapter: <%= adapter %>
+<% unless host == 'UNSET' -%>
+  host: <%= host %>
+<% end -%>
+<% unless (port = scope.lookupvar("::foreman::db_port")) == 'UNSET' -%>
+  port: <%= port %>
+<% end -%>
+<% unless (sslmode = scope.lookupvar("::foreman::db_sslmode")) == 'UNSET' -%>
+  sslmode: <%= sslmode %>
+<% end -%>
+  database: <%= database %>
+<% unless (username = scope.lookupvar("::foreman::db_username")) == 'UNSET' -%>
+  username: <%= username %>
+<% end -%>
+<% unless (password = scope.lookupvar("::foreman::db_password")) == 'UNSET' -%>
+  password: <%= password %>
+<% end -%>
+<% if type == 'sqlite' -%>
+  pool: 5
+  timeout: 5000
+<% end -%>


### PR DESCRIPTION
database.yml is now managed by this module, and by default it will fully manage
a PostgreSQL server on the host.  The db_type parameter can be changed to
manage MySQL or use SQLite instead.  The puppet-postgresql and puppetlabs-mysql
modules are used.  manage_db can be changed to stop managing the server and
instead only manage Foreman's database config.
