### PR TITLE
fixes #2342 keeping $oslevel, setting warning to $osfamily

### DIFF
--- a/manifests/install/repos.pp
+++ b/manifests/install/repos.pp
@@ -3,8 +3,8 @@ define foreman::install::repos(
 ) {
   include foreman::params
 
-  case $::operatingsystem {
-    redhat,centos,fedora,Scientific: {
+  case $::osfamily {
+    RedHat: {
       $repo_path = $repo ? {
         'stable' => 'releases/latest',
         default  => $repo,
@@ -16,7 +16,7 @@ define foreman::install::repos(
           enabled  => '1';
       }
     }
-    Debian,Ubuntu: {
+    Debian: {
       file { "/etc/apt/sources.list.d/${name}.list":
         content => "deb http://deb.theforeman.org/ ${::lsbdistcodename} ${repo}\n"
       }
@@ -31,6 +31,6 @@ define foreman::install::repos(
         refreshonly => true
       }
     }
-    default: { fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}") }
+    default: { fail("${::hostname}: This module does not support operatingsystem ${::osfamily}") }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,23 +44,22 @@ class foreman::params {
 
   # OS specific paths
   $ruby_major = regsubst($::rubyversion, '^(\d+\.\d+).*', '\1')
-  case $::operatingsystem {
-    fedora: {
+  case $::osfamily {
+    RedHat: {
       if $::operatingsystemrelease >= 17 {
         $puppet_basedir  = "/usr/share/ruby/vendor_ruby/puppet"
       } else {
         $puppet_basedir  = "/usr/lib/ruby/site_ruby/${ruby_major}/puppet"
       }
+      if $::operatingsystemrelease >- 17 {
+        $yumcode = "f${::operatingsystemrelease}"
+      } else {
+        $osmajor = regsubst($::operatingsystemrelease, '\..*', '')
+        $yumcode = "el${osmajor}"
+      }
       $apache_conf_dir = '/etc/httpd/conf.d'
-      $yumcode = "f${::operatingsystemrelease}"
     }
-    redhat,centos,Scientific: {
-      $puppet_basedir  = "/usr/lib/ruby/site_ruby/${ruby_major}/puppet"
-      $apache_conf_dir = '/etc/httpd/conf.d'
-      $osmajor = regsubst($::operatingsystemrelease, '\..*', '')
-      $yumcode = "el${osmajor}"
-    }
-    Debian,Ubuntu: {
+    Debian: {
       $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
       $apache_conf_dir = '/etc/apache2/conf.d'
     }


### PR DESCRIPTION
Removed the checks for every redhat variant, set the check to ::osfamily, removed the double check for Ubunto under the Debian check and also changed the not supported from ::operatingsystem to ::osfamily. This should allow all RedHat based OS's including Oracle Linux to install with latest facter showing the correct ::osfamily.

Sorry for all the dupe pull requests.. i'm a nub
