### PR TITLE
Ensuring proper yaml for for external node classifier.

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -124,8 +124,8 @@ end
 
 # Setuid to puppet if we can
 begin
-  Process::GID.change_privilege(Etc.getgrnam('puppet').gid)
-  Process::UID.change_privilege(Etc.getpwnam('puppet').uid)
+  Process::GID.change_privilege(Etc.getgrnam('puppet').gid) unless Etc.getpwuid.name == 'puppet'
+  Process::UID.change_privilege(Etc.getpwnam('puppet').uid) unless Etc.getpwuid.name == 'puppet'
 rescue
   puts "cannot switch to user 'puppet', continuing as '#{Etc.getpwuid.name}'"
 end


### PR DESCRIPTION
Ensuring proper yaml when using external node classifier
Removing unnecessary setuid when already running as puppet
