### PR TITLE
fixes #3262 - actually create "cache" file to save the time of the last host facts push

### DIFF
--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -16,7 +16,7 @@ describe 'foreman_external_node' do
   it "should connect to the URL in the manifest" do
     webstub = stub_request(:post, "http://localhost:3000/api/hosts/facts").with(:body => {"fake"=>"data"})
 
-    enc.stubs(:stat_file).with('fake.host.fqdn.com').returns("/tmp/fake.host.fqdn.com.yaml")
+    enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
     File.stubs(:exists?).returns(false)
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})

--- a/templates/external_node_v1.rb.erb
+++ b/templates/external_node_v1.rb.erb
@@ -55,7 +55,7 @@ end
 
 def upload_facts(certname, filename)
   # Temp file keeping the last run time
-  stat = stat_file(certname)
+  stat = stat_file("#{certname}-push-facts")
   last_run = File.exists?(stat) ? File.stat(stat).mtime.utc : Time.now - 365*24*60*60
   last_fact = File.stat(filename).mtime.utc
   if last_fact > last_run
@@ -79,6 +79,7 @@ def upload_facts(certname, filename)
         end
       end
       res.start { |http| http.request(req) }
+      cache("#{certname}-push-facts", "Facts from this host were last pushed to #{uri} at #{Time.now}\n")
     rescue => e
       raise "Could not send facts to Foreman: #{e}"
     end

--- a/templates/external_node_v2.rb.erb
+++ b/templates/external_node_v2.rb.erb
@@ -80,7 +80,7 @@ end
 
 def upload_facts(certname, filename)
   # Temp file keeping the last run time
-  stat = stat_file(certname)
+  stat = stat_file("#{certname}-push-facts")
   last_run = File.exists?(stat) ? File.stat(stat).mtime.utc : Time.now - 365*24*60*60
   last_fact = File.stat(filename).mtime.utc
   if last_fact > last_run
@@ -105,6 +105,7 @@ def upload_facts(certname, filename)
         end
       end
       res.start { |http| http.request(req) }
+      cache("#{certname}-push-facts", "Facts from this host were last pushed to #{uri} at #{Time.now}\n")
     rescue => e
       raise "Could not send facts to Foreman: #{e}"
     end


### PR DESCRIPTION
Without this line calling this script with --push-facts will never create a "cache" file under yaml/foreman/ to remember the last time it pushed the host facts to foreman, which will result in all puppetmaster needlessly sending _all_ host facts _every_ time this script is run (with --push-facts parameter).

http://projects.theforeman.org/issues/3262
