### PR TITLE
Trigger db:seed too when DB changes

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -4,7 +4,7 @@ class foreman::database {
     $db_class = "foreman::database::${foreman::db_type}"
 
     class { $db_class: } ~>
-    foreman::rake { 'db:migrate': } ->
+    foreman::rake { 'db:migrate': } ~>
     foreman::rake { 'db:seed': }
   }
 }


### PR DESCRIPTION
From #theforeman this morning, seems that if the $db_class changes then the notification doesn't necessarily make it to db:seed.
