### PR TITLE
Using camptocamp/apt for Debian/Ubuntu, Modulefile added.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,12 @@
+name    'theforeman-foreman'
+version '0.0.1'
+source 'https://github.com/theforeman/puppet-foreman.git'
+author 'theforeman'
+#license 'TODO'
+summary 'Puppet module for Foreman'
+description 'Puppet module for Foreman'
+project_page 'https://github.com/theforeman/puppet-foreman'
+
+#dependency 'camptocamp/apt', '>=0.0.2'
+#dependency 'theforeman/passenger', 'TODO'
+#dependency 'theforeman/apache', 'TODO'

--- a/manifests/install/repos.pp
+++ b/manifests/install/repos.pp
@@ -17,19 +17,16 @@ define foreman::install::repos(
       }
     }
     Debian,Ubuntu: {
-      file { "/etc/apt/sources.list.d/${name}.list":
-        content => "deb http://deb.theforeman.org/ ${::lsbdistcodename} ${repo}\n"
+
+      apt::key{'2048R/E775FF07':
+        source => 'http://deb.theforeman.org/foreman.asc',
       }
-      ~>
-      exec { "foreman-key-${name}":
-        command     => '/usr/bin/wget -q http://deb.theforeman.org/foreman.asc -O- | /usr/bin/apt-key add -',
-        refreshonly => true
+
+      apt::sources_list{'foreman':
+        content => "deb http://deb.theforeman.org/ ${::lsbdistcodename} ${repo}",
+        require => Apt::Key['2048R/E775FF07'],
       }
-      ~>
-      exec { "update-apt-${name}":
-        command     => '/usr/bin/apt-get update',
-        refreshonly => true
-      }
+
     }
     default: { fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}") }
   }


### PR DESCRIPTION
Just added the Modulefile to indicate dependencies on theforman/apache and theforman/passenger. Those modules may need a Modulefile as well.

The camptocamp/apt dependency in the Modulefile is commented as this is not required for RedHat.
