### PR TITLE
Add ruby Type and Provider for foreman_smartproxy

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/ruby.rb
+++ b/lib/puppet/provider/foreman_smartproxy/ruby.rb
@@ -1,0 +1,77 @@
+begin
+  ENV['RAILS_ENV'] = 'production'
+  require File.expand_path('config/boot', '/usr/share/foreman')
+  require File.expand_path('config/application', '/usr/share/foreman')
+  Rails.application.require_environment!
+rescue LoadError
+end
+
+Puppet::Type.type(:foreman_smartproxy).provide(:ruby) do
+
+  def self.instances
+    resources = []
+    begin
+      SmartProxy.all.each do |proxy|
+        resources << new(
+          :name   => proxy[:name],
+          :ensure => :present,
+          :url    => proxy[:url]
+        )
+      end
+    rescue => e
+      raise "Could not get smartproxies from Foreman: #{e}"
+    end
+    resources
+  end
+
+  def self.prefetch(resources)
+    proxies = instances
+    resources.keys.each do |name|
+      if provider = proxies.find{ |p| p.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present 
+  end
+
+  def create
+    proxy = SmartProxy.new(
+      :name => resource[:name],
+      :url  => resource[:url]
+    )
+    old_current = User.current
+    User.current = User.admin
+    proxy.save!
+  ensure
+    User.current = old_current
+  end
+
+  def destroy
+    @property_hash[:ensure] = :absent
+    old_current = User.current
+    User.current = User.admin
+    SmartProxy.find_by_name(@property_hash[:name]).destroy
+  ensure
+    User.current = old_current
+  end
+
+  def url
+    @property_hash[:url]
+  end
+
+  def url=(value)
+    @property_hash[:url] = value
+    proxy = SmartProxy.find_by_name(@property_hash[:name])
+    proxy.update_attribute :url, value
+    old_current = User.current
+    User.current = User.admin
+    proxy.save!
+  ensure
+    User.current = old_current
+  end
+
+end
+

--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -1,0 +1,16 @@
+Puppet::Type.newtype(:foreman_smartproxy) do
+  desc 'foreman_smartproxy creates a smartproxy in foreman database.'
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc 'The name of the smartproxy.'
+  end
+
+  newproperty(:url) do
+    desc 'The url of the smartproxy'
+    newvalues(/^https?:\/\/[A-z0-9]+(-[A-z0-9]+)*(\.[A-z0-9]+(-[A-z0-9]+)*)*(:[0-9]+)*$/)
+  end
+
+end
+

--- a/spec/unit/puppet/type/foreman_smartproxy_spec.rb
+++ b/spec/unit/puppet/type/foreman_smartproxy_spec.rb
@@ -1,0 +1,39 @@
+require 'puppet'
+require 'puppet/type/foreman_smartproxy'
+
+describe Puppet::Type.type(:foreman_smartproxy) do
+  subject { Puppet::Type.type(:foreman_smartproxy).new(:name => 'foo') }
+
+  it 'should accept ensure' do
+    subject[:ensure] = :present
+    subject[:ensure].should == :present
+  end
+
+  it 'should accept a valid name' do
+    subject[:name] = 'foo'
+    subject[:name].should == 'foo'
+  end
+
+  it 'should fail for invalid url' do
+    expect{subject[:url] = 'ftp://example.com'}.to raise_error(Puppet::Error)
+    expect{subject[:url] = 'http://example.com/file.html'}.to raise_error(Puppet::Error)
+    expect{subject[:url] = 'http://-example.com'}.to raise_error(Puppet::Error)
+  end
+
+  it 'should accept a valid url' do
+    subject[:url] = 'http://example'
+    subject[:url].should == 'http://example'
+    subject[:url] = 'https://example'
+    subject[:url].should == 'https://example'
+    subject[:url] = 'http://example.com'
+    subject[:url].should == 'http://example.com'
+    subject[:url] = 'https://example.com'
+    subject[:url].should == 'https://example.com'
+    subject[:url] = 'http://example.com:8080'
+    subject[:url].should == 'http://example.com:8080'
+    subject[:url] = 'https://example.com:8443'
+    subject[:url].should == 'https://example.com:8443'
+    subject[:url] = 'http://Example.Com'
+    subject[:url].should == 'http://Example.Com'
+  end
+end


### PR DESCRIPTION
Use this to define a smartproxy in your smartproxy node:

``` puppet
@@foreman_smartproxy {$::fqdn:
  url => "https://${::fqdn}:8443",
}
```

And this in your foreman node:

``` puppet
Foreman_smartproxy <<| |>>
```
