### PR TITLE
Add missing dependency on concat from file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,7 @@ class foreman::config {
 
   file {'/etc/foreman/settings.yaml':
     source  => concat_output('foreman_settings'),
+    require => Concat_build['foreman_settings'],
     notify  => Class['foreman::service'],
     owner   => 'root',
   }


### PR DESCRIPTION
```
Error: /File[/etc/foreman/settings.yaml]: Could not evaluate: Could not retrieve information from environment production source(s) file:/var/lib/puppet/concat/output/foreman_settings.out
Notice: /Stage[main]/Foreman::Config/Concat_fragment[foreman_settings+01-header.yaml]/content: content changed '' to '--- ..... '
Notice: /Stage[main]/Foreman::Config/Concat_build[foreman_settings]/target: *.yaml used for ordering
```
