### PR TITLE
Improve response when server-side Foreman errors occurs

### DIFF
--- a/templates/external_node_v2.rb.erb
+++ b/templates/external_node_v2.rb.erb
@@ -183,7 +183,7 @@ def enc(certname)
   end
   res = http.start { |http| http.request(req) }
 
-  raise "Error retrieving node #{certname}: #{res.class}" unless res.code == "200"
+  raise "Error retrieving node #{certname}: #{res.class}\nCheck Foreman's /var/log/foreman/production.log for more information." unless res.code == "200"
   res.body
 end
 
@@ -333,14 +333,16 @@ if __FILE__ == $0 then
       rescue TimeoutError, SocketError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED
         # Read from cache, we got some sort of an error.
         result = read_cache(certname)
-      ensure
+      end
+
+      if no_env
         require 'yaml'
         yaml = YAML.load(result)
-        if no_env
-          yaml.delete('environment')
-        end
+        yaml.delete('environment')
         # Always reset the result to back to clean yaml on our end
         puts yaml.to_yaml
+      else
+        puts result
       end
     end
   rescue => e


### PR DESCRIPTION
No longer parse YAML in "ensure" block (which included errors), now only when
--no-environment is used.  Add pointer to Foreman's production.log.

Previously:

<pre>
# puppet agent -t
Warning: Unable to fetch my node definition, but the agent run will continue:
Warning: Error 400 on SERVER: Failed to find foreman.example.com via exec: Execution of '/etc/puppet/node.rb foreman.example.com' returned 1: --- false

Info: Retrieving plugin
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed when searching for node foreman.example.com: Failed to find foreman.example.com via exec: Execution of '/etc/puppet/node.rb foreman.example.com' returned 1: --- false

Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
</pre>


Now:

<pre>
# puppet agent -t
Warning: Unable to fetch my node definition, but the agent run will continue:
Warning: Error 400 on SERVER: Failed to find foreman.example.com via exec: Execution of '/etc/puppet/node.rb foreman.example.com' returned 1: Error retrieving node foreman.example.com: Net::HTTPForbidden
Check Foreman's /var/log/foreman/production.log for more information.

Info: Retrieving plugin
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed when searching for node foreman.example.com: Failed to find foreman.example.com via exec: Execution of '/etc/puppet/node.rb foreman.example.com' returned 1: Error retrieving node foreman.example.com: Net::HTTPForbidden
Check Foreman's /var/log/foreman/production.log for more information.

Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
</pre>
