### PR TITLE
Fix nologin shell path on Debian

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ class foreman::config {
 
   user { $foreman::user:
     ensure  => 'present',
-    shell   => '/sbin/nologin',
+    shell   => '/bin/false',
     comment => 'Foreman',
     home    => $foreman::app_root,
     gid     => $foreman::group,

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -69,7 +69,7 @@ describe 'foreman::config' do
 
       it { should contain_user('foreman').with({
         'ensure'  => 'present',
-        'shell'   => '/sbin/nologin',
+        'shell'   => '/bin/false',
         'comment' => 'Foreman',
         'gid'     => 'foreman',
         'groups'  => ['puppet'],
@@ -201,7 +201,7 @@ describe 'foreman::config' do
 
       it { should contain_user('foreman').with({
         'ensure'  => 'present',
-        'shell'   => '/sbin/nologin',
+        'shell'   => '/bin/false',
         'comment' => 'Foreman',
         'gid'     => 'foreman',
         'groups'  => ['puppet'],


### PR DESCRIPTION
This shouldn't break Fedora as they have a symlink /usr/sbin -> /sbin
