### PR TITLE
Fixes #4225 - Don't deploy a default vhost on port 80

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -82,7 +82,7 @@ class foreman::config::passenger(
       ip              => $listen_interface,
       port            => 80,
       docroot         => $docroot,
-      priority        => '5',
+      priority        => '05',
       options         => ['SymLinksIfOwnerMatch'],
       custom_fragment => template('foreman/apache-fragment.conf.erb', 'foreman/_assets.conf.erb'),
     }
@@ -94,7 +94,7 @@ class foreman::config::passenger(
         ip                => $listen_interface,
         port              => 443,
         docroot           => $docroot,
-        priority          => '5',
+        priority          => '05',
         options           => ['SymLinksIfOwnerMatch'],
         ssl               => true,
         ssl_cert          => $ssl_cert,


### PR DESCRIPTION
Hopefully mixing class- and include-style directives won't bite us....
