### PR TITLE
Adds a check to see if the puppet user exists before attempting to

### DIFF
--- a/lib/puppet/parser/functions/cache_data.rb
+++ b/lib/puppet/parser/functions/cache_data.rb
@@ -27,8 +27,7 @@ module Puppet::Parser::Functions
         c.write(YAML.dump(initial_data))
       end
       # Chown to puppet to prevent later cache-read errors when this is run as root
-      if Etc.getpwuid.name == 'root'
-        uid = Etc.getpwnam('puppet').uid
+      if Etc.getpwuid.name == 'root' && (uid = (Etc.getpwnam('puppet').uid rescue nil))
         File.chown(uid, nil, cache)
         File.chown(uid, nil, cache_dir)
       end


### PR DESCRIPTION
chown directories for that user.

This can arise from the case where puppet is installed via gems only.
