### PR TITLE
Fix include on Apache 2.4 when no matching files exist

### DIFF
--- a/templates/_ssl_virt_host_include.erb
+++ b/templates/_ssl_virt_host_include.erb
@@ -1,1 +1,6 @@
-Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman-ssl.d/*.conf') %>
+<IfVersion < 2.4>
+  Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman-ssl.d/*.conf') %>
+</IfVersion>
+<IfVersion >= 2.4>
+  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman-ssl.d/*.conf') %>
+</IfVersion>

--- a/templates/_virt_host_include.erb
+++ b/templates/_virt_host_include.erb
@@ -1,1 +1,6 @@
-Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman.d/*.conf') %>
+<IfVersion < 2.4>
+  Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman.d/*.conf') %>
+</IfVersion>
+<IfVersion >= 2.4>
+  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman.d/*.conf') %>
+</IfVersion>


### PR DESCRIPTION
systest on F19 caught this:

```
Syntax error on line 97 of /etc/httpd/conf.d/05-foreman-ssl.conf: No matches for the wildcard '*.conf' in '/etc/httpd/conf.d/05-foreman-ssl.d', failing (use IncludeOptional if required)
```

http://httpd.apache.org/docs/2.4/mod/core.html#include
