### PR TITLE
Fixes #3081 - proper handling of disabling ssl verification

### DIFF
--- a/templates/external_node_v2.rb.erb
+++ b/templates/external_node_v2.rb.erb
@@ -125,13 +125,13 @@ def enc(certname)
   http             = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl     = uri.scheme == 'https'
   if http.use_ssl?
-    if SETTINGS[:ssl_ca]
+    if SETTINGS[:ssl_ca] && !SETTINGS[:ssl_ca].empty?
       http.ca_file = SETTINGS[:ssl_ca]
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     else
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
-    if SETTINGS[:ssl_cert] and SETTINGS[:ssl_key]
+    if SETTINGS[:ssl_cert] && !SETTINGS[:ssl_cert].empty? && SETTINGS[:ssl_key] && !SETTINGS[:ssl_key].empty?
       http.cert = OpenSSL::X509::Certificate.new(File.read(SETTINGS[:ssl_cert]))
       http.key  = OpenSSL::PKey::RSA.new(File.read(SETTINGS[:ssl_key]), nil)
     end


### PR DESCRIPTION
Empty ssl_ca, ssl_cert and ssl_key mean not to use ssl
verification/authentication
