### PR TITLE
Set SymLinksIfOwnerMatch options in apache vhosts

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -83,7 +83,7 @@ class foreman::config::passenger(
       port            => 80,
       docroot         => $docroot,
       priority        => '5',
-      options         => ['none'],
+      options         => ['SymLinksIfOwnerMatch'],
       custom_fragment => template('foreman/apache-fragment.conf.erb', 'foreman/_assets.conf.erb'),
     }
 
@@ -95,7 +95,7 @@ class foreman::config::passenger(
         port              => 443,
         docroot           => $docroot,
         priority          => '5',
-        options           => ['none'],
+        options           => ['SymLinksIfOwnerMatch'],
         ssl               => true,
         ssl_cert          => $ssl_cert,
         ssl_key           => $ssl_key,

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -50,7 +50,7 @@ describe 'foreman::config::passenger' do
         :serveraliases   => ['foreman'],
         :docroot         => "#{params[:app_root]}/public",
         :priority        => '5',
-        :options         => ['none'],
+        :options         => ['SymLinksIfOwnerMatch'],
         :port            => 80,
         :custom_fragment => %r{^<Directory #{params[:app_root]}/public>$},
       })
@@ -63,7 +63,7 @@ describe 'foreman::config::passenger' do
         :serveraliases     => ['foreman'],
         :docroot           => "#{params[:app_root]}/public",
         :priority          => '5',
-        :options           => ['none'],
+        :options           => ['SymLinksIfOwnerMatch'],
         :port              => 443,
         :ssl               => true,
         :ssl_cert          => params[:ssl_cert],


### PR DESCRIPTION
Without FollowSymLinks or SymLinksIfOwnerMatch option in vhost I get this error message in apache logs:

```
Options FollowSymLinks or SymLinksIfOwnerMatch is off which implies that RewriteRule directive is forbidden: /usr/share/foreman/public/assets/application-60157ee362dadef8e1c5b73833bba06f.css
```

With foreman 1.3.2 on RHEL6.
