### PR TITLE
use concat to manage /etc/foreman/settings.yaml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,8 +5,16 @@ class foreman::config {
     environment => "RAILS_ENV=${foreman::environment}",
   }
 
-  file {'/etc/foreman/settings.yaml':
+  concat_build {'foreman_settings':
+    order => ['*.yaml'],
+  }
+
+  concat_fragment {'foreman_settings+01-header.yaml':
     content => template('foreman/settings.yaml.erb'),
+  }
+
+  file {'/etc/foreman/settings.yaml':
+    source  => concat_output('foreman_settings'),
     notify  => Class['foreman::service'],
     owner   => $foreman::user,
     require => User[$foreman::user],


### PR DESCRIPTION
Foreman plugins usually stores configuration in foreman's settings.yaml, so we can't manage settings.yaml as a single File resource.

With this patch, I can do that to configure, for example, column_view plugin:

``` puppet
concat_fragment {'foreman_settings+02-column_view.yaml':
  content => ':column_view:
  :title: Uptime
  :content: facts_hash[\'uptime\']
',
}
```
