### PR TITLE
Add passenger_scl parameter for EL+SCL installations

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,6 +68,7 @@ class foreman::config {
   if $foreman::passenger  {
     class{"foreman::config::passenger":
       listen_on_interface => $foreman::passenger_interface,
+      scl_prefix          => $foreman::passenger_scl,
     }
   }
 

--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -1,12 +1,17 @@
 class foreman::config::passenger(
 
   # specifiy which interface to bind passenger to eth0, eth1, ...
-  $listen_on_interface = ''
-
+  $listen_on_interface = '',
+  $scl_prefix = undef
 
 ) {
   include apache::ssl
   include ::passenger
+  if $scl_prefix {
+    class { '::passenger::install::scl':
+      prefix => $scl_prefix,
+    }
+  }
 
   # Check the value in case the interface doesn't exist, otherwise listen on all interfaces
   if inline_template('<%= @interfaces.split(',').include?(@listen_on_interface) %>') == 'true' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class foreman (
   $unattended             = $foreman::params::unattended,
   $authentication         = $foreman::params::authentication,
   $passenger              = $foreman::params::passenger,
+  $passenger_scl          = $foreman::params::passenger_scl,
   $use_vhost              = $foreman::params::use_vhost,
   $ssl                    = $foreman::params::ssl,
   $custom_repo            = $foreman::params::custom_repo,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,22 +64,27 @@ class foreman::params {
           }
           $apache_conf_dir = '/etc/httpd/conf.d'
           $yumcode = "f${::operatingsystemrelease}"
+          $passenger_scl = undef
         }
         default: {
           $puppet_basedir  = "/usr/lib/ruby/site_ruby/${ruby_major}/puppet"
           $apache_conf_dir = '/etc/httpd/conf.d'
           $osmajor = regsubst($::operatingsystemrelease, '\..*', '')
           $yumcode = "el${osmajor}"
+          # add passenger::install::scl as EL uses SCL on Foreman 1.2+
+          $passenger_scl = 'ruby193'
         }
       }
     }
     Debian: {
       $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
       $apache_conf_dir = '/etc/apache2/conf.d'
+      $passenger_scl = undef
     }
     default:              {
       $puppet_basedir  = "/usr/lib/ruby/${ruby_major}/puppet"
       $apache_conf_dir = '/etc/apache2/conf.d/foreman.conf'
+      $passenger_scl = undef
     }
   }
   $puppet_home = '/var/lib/puppet'

--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -5,8 +5,10 @@
   ServerAlias foreman
   DocumentRoot <%= scope.lookupvar 'foreman::app_root' %>/public
   PassengerAppRoot <%= scope.lookupvar 'foreman::app_root' %>
+<% if @scl_prefix -%>
+  PassengerRuby /usr/bin/<%= @scl_prefix -%>-ruby
+<% end -%>
 
-  RailsAutoDetect On
   AddDefaultCharset UTF-8
 
 </VirtualHost>
@@ -15,9 +17,11 @@
   ServerName <%= @fqdn %>
   ServerAlias foreman
 
-  RailsAutoDetect On
   DocumentRoot <%= scope.lookupvar 'foreman::app_root' %>/public
   PassengerAppRoot <%= scope.lookupvar 'foreman::app_root' %>
+<% if @scl_prefix -%>
+  PassengerRuby /usr/bin/<%= @scl_prefix -%>-ruby
+<% end -%>
 
   # Use puppet certificates for SSL
 


### PR DESCRIPTION
Installs extra passenger components for the SCL and changes vhosts to use the
SCL ruby version.

Depends on https://github.com/theforeman/puppet-passenger/pull/9
