### PR TITLE
Be compliant with the Puppet Forge

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,6 +9,6 @@ project_page 'http://github.com/theforeman/foreman-installer'
 
 dependency 'theforeman/concat_native', '>= 1.3.0'
 
-dependency 'puppetlabs/apache', '~> 1.0'
+dependency 'puppetlabs/apache', '>= 1.0.0 < 2.0.0'
 dependency 'puppetlabs/postgresql', '>= 3.0.0'
 dependency 'puppetlabs/stdlib', '>= 2.0.0'


### PR DESCRIPTION
Like in https://github.com/theforeman/puppet-puppet/commit/27c73a6ab9b7842fa3827ad7bc24fddbdd91c73a.

The ~> dependency expression used here is not expressly supported by the Puppet Forge and module tool. It may not always work as desired.

The currently supported expressions are documented [here](http://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#dependencies-in-the-modulefile).
