### PR TITLE
Add Amazon Linux support

### DIFF
--- a/manifests/install/repos.pp
+++ b/manifests/install/repos.pp
@@ -6,7 +6,7 @@ define foreman::install::repos(
   include foreman::params
 
   case $::osfamily {
-    RedHat: {
+    RedHat, Linux: {
       $repo_path = $repo ? {
         'stable' => 'releases/latest',
         default  => $repo,


### PR DESCRIPTION
This module does not support operatingsystem Linux at /usr/share/foreman-installer/foreman/manifests/install/repos.pp:52
