### PR TITLE
Remove Puppet 2.6 pending marker using pre-Facter 2 API call

### DIFF
--- a/spec/functions/foreman_spec.rb
+++ b/spec/functions/foreman_spec.rb
@@ -5,16 +5,14 @@ describe 'foreman' do
   let(:node) { 'test.example.com' }
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
-  pending "due to Puppet #4549 on 2.6", :if => Facter.puppetversion =~ /^2\.6/ do
-    it 'should exist' do
-      Puppet::Parser::Functions.function('foreman').should == 'function_foreman'
-    end
+  it 'should exist' do
+    Puppet::Parser::Functions.function('foreman').should == 'function_foreman'
+  end
 
-    it 'should throw an error with no arguments' do
-      lambda {
-        scope.function_foreman([])
-      }.should(raise_error(Puppet::ParseError))
-    end
+  it 'should throw an error with no arguments' do
+    lambda {
+      scope.function_foreman([])
+    }.should(raise_error(Puppet::ParseError))
   end
 
   # TODO: Test functionality of the actual function.

--- a/spec/functions/smartvar_spec.rb
+++ b/spec/functions/smartvar_spec.rb
@@ -7,16 +7,14 @@ describe 'smartvar' do
   let(:node) { 'test.example.com' }
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
-  pending "due to Puppet #4549 on 2.6", :if => Facter.puppetversion =~ /^2\.6/ do
-    it 'should exist' do
-      Puppet::Parser::Functions.function('smartvar').should == 'function_smartvar'
-    end
+  it 'should exist' do
+    Puppet::Parser::Functions.function('smartvar').should == 'function_smartvar'
+  end
 
-    it 'should throw an error with no arguments' do
-      lambda {
-        scope.function_smartvar([])
-      }.should(raise_error(Puppet::ParseError))
-    end
+  it 'should throw an error with no arguments' do
+    lambda {
+      scope.function_smartvar([])
+    }.should(raise_error(Puppet::ParseError))
   end
 
   # TODO: Test functionality of the actual function.


### PR DESCRIPTION
We don't support 2.6 any more, so just remove the broken line.
