### PR TITLE
refs #3752 - run db:seed after DB migration

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -4,12 +4,7 @@ class foreman::database {
     $db_class = "foreman::database::${foreman::db_type}"
 
     class { $db_class: } ~>
-    exec { 'dbmigrate':
-      command     => "${foreman::app_root}/extras/dbmigrate",
-      user        => $foreman::user,
-      environment => "HOME=${foreman::app_root}",
-      logoutput   => 'on_failure',
-      refreshonly => true,
-    }
+    foreman::rake { 'db:migrate': } ->
+    foreman::rake { 'db:seed': }
   }
 }

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -1,0 +1,10 @@
+# Run a Foreman rake task when notified
+define foreman::rake() {
+  exec { "foreman-rake-${title}":
+    command     => "/usr/sbin/foreman-rake ${title}",
+    user        => $::foreman::user,
+    environment => "HOME=${::foreman::app_root}",
+    logoutput   => 'on_failure',
+    refreshonly => true,
+  }
+}

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -24,13 +24,8 @@ describe 'foreman::install' do
 
       it { should contain_class('foreman::database::postgresql') }
 
-      it { should contain_exec('dbmigrate').with({
-        'command'     => '/usr/share/foreman/extras/dbmigrate',
-        'user'        => 'foreman',
-        'environment' => 'HOME=/usr/share/foreman',
-        'logoutput'   => 'on_failure',
-        'refreshonly' => true,
-      })}
+      it { should contain_foreman__rake('db:migrate') }
+      it { should contain_foreman__rake('db:seed') }
     end
   end
 
@@ -49,13 +44,8 @@ describe 'foreman::install' do
 
       it { should contain_class('foreman::database::postgresql') }
 
-      it { should contain_exec('dbmigrate').with({
-        'command'     => '/usr/share/foreman/extras/dbmigrate',
-        'user'        => 'foreman',
-        'environment' => 'HOME=/usr/share/foreman',
-        'logoutput'   => 'on_failure',
-        'refreshonly' => true,
-      })}
+      it { should contain_foreman__rake('db:migrate') }
+      it { should contain_foreman__rake('db:seed') }
     end
   end
 end

--- a/spec/defines/foreman_rake_spec.rb
+++ b/spec/defines/foreman_rake_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'foreman::rake' do
+  let :default_facts do
+    {
+      :concat_basedir           => '/tmp',
+      :interfaces               => '',
+      :postgres_default_version => '8.4',
+    }
+  end
+
+  let :pre_condition do
+    "class { 'foreman':
+      db_manage => false,
+     }"
+  end
+
+  let(:title) { 'db:migrate' }
+
+  context 'on RedHat' do
+    let :facts do
+      default_facts.merge({
+        :operatingsystem        => 'RedHat',
+        :operatingsystemrelease => '6.4',
+        :osfamily               => 'RedHat',
+      })
+    end
+
+    it { should contain_exec('foreman-rake-db:migrate').with({
+      'command'     => '/usr/sbin/foreman-rake db:migrate',
+      'user'        => 'foreman',
+      'environment' => 'HOME=/usr/share/foreman',
+      'logoutput'   => 'on_failure',
+      'refreshonly' => true,
+    })}
+  end
+end


### PR DESCRIPTION
Using foreman-rake means 1.3+, but I think we said that we'd support current stable + the development version.  Running db:seed on 1.3 will be fine as either the seed file doesn't exist (no error) or it contains next to nothing.
