### PR TITLE
Deploy Foreman with cert not from puppet

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -3,8 +3,10 @@ class foreman::config::passenger(
 
   # specifiy which interface to bind passenger to eth0, eth1, ...
   $listen_on_interface = '',
-  $scl_prefix = undef
-
+  $scl_prefix = undef,
+  $ssl_ca = $foreman::server_ssl_ca,
+  $ssl_cert = $foreman::server_ssl_cert,
+  $ssl_key = $foreman::server_ssl_key
 ) {
   include apache::ssl
   include ::passenger

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,12 @@
 #
 # $passenger_interface::    Defines which network interface passenger should listen on, undef means all interfaces
 #
+# $server_ssl_ca::          Defines Apache mod_ssl SSLCertificateChainFile setting in Foreman vhost conf file.
+#
+# $server_ssl_cert::        Defines Apache mod_ssl SSLCertificateFile setting in Foreman vhost conf file.
+#
+# $server_ssl_key::         Defines Apache mod_ssl SSLCertificateKeyFile setting in Foreman vhost conf file.
+#
 # $oauth_active::           Enable OAuth authentication for REST API
 #                           type:boolean
 #
@@ -123,6 +129,9 @@ class foreman (
   $locations_enabled      = $foreman::params::locations_enabled,
   $organizations_enabled  = $foreman::params::organizations_enabled,
   $passenger_interface    = $foreman::params::passenger_interface,
+  $server_ssl_ca          = $foreman::params::server_ssl_ca,
+  $server_ssl_cert        = $foreman::params::server_ssl_cert,
+  $server_ssl_key         = $foreman::params::server_ssl_key,
   $oauth_active           = $foreman::params::oauth_active,
   $oauth_map_users        = $foreman::params::oauth_map_users,
   $oauth_consumer_key     = $foreman::params::oauth_consumer_key,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -105,6 +105,11 @@ class foreman::params {
   $client_ssl_cert = "${puppet_home}/ssl/certs/${::fqdn}.pem"
   $client_ssl_key  = "${puppet_home}/ssl/private_keys/${::fqdn}.pem"
 
+  # Set these values if you want Passenger to serve a CA-provided cert instead of puppet's
+  $server_ssl_ca   = "${puppet_home}/ssl/certs/ca.pem"
+  $server_ssl_cert = "${puppet_home}/ssl/certs/${::fqdn}.pem"
+  $server_ssl_key  = "${puppet_home}/ssl/private_keys/${::fqdn}.pem"
+
   # We need the REST API interface with OAuth for some REST Puppet providers
   $oauth_active = true
   $oauth_map_users = true

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -108,5 +108,22 @@ describe 'foreman::config::passenger' do
         should_not contain_file('foreman_vhost').with_content(/<VirtualHost \*:443>/)
       end
     end
+
+    describe 'with custom ssl cert' do
+      let :pre_condition do
+        "class {'foreman':
+          server_ssl_cert => 'foo',
+          server_ssl_key  => 'bar',
+          server_ssl_ca   => 'baz',
+          ssl             => true,
+        }"
+      end
+
+      it 'should specify trust chain' do
+        should contain_file('foreman_vhost').with_content(/SSLCertificateFile\s+foo/)
+        should contain_file('foreman_vhost').with_content(/SSLCertificateKeyFile\s+bar/)
+        should contain_file('foreman_vhost').with_content(/SSLCertificateChainFile\s+baz/)
+      end
+    end
   end
 end

--- a/templates/foreman-vhost.conf.erb
+++ b/templates/foreman-vhost.conf.erb
@@ -31,12 +31,10 @@
 
   <%= scope.function_template(['foreman/_assets.conf.erb']) %>
 
-  # Use puppet certificates for SSL
-
   SSLEngine On
-  SSLCertificateFile      /var/lib/puppet/ssl/certs/<%= @fqdn %>.pem
-  SSLCertificateKeyFile   /var/lib/puppet/ssl/private_keys/<%= @fqdn %>.pem
-  SSLCertificateChainFile /var/lib/puppet/ssl/certs/ca.pem
+  SSLCertificateFile      <%= @ssl_cert %>
+  SSLCertificateKeyFile   <%= @ssl_key %>
+  SSLCertificateChainFile <%= @ssl_ca %>
   SSLCACertificateFile    /var/lib/puppet/ssl/certs/ca.pem
   SSLVerifyClient         optional
   SSLOptions              +StdEnvVars


### PR DESCRIPTION
On CentOS 6, the following settings allow me to use a CA-provided cert instead of a puppet cert.

```
$tlsdir = "/etc/pki/tls"

class { '::foreman':
    client_ssl_ca   => "${tlsdir}/certs/IntermediateCA.crt",
    client_ssl_cert => "${tlsdir}/certs/star.domain.com.crt",
    client_ssl_key  => "${tlsdir}/private/star.domain.com.key",
}

class { "::foreman_proxy": }

class { "::puppet":
    # Generated per http://curl.haxx.se/docs/caextract.html
    server_foreman_ssl_ca => "${tlsdir}/certs/ca-bundle.crt",
}
```
