### PR TITLE
Updated permissions for /etc/foreman/settings.yaml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,8 @@ class foreman::config {
     require => Concat_build['foreman_settings'],
     notify  => Class['foreman::service'],
     owner   => 'root',
+    group   => $foreman::group,
+    mode    => '0640',
   }
 
   file { '/etc/foreman/database.yml':


### PR DESCRIPTION
Due to my umask of 077, I was unable to read the settings.yaml file.  By making sure the foreman group owns the file and the permissions allow the foreman group to read the file, I was able to use this module to start foreman.
