### PR TITLE
refs #4515 - cache apipie docs on installation

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -5,6 +5,7 @@ class foreman::database {
 
     class { $db_class: } ~>
     foreman::rake { 'db:migrate': } ~>
-    foreman::rake { 'db:seed': }
+    foreman::rake { 'db:seed': } ~>
+    foreman::rake { 'apipie:cache': }
   }
 }

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -26,6 +26,7 @@ describe 'foreman::install' do
 
       it { should contain_foreman__rake('db:migrate') }
       it { should contain_foreman__rake('db:seed') }
+      it { should contain_foreman__rake('apipie:cache') }
     end
   end
 
@@ -47,6 +48,7 @@ describe 'foreman::install' do
 
       it { should contain_foreman__rake('db:migrate') }
       it { should contain_foreman__rake('db:seed') }
+      it { should contain_foreman__rake('apipie:cache') }
     end
   end
 end


### PR DESCRIPTION
Tested on nightly and tested the command on 1.4 successfully.

This caches the API docs (like https://github.com/theforeman/foreman/commit/0527e75be3647c1e89b8fd19d2e3cee00d07aa38#diff-f253775911a09d6068d2a99e41a60bd8R537) after installation so Hammer can fetch the JSON docs from the Foreman server for dynamic bindings.
