### PR TITLE
Contain Apache before foreman::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,6 +48,6 @@ class foreman::config {
   }
 
   if $foreman::passenger  {
-    include foreman::config::passenger
+    class { '::foreman::config::passenger': } -> anchor { 'foreman::config_end': }
   }
 }

--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -46,6 +46,7 @@ class foreman::config::passenger(
   include ::apache
   include ::apache::mod::headers
   include ::apache::mod::passenger
+  Class['::apache'] -> anchor { 'foreman::config::passenger_end': }
 
   if $::osfamily == 'RedHat' {
     # Work around https://github.com/puppetlabs/puppetlabs-apache/pull/563

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -18,7 +18,7 @@ describe 'foreman::config::passenger' do
     } end
 
     it 'should include apache with modules' do
-      should contain_class('apache')
+      should contain_class('apache').that_comes_before('Anchor[foreman::config::passenger_end]')
       should contain_class('apache::mod::headers')
       should contain_class('apache::mod::passenger')
     end

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -82,10 +82,12 @@ describe 'foreman::config' do
         should contain_cron('daily summary').with_ensure('absent')
       end
 
-      it { should contain_class('foreman::config::passenger').with({
-        :listen_on_interface => '',
-        :scl_prefix          => 'ruby193',
-      })}
+      it 'should contain foreman::config::passenger' do
+        should contain_class('foreman::config::passenger').
+          with_listen_on_interface('').
+          with_scl_prefix('ruby193').
+          that_comes_before('Anchor[foreman::config_end]')
+      end
     end
 
     describe 'without passenger' do


### PR DESCRIPTION
Contain Apache before foreman::config, stops it being (re)started after foreman_smartproxy resources.
