### PR TITLE
check host facts file size and skip empty ones

### DIFF
--- a/templates/external_node_v2.rb.erb
+++ b/templates/external_node_v2.rb.erb
@@ -63,7 +63,10 @@ end
 def upload_all_facts
   Dir["#{puppetdir}/yaml/facts/*.yaml"].each do |f|
     certname = File.basename(f, ".yaml")
-    upload_facts(certname, f)
+    # Skip empty host fact yaml files
+    if File.size(f) != 0
+      upload_facts(certname, f)
+    end
   end
 end
 


### PR DESCRIPTION
When the script encounters an empty host facts yaml file it terminates with

```
Could not send facts to Foreman: undefined method `[]' for false:FalseClass
```

Which could prevent some host facts from ever being send to foreman.
