### PR TITLE
fixes #2653 - fixing httpd 2.4+ support in F18+

### DIFF
--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -3,6 +3,7 @@
 <VirtualHost <%= @listen_interface %>:80>
   ServerName <%= @fqdn %>
   ServerAlias foreman
+
   DocumentRoot <%= scope.lookupvar 'foreman::app_root' %>/public
   PassengerAppRoot <%= scope.lookupvar 'foreman::app_root' %>
 <% if @scl_prefix and !@scl_prefix.empty? -%>
@@ -10,6 +11,15 @@
 <% end -%>
 
   AddDefaultCharset UTF-8
+
+  <Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
+    <IfVersion < 2.4>
+      Allow from all
+    </IfVersion>  
+    <IfVersion >= 2.4>
+      Require all granted
+    </IfVersion>
+  </Directory>
 
 </VirtualHost>
 
@@ -22,6 +32,17 @@
 <% if @scl_prefix and !@scl_prefix.empty? -%>
   PassengerRuby /usr/bin/<%= @scl_prefix -%>-ruby
 <% end -%>
+
+  AddDefaultCharset UTF-8
+
+  <Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
+    <IfVersion < 2.4>
+      Allow from all
+    </IfVersion>  
+    <IfVersion >= 2.4>
+      Require all granted
+    </IfVersion>
+  </Directory>
 
   # Use puppet certificates for SSL
 


### PR DESCRIPTION
SSIA

Will do the same for puppet module. Going to investigate why RHEL6 works
without this access control.
