### PR TITLE
Clean up foreman::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,5 @@
 # Configure foreman
 class foreman::config {
-  Cron {
-    require     => User[$foreman::user],
-    user        => $foreman::user,
-    environment => "RAILS_ENV=${foreman::environment}",
-  }
-
   concat_build {'foreman_settings':
     order => ['*.yaml'],
   }
@@ -17,7 +11,6 @@ class foreman::config {
   file {'/etc/foreman/settings.yaml':
     source  => concat_output('foreman_settings'),
     require => Concat_build['foreman_settings'],
-    notify  => Class['foreman::service'],
     owner   => 'root',
     group   => $foreman::group,
     mode    => '0640',
@@ -28,24 +21,11 @@ class foreman::config {
     group   => $foreman::group,
     mode    => '0640',
     content => template('foreman/database.yml.erb'),
-    notify  => Class['foreman::service'],
   }
 
-  case $::operatingsystem {
-    Debian,Ubuntu: {
-      $init_config = '/etc/default/foreman'
-      $init_config_tmpl = 'foreman.default'
-    }
-    default: {
-      $init_config = '/etc/sysconfig/foreman'
-      $init_config_tmpl = 'foreman.sysconfig'
-    }
-  }
-  file { $init_config:
+  file { $foreman::init_config:
     ensure  => present,
-    content => template("foreman/${init_config_tmpl}.erb"),
-    require => Class['foreman::install'],
-    before  => Class['foreman::service'],
+    content => template("foreman/${foreman::init_config_tmpl}.erb"),
   }
 
   file { $foreman::app_root:
@@ -59,7 +39,6 @@ class foreman::config {
     home    => $foreman::app_root,
     gid     => $foreman::group,
     groups  => $foreman::user_groups,
-    require => Class['foreman::install'],
   }
 
   # remove crons previously installed here, they've moved to the package's
@@ -71,5 +50,4 @@ class foreman::config {
   if $foreman::passenger  {
     include foreman::config::passenger
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,9 @@ class foreman::params {
   # OS specific paths
   case $::osfamily {
     RedHat: {
+      $init_config = '/etc/sysconfig/foreman'
+      $init_config_tmpl = 'foreman.sysconfig'
+
       case $::operatingsystem {
         fedora: {
           $puppet_basedir  = '/usr/share/ruby/vendor_ruby/puppet'
@@ -79,6 +82,8 @@ class foreman::params {
       $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
       $passenger_scl = undef
       $plugin_prefix = 'ruby-foreman-'
+      $init_config = '/etc/default/foreman'
+      $init_config_tmpl = 'foreman.default'
     }
     Linux: {
       case $::operatingsystem {
@@ -88,6 +93,8 @@ class foreman::params {
           # add passenger::install::scl as EL uses SCL on Foreman 1.2+
           $passenger_scl = 'ruby193'
           $plugin_prefix = 'ruby193-rubygem-foreman_'
+          $init_config = '/etc/sysconfig/foreman'
+          $init_config_tmpl = 'foreman.sysconfig'
         }
         default: {
           fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -41,35 +41,31 @@ describe 'foreman::config' do
         should contain_file('/etc/foreman/settings.yaml').with({
           'source'  => %r{/concat/output/foreman_settings.out$},
           'require' => 'Concat_build[foreman_settings]',
-          'notify'  => 'Class[Foreman::Service]',
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',
         })
+      end
 
+      it 'should configure the database' do
         should contain_file('/etc/foreman/database.yml').with({
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',
           'content' => /adapter: postgresql/,
-          'notify'  => 'Class[Foreman::Service]',
         })
+      end
 
+      it 'should set the defaults file' do
         should contain_file('/etc/sysconfig/foreman').
           with_content(/^FOREMAN_HOME=\/usr\/share\/foreman$/).
           with_content(/^FOREMAN_USER=foreman$/).
           with_content(/^FOREMAN_ENV=production/).
           with_content(/^FOREMAN_USE_PASSENGER=1$/).
-          with({
-            'ensure'  => 'present',
-            'require' => 'Class[Foreman::Install]',
-            'before'  => 'Class[Foreman::Service]',
-          })
+          with_ensure('present')
       end
 
-      it { should contain_file('/usr/share/foreman').with({
-        'ensure'  => 'directory',
-      })}
+      it { should contain_file('/usr/share/foreman').with_ensure('directory') }
 
       it { should contain_user('foreman').with({
         'ensure'  => 'present',
@@ -78,30 +74,12 @@ describe 'foreman::config' do
         'gid'     => 'foreman',
         'groups'  => ['puppet'],
         'home'    => '/usr/share/foreman',
-        'require' => 'Class[Foreman::Install]',
       })}
 
       it 'should remove old crons' do
-        should contain_cron('clear_session_table').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
-
-        should contain_cron('expire_old_reports').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
-
-        should contain_cron('daily summary').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
+        should contain_cron('clear_session_table').with_ensure('absent')
+        should contain_cron('expire_old_reports').with_ensure('absent')
+        should contain_cron('daily summary').with_ensure('absent')
       end
 
       it { should contain_class('foreman::config::passenger').with({
@@ -177,7 +155,7 @@ describe 'foreman::config' do
         "class {'foreman':}"
       end
 
-      it 'should set up the config' do
+      it 'should set up settings.yaml' do
         should contain_concat_build('foreman_settings').with_order(['*.yaml'])
 
         should contain_concat_fragment('foreman_settings+01-header.yaml').
@@ -195,65 +173,45 @@ describe 'foreman::config' do
         should contain_file('/etc/foreman/settings.yaml').with({
           'source'  => %r{/concat/output/foreman_settings.out$},
           'require' => 'Concat_build[foreman_settings]',
-          'notify'  => 'Class[Foreman::Service]',
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',
         })
+      end
 
+      it 'should configure the database' do
         should contain_file('/etc/foreman/database.yml').with({
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',
           'content' => /adapter: postgresql/,
-          'notify'  => 'Class[Foreman::Service]',
         })
+      end
 
+      it 'should set the defaults file' do
         should contain_file('/etc/default/foreman').
           with_content(/^START=no$/).
           with_content(/^FOREMAN_HOME=\/usr\/share\/foreman$/).
           with_content(/^FOREMAN_USER=foreman$/).
           with_content(/^FOREMAN_ENV=production/).
-          with({
-            'ensure'  => 'present',
-            'require' => 'Class[Foreman::Install]',
-            'before'  => 'Class[Foreman::Service]',
-          })
+          with_ensure('present')
       end
 
-      it { should contain_file('/usr/share/foreman').with({
-        'ensure'  => 'directory',
-      })}
+      it { should contain_file('/usr/share/foreman').with_ensure('directory') }
 
       it { should contain_user('foreman').with({
         'ensure'  => 'present',
         'shell'   => '/sbin/nologin',
         'comment' => 'Foreman',
+        'gid'     => 'foreman',
+        'groups'  => ['puppet'],
         'home'    => '/usr/share/foreman',
-        'require' => 'Class[Foreman::Install]',
       })}
 
       it 'should remove old crons' do
-        should contain_cron('clear_session_table').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
-
-        should contain_cron('expire_old_reports').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
-
-        should contain_cron('daily summary').with({
-          'ensure'      => 'absent',
-          'require'     => 'User[foreman]',
-          'user'        => 'foreman',
-          'environment' => 'RAILS_ENV=production'
-        })
+        should contain_cron('clear_session_table').with_ensure('absent')
+        should contain_cron('expire_old_reports').with_ensure('absent')
+        should contain_cron('daily summary').with_ensure('absent')
       end
 
       it { should contain_class('foreman::config::passenger').with({


### PR DESCRIPTION
This removed all requires on install and notifies to service since init should
take care of that relation.

To remove OS specific information, it moves init_config and init_config_tmpl
to params.pp.

Since the crons are no longer defined, setting the default is no longer 
needed.
