### PR TITLE
Setup far-future expires headers for assets

### DIFF
--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -40,6 +40,8 @@ describe 'foreman::config::passenger' do
 
         should contain_file('foreman_vhost').with_content(/<VirtualHost \*:443>/)
 
+        should contain_file('foreman_vhost').with_content(/access plus 1 year/)
+
         should contain_exec('restart_foreman').with({
           :command     => '/bin/touch /usr/share/foreman/tmp/restart.txt',
           :refreshonly => true,

--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -1,0 +1,43 @@
+# Static public dir serving
+<Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
+
+  <IfVersion < 2.4>
+    Allow from all
+  </IfVersion>
+  <IfVersion >= 2.4>
+    Require all granted
+  </IfVersion>
+
+</Directory>
+
+<Directory <%= scope.lookupvar 'foreman::app_root' %>/public/assets>
+
+  # Use standard http expire header for assets instead of ETag
+  <IfModule mod_expires.c>
+    Header unset ETag
+    FileETag None
+    ExpiresActive On
+    ExpiresDefault "access plus 1 year"
+  </IfModule>
+
+  # Return compressed assets if they are precompiled
+  <IfModule mod_rewrite.c>
+    RewriteEngine on
+    # Make sure the browser supports gzip encoding and file with .gz added
+    # does exist on disc before we rewrite with the extension
+    RewriteCond %{HTTP:Accept-Encoding} \b(x-)?gzip\b
+    RewriteCond %{REQUEST_FILENAME}.gz -s
+    RewriteRule ^(.+) $1.gz [L]
+    # Set headers for all possible assets which are compressed
+    <FilesMatch \.css\.gz$>
+      ForceType text/css
+      Header set Content-Encoding gzip
+    </FilesMatch>
+    <FilesMatch \.js\.gz$>
+      ForceType text/javascript
+      Header set Content-Encoding gzip
+    </FilesMatch>
+  </IfModule>
+
+</Directory>
+

--- a/templates/foreman-apache.conf.erb
+++ b/templates/foreman-apache.conf.erb
@@ -8,11 +8,4 @@ PassengerRuby /usr/bin/<%= @scl_prefix -%>-ruby
 
 AddDefaultCharset UTF-8
 
-<Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
-  <IfVersion < 2.4>
-    Allow from all
-  </IfVersion>  
-  <IfVersion >= 2.4>
-    Require all granted
-  </IfVersion>
-</Directory>
+<%= scope.function_template(['foreman/_assets.conf.erb']) %>

--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -12,14 +12,7 @@
 
   AddDefaultCharset UTF-8
 
-  <Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
-    <IfVersion < 2.4>
-      Allow from all
-    </IfVersion>  
-    <IfVersion >= 2.4>
-      Require all granted
-    </IfVersion>
-  </Directory>
+  <%= scope.function_template(['foreman/_assets.conf.erb']) %>
 
 </VirtualHost>
 
@@ -36,14 +29,7 @@
 
   AddDefaultCharset UTF-8
 
-  <Directory <%= scope.lookupvar 'foreman::app_root' %>/public>
-    <IfVersion < 2.4>
-      Allow from all
-    </IfVersion>  
-    <IfVersion >= 2.4>
-      Require all granted
-    </IfVersion>
-  </Directory>
+  <%= scope.function_template(['foreman/_assets.conf.erb']) %>
 
   # Use puppet certificates for SSL
 


### PR DESCRIPTION
This patch dramatically improves Foreman loading times. How to test:
- Enable developer console in Chrome or your browser
- Go to Hosts list and refresh clearing cache (Ctrl+Shift+R in Chrome)
- Note the loading time of main asset file (1.1 MB)
- Now click on the Host list link again
- Note it now says "Not modified" or "From cache" and loading is faster
  (with this patch applied)

For more info:

4.1.1 Far-future Expires Header

Precompiled assets exist on the filesystem and are served directly by your
web server. They do not have far-future headers by default, so to get the
benefit of fingerprinting you'll have to update your server configuration to
add them.

http://guides.rubyonrails.org/asset_pipeline.html#precompiling-assets
