### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -105,6 +105,12 @@ class foreman::params {
       # Only the agent classes (cron / service) are supported for now, which
       # doesn't require any OS-specific params
     }
+    windows: {
+      $puppet_basedir = undef
+      $yumcode = undef
+      $passenger_scl = undef
+      $plugin_prefix = undef
+    }
     default: {
       fail("${::hostname}: This module does not support osfamily ${::osfamily}")
     }


### PR DESCRIPTION
add support for windows: puppet can configure puppet.conf on windows, but needs parameters from here
