### PR TITLE
We download and install discovery images

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,6 +11,7 @@ fixtures:
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'
+    tftp:             'git://github.com/theforeman/puppet-tftp'
 
 
   symlinks:

--- a/Modulefile
+++ b/Modulefile
@@ -8,6 +8,7 @@ description 'Module for configuring Foreman'
 project_page 'http://github.com/theforeman/foreman-installer'
 
 dependency 'theforeman/concat_native', '>= 1.3.0'
+dependency 'theforeman/puppet-tftp', '>= 1.4.0'
 
 dependency 'puppetlabs/apache', '>= 1.0.0 < 2.0.0'
 dependency 'puppetlabs/postgresql', '>= 3.0.0'

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -1,4 +1,46 @@
-class foreman::plugin::discovery {
+# = Foreman Discovery plugin
+#
+# This class installs discovery plugin and images
+#
+# === Parameters:
+#
+# $version::         version string of discovery image, in form of x.y.z-r
+#
+# $source::          mirror url from which the image files should be obtained, you
+#                    can use http(s):// or file://
+#
+# $initrd::          name of initrd image file
+#
+# $kernel::          name of kernel file
+#
+# $install_images::  should the installer download and setup discovery images
+#                    for you? the average size is few hundreds of MB
+#                    type:boolean
+#
+class foreman::plugin::discovery (
+  $version        = $foreman::plugin::discovery::params::version,
+  $source         = $foreman::plugin::discovery::params::source,
+  $initrd         = $foreman::plugin::discovery::params::initrd,
+  $kernel         = $foreman::plugin::discovery::params::kernel,
+  $install_images = $foreman::plugin::discovery::params::install_images,
+) inherits foreman::plugin::discovery::params {
+
+  validate_bool($install_images)
+
   foreman::plugin {'discovery':
+  }
+
+  if $install_images {
+    include ::tftp::params
+
+    foreman::remote_file {"${::tftp::params::root}boot/${kernel}":
+      remote_location => "${source}${kernel}",
+      mode            => 0644,
+    }
+
+    foreman::remote_file {"${::tftp::params::root}boot/${initrd}":
+      remote_location => "${source}${initrd}",
+      mode            => 0644,
+    }
   }
 }

--- a/manifests/plugin/discovery/params.pp
+++ b/manifests/plugin/discovery/params.pp
@@ -1,0 +1,7 @@
+class foreman::plugin::discovery::params {
+  $version         = 'latest'
+  $source          = 'http://yum.theforeman.org/discovery/releases/latest/'
+  $initrd          = "foreman-discovery-image-${version}.el6.iso-img"
+  $kernel          = "foreman-discovery-image-${version}.el6.iso-vmlinuz"
+  $install_images  = false
+}

--- a/manifests/remote_file.pp
+++ b/manifests/remote_file.pp
@@ -1,0 +1,12 @@
+define foreman::remote_file($remote_location, $mode=0644) {
+  exec {"retrieve_${title}":
+    command => "/usr/bin/curl -s ${remote_location} -o ${title}",
+    creates => $title,
+    timeout => 0,
+  }
+
+  file {$title:
+    mode    => $mode,
+    require => Exec["retrieve_${title}"],
+  }
+}

--- a/spec/classes/foreman_plugin_discovery_spec.rb
+++ b/spec/classes/foreman_plugin_discovery_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::discovery' do
+  let :facts do
+    {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Fedora',
+    }
+  end
+
+  context 'with enabled image installation' do
+    let :params do
+      {
+          :version => 'latest',
+          :source => 'http://yum.theforeman.org/discovery/releases/latest/',
+          :initrd => 'foreman-discovery-image-latest.el6.iso-img',
+          :kernel => 'foreman-discovery-image-latest.el6.iso-vmlinuz',
+          :install_images => true
+      }
+    end
+
+    it 'should call the plugin' do
+      should contain_foreman__plugin('discovery')
+    end
+
+    it 'should download and install kernel file' do
+      should contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-vmlinuz").
+                 with_remote_location('http://yum.theforeman.org/discovery/releases/latest/foreman-discovery-image-latest.el6.iso-vmlinuz')
+    end
+
+    it 'should download and install initrd file' do
+      should contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-img").
+                 with_remote_location('http://yum.theforeman.org/discovery/releases/latest/foreman-discovery-image-latest.el6.iso-img')
+    end
+  end
+
+  context 'with disabled image installation' do
+    let :params do
+      {
+          :version => 'latest',
+          :source => 'http://yum.theforeman.org/discovery/releases/latest/',
+          :initrd => 'foreman-discovery-image-latest.el6.iso-img',
+          :kernel => 'foreman-discovery-image-latest.el6.iso-vmlinuz',
+          :install_images => false
+      }
+    end
+
+    it 'should call the plugin' do
+      should contain_foreman__plugin('discovery')
+    end
+
+    it 'should not download and install kernel file' do
+      should_not contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-vmlinuz")
+    end
+
+    it 'should not download and install initrd file' do
+      should_not contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-img")
+    end
+  end
+end

--- a/spec/defines/foreman_remote_file_spec.rb
+++ b/spec/defines/foreman_remote_file_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'foreman::remote_file' do
+  let(:title) { '/tmp/a' }
+  let(:params) { {:remote_location => 'file:///tmp/a', :mode => '0664'} }
+
+  it 'should download file' do
+    should contain_exec('retrieve_/tmp/a').
+               with_command('/usr/bin/curl -s file:///tmp/a -o /tmp/a').
+               with_creates('/tmp/a').
+               with_timeout(0)
+  end
+
+  it 'should set correct mode' do
+    should contain_file('/tmp/a').with_mode('0664')
+  end
+end


### PR DESCRIPTION
Kafo 0.5.3 makes it possible to set parameters even for plugins. Before this gets merged I think we need to find answers for following questions.
1. Is there better way than using curl, so it supports not only `http://` but `file://`? 
2. Do we need to add curl as dependency? 
3. Should we make discovery image releases more standardized?
