### PR TITLE
Add ability to configure groups for the foreman user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,6 +57,8 @@ class foreman::config {
     shell   => '/sbin/nologin',
     comment => 'Foreman',
     home    => $foreman::app_root,
+    gid     => $foreman::group,
+    groups  => $foreman::user_groups,
     require => Class['foreman::install'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,11 @@
 #
 # $user::                   User under which foreman will run
 #
+# $group::                  Primary group for the Foreman user
+#
+# $user_groups::            Additional groups for the Foreman user
+#                           type:array
+#
 # $environment::            Rails environment of foreman
 #
 # $puppet_basedir::         Where are puppet modules located
@@ -112,6 +117,8 @@ class foreman (
   $db_sslmode             = 'UNSET',
   $app_root               = $foreman::params::app_root,
   $user                   = $foreman::params::user,
+  $group                  = $foreman::params::group,
+  $user_groups            = $foreman::params::user_groups,
   $environment            = $foreman::params::environment,
   $puppet_basedir         = $foreman::params::puppet_basedir,
   $apache_conf_dir        = $foreman::params::apache_conf_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class foreman::params {
   $app_root    = "${railspath}/foreman"
   $user        = 'foreman'
   $group       = 'foreman'
+  $user_groups = ['puppet']
   $environment = 'production'
   $gpgcheck    = true
   $version     = 'present'

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -75,6 +75,8 @@ describe 'foreman::config' do
         'ensure'  => 'present',
         'shell'   => '/sbin/nologin',
         'comment' => 'Foreman',
+        'gid'     => 'foreman',
+        'groups'  => ['puppet'],
         'home'    => '/usr/share/foreman',
         'require' => 'Class[Foreman::Install]',
       })}


### PR DESCRIPTION
Defaults to the correct values for the all-in-one case - split-setup
users will need to adjust this accordingly. I think this is better
than a bunch of `if defined ...` magic to try and detect the
presence of the `foreman::puppetmaster` class in the catalog
