### PR TITLE
implement full anchor pattern

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,10 +155,12 @@ class foreman (
   } else {
     $db_adapter_real = $db_adapter
   }
+
+  anchor { 'foreman::begin': } ->
   class { 'foreman::install': } ~>
   class { 'foreman::config': } ~>
   class { 'foreman::database': } ~>
   class { 'foreman::service': } ->
-  Class['foreman'] ->
+  anchor { 'foreman::end': } ->
   Foreman_smartproxy <| |>
 }


### PR DESCRIPTION
This is required in allow repos (such as EPEL) to be declared independently in
the manifest with correct ordering.