### PR TITLE
Add support for foreman-tasks

### DIFF
--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -1,0 +1,25 @@
+class foreman::plugin::tasks {
+  case $::osfamily {
+    RedHat: {
+      case $::operatingsystem {
+        fedora: {
+          $package = 'rubygem-foreman-tasks'
+        }
+        default: {
+          $package = 'ruby193-rubygem-foreman-tasks'
+        }
+      }
+    }
+    default: {
+      fail("${::hostname}: foreman-tasks does not support osfamily ${::osfamily}")
+    }
+  }
+
+  foreman::plugin { 'tasks':
+    package => $package,
+  } ~>
+  service { 'foreman-tasks':
+    ensure => running,
+    enable => true
+  }
+}

--- a/spec/classes/foreman_plugin_tasks_spec.rb
+++ b/spec/classes/foreman_plugin_tasks_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::tasks' do
+  describe "Fedora" do
+    let :facts do
+      {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'Fedora',
+      }
+    end
+
+    it 'should call the plugin' do
+      should contain_foreman__plugin('tasks').with_package('rubygem-foreman-tasks')
+      should contain_service('foreman-tasks').with('ensure' => 'running', 'enable' => 'true')
+    end
+  end
+
+  describe "RHEL" do
+    let :facts do
+      {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+      }
+    end
+
+    it 'should call the plugin' do
+      should contain_foreman__plugin('tasks').with_package('ruby193-rubygem-foreman-tasks')
+      should contain_service('foreman-tasks').with('ensure' => 'running', 'enable' => 'true')
+    end
+  end
+
+  describe "Debian" do
+    let :facts do
+      {
+          :osfamily => 'Debian',
+      }
+    end
+
+    it 'should fail' do
+      expect {
+        should contain_foreman__plugin('tasks')
+      }.to raise_error(Puppet::Error, /foreman-tasks does not support osfamily/)
+    end
+  end
+end


### PR DESCRIPTION
fedora 19 and rhel should use ruby 1.9+ so I think we don't need to check ruby version
