### PR TITLE
added require 'puppet' so that script functions properly.

### DIFF
--- a/templates/external_node.rb.erb
+++ b/templates/external_node.rb.erb
@@ -40,6 +40,7 @@ def tsecs
   SETTINGS[:timeout] || 3
 end
 
+require 'puppet'
 require 'etc'
 require 'net/http'
 require 'net/https'


### PR DESCRIPTION
When the file did NOT have require 'puppet' I continued to receive this error:

```
[15:03:23 CDT] jbarnett@puppet001 [/etc/puppet]# ./node.rb r225.mydomain.com
--- false
SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```

After I added the require 'puppet' my problems were solved:

```
[15:04:21 CDT] jbarnett@puppet001 [/etc/puppet]# ./node.rb r225.mydomain.com

---
  environment: staging
  classes:
    ntp:
    cloudfiles_backups:
    rvm:
    rsyslog:
    mysql_backups:
    postfix:
    motd:
      encfs: true
      clientname: "Engineering Stuff"
      dedicated: true
    yum:
    "base::services":
    ssh:
    diskalert:
    jdk:
    rackspace:
    sudo:
    "base::packages":
    cacti:
    "base::configs":
    jbarnett_profile:
    openldap:
    krb5:
  parameters:
    owner_name: "Jason Barnett"
    puppetmaster: ""
    root_pw: 1234
    hostgroup: Base
    foreman_env: staging
    owner_email: "J@sonBarnett.com"
```
