### PR TITLE
Set correct owner of postgre DB

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -15,7 +15,7 @@ class foreman::database::postgresql {
     cwd => '/',
   }
 
-  include postgresql::client, postgresql::server
+  include postgresql::client, postgresql::server, postgresql::params
   $grant = 'ALL'
   # TODO copied from puppetlabs-postgresql 2.3.0 manifests/db.pp
   # should be removed by db once they expose owner parameter
@@ -24,11 +24,11 @@ class foreman::database::postgresql {
     tablespace  => undef,
     require     => Class['postgresql::server'],
     locale      => $postgresql::params::locale,
-    owner       => $dbname,
+    owner       => $foreman::db_username,
   }
 
-  if ! defined(Postgresql::Database_user[$user]) {
-    postgresql::database_user { $dbname:
+  if ! defined(Postgresql::Database_user[$foreman::db_username]) {
+    postgresql::database_user { $foreman::db_username:
       password_hash   => $password,
       require         => Postgresql::Database[$dbname],
     }

--- a/manifests/database/sqlite.pp
+++ b/manifests/database/sqlite.pp
@@ -1,4 +1,7 @@
 # Set up the foreman database using sqlite
 class foreman::database::sqlite {
-  # no-op
+  exec { 'create':
+    command => '/usr/sbin/foreman-rake db:create',
+    creates => "${foreman::app_root}/db/production.sqlite3",
+  }
 }


### PR DESCRIPTION
With this change we can use foreman-rake db:drop to drop the whole DB.
It's needed for installer which can drop db and let it recreate using
existing tools.

This commit also fixes the issue when migrations are not run on sqlite
since it did not emit any refresh notification.
