### PR TITLE
Changed instructions on foreman parser, and added per_page hash element

### DIFF
--- a/lib/puppet/parser/functions/foreman.rb
+++ b/lib/puppet/parser/functions/foreman.rb
@@ -5,7 +5,7 @@
 # To use foreman(), first create a hash. This sample hash will contain
 # parameters to let us get a list of 'hosts' that match our search parameters.
 #
-# $f = { item         => 'hosts',   <-
+# $f = { item         => 'hosts',
 #        search       => 'hostgroup=Grid',
 #        per_page     => '20',
 #        foreman_url  => 'https://foreman',


### PR DESCRIPTION
The directions at the header of the file were old, so I tried to make the header match reality.

I also added a per_page hash element as well. This could be better done with a hash parameter, but that's a bit outside my comfort level.
