### PR TITLE
add support for different storeconfigs backends

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -2,6 +2,7 @@ class foreman::config::enc (
   $foreman_url  = $foreman::params::foreman_url,
   $facts        = $foreman::params::facts,
   $storeconfigs = $foreman::params::storeconfigs,
+  $storeconfigs_backend = $foreman::params::storeconfigs_backend,
   $puppet_home  = $foreman::params::puppet_home,
   $ssl_ca       = $foreman::params::client_ssl_ca,
   $ssl_cert     = $foreman::params::client_ssl_cert,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,8 @@ class foreman::params {
   # Do you use storeconfig (and run foreman on the same database) ? (note: not
   # required)
   $storeconfigs = false
+  # what backend to use for storedconfigs (false for default (activerecord), puppetdb for puppetdb)
+  $storeconfigs_backend = false
   # should foreman manage host provisioning as well
   $unattended   = true
   # Enable users authentication (default user:admin pw:changeme)

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -4,6 +4,7 @@ class foreman::puppetmaster (
   $foreman_url    = $foreman::params::foreman_url,
   $facts          = $foreman::params::facts,
   $storeconfigs   = $foreman::params::storeconfigs,
+  $storeconfigs_backend = $foreman::params::storeconfigs_backend,
   $puppet_home    = $foreman::params::puppet_home,
   $puppet_basedir = $foreman::params::puppet_basedir,
   $ssl_ca         = $foreman::params::client_ssl_ca,
@@ -30,13 +31,14 @@ class foreman::puppetmaster (
 
   if $foreman::params::enc     {
     class {'foreman::config::enc':
-      foreman_url  => $foreman_url,
-      facts        => $facts,
-      storeconfigs => $storeconfigs,
-      puppet_home  => $puppet_home,
-      ssl_ca       => $ssl_ca,
-      ssl_cert     => $ssl_cert,
-      ssl_key      => $ssl_key
+      foreman_url          => $foreman_url,
+      facts                => $facts,
+      storeconfigs         => $storeconfigs,
+      storeconfigs_backend => $storeconfigs_backend,
+      puppet_home          => $puppet_home,
+      ssl_ca               => $ssl_ca,
+      ssl_cert             => $ssl_cert,
+      ssl_key              => $ssl_key
     }
   }
 }

--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -6,7 +6,7 @@ SETTINGS = {
   :url          => "<%= @foreman_url %>",  # e.g. https://foreman.example.com
   :puppetdir    => "<%= @puppet_home %>",  # e.g. /var/lib/puppet
   :facts        => <%= @facts %>,          # true/false to upload facts
-  :storeconfigs => <%= @storeconfigs %>,   # true/false if sharing ActiveRecord-storeconfigs
+  :storeconfigs => <%= @storeconfigs && !@storeconfigs_backend %>,   # true/false if sharing ActiveRecord-storeconfigs
   :timeout      => 3,
   # if CA is specified, remote Foreman host will be verified
   :ssl_ca       => "<%= @ssl_ca -%>",      # e.g. /var/lib/puppet/ssl/certs/ca.pem


### PR DESCRIPTION
needed for puppet-puppet to support defining puppetdb as storeconfigs_backend
