### PR TITLE
Clean up tests

### DIFF
--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -25,9 +25,9 @@ describe 'foreman::config::passenger' do
       end
 
       it do
-        should include_class('apache::ssl')
-        should include_class('passenger')
-        should_not include_class('::passenger::install::scl')
+        should contain_class('apache::ssl')
+        should contain_class('passenger')
+        should_not contain_class('::passenger::install::scl')
 
         should contain_file('foreman_vhost').with({
           :path    => '/etc/httpd/conf.d/foreman.conf',
@@ -82,7 +82,7 @@ describe 'foreman::config::passenger' do
       end
 
       it 'should include scl' do
-        should include_class('passenger::install::scl')
+        should contain_class('passenger::install::scl')
       end
     end
 

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -18,10 +18,10 @@ describe 'foreman' do
       })
     end
 
-    it { should include_class('foreman::install') }
-    it { should include_class('foreman::config') }
-    it { should include_class('foreman::database') }
-    it { should include_class('foreman::service') }
+    it { should contain_class('foreman::install') }
+    it { should contain_class('foreman::config') }
+    it { should contain_class('foreman::database') }
+    it { should contain_class('foreman::service') }
   end
 
   context 'on debian' do
@@ -32,9 +32,9 @@ describe 'foreman' do
       })
     end
 
-    it { should include_class('foreman::install') }
-    it { should include_class('foreman::config') }
-    it { should include_class('foreman::database') }
-    it { should include_class('foreman::service') }
+    it { should contain_class('foreman::install') }
+    it { should contain_class('foreman::config') }
+    it { should contain_class('foreman::database') }
+    it { should contain_class('foreman::service') }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,3 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 def static_fixture_path
   File.join(File.dirname(__FILE__), 'static_fixtures')
 end
-
-RSpec.configure do |c|
-  c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests')
-  c.mock_with :mocha
-end


### PR DESCRIPTION
This replaces the deprecated include_class with contain_class and removes the redundant rspec configuration.
