### PR TITLE
Add basic Archlinux support for agent classes

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,7 +2,8 @@ define foreman::plugin(
   $package = "${foreman::plugin_prefix}${title}"
 ) {
   package { $package:
-    ensure => installed,
-    notify => Class['foreman::service'],
+    ensure  => installed,
+    require => Class['foreman::config'],
+    notify  => Class['foreman::service'],
   }
 }


### PR DESCRIPTION
This helps me re-use our installer modules at home. I'm not trying to support the full Apache/Passenger/Puppet/Foreman stack (my Foreman server is Debian 7), so there's a note to say that only the agent classes are supported.
