### PR TITLE
Add foreman::cli class to install Hammer

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -1,0 +1,69 @@
+# = Foreman command line interface
+#
+# This class installs the Hammer command line interface (CLI).
+#
+# $foreman_url::        URL on which Foreman runs
+#
+# $username::           Username for authentication
+#
+# $password::           Password for authentication
+#
+# === Advanced parameters:
+#
+# $manage_root_config:: Whether to manage /root/.hammer configuration.
+#                       type:boolean
+#
+# $refresh_cache::      Check API documentation cache status on each request
+#                       type:boolean
+#
+# $request_timeout::    API request timeout, set -1 for infinity
+#                       type:integer
+#
+class foreman::cli (
+  $foreman_url        = $::foreman::cli::params::foreman_url,
+  $manage_root_config = $::foreman::cli::params::manage_root_config,
+  $username           = $::foreman::cli::params::username,
+  $password           = $::foreman::cli::params::password,
+  $refresh_cache      = $::foreman::cli::params::refresh_cache,
+  $request_timeout    = $::foreman::cli::params::request_timeout,
+) inherits foreman::cli::params {
+  # Inherit URL & auth parameters from foreman class if possible
+  $foreman_url_real = pick($foreman_url, $::foreman::foreman_url)
+  validate_string($foreman_url_real, $username, $password)
+  validate_bool($manage_root_config, $refresh_cache)
+
+  package { 'foreman-cli':
+    ensure => installed,
+  } ->
+  file { '/etc/hammer/cli.modules.d/foreman.yml':
+    ensure  => present,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('foreman/hammer_etc.yml.erb'),
+  }
+
+  # Separate configuration for admin username/password
+  if $manage_root_config {
+    file { '/root/.hammer':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+    }
+    file { '/root/.hammer/cli.modules.d':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0600',
+    }
+    file { '/root/.hammer/cli.modules.d/foreman.yml':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      replace => false,
+      content => template('foreman/hammer_root.yml.erb'),
+    }
+  }
+}

--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -1,0 +1,9 @@
+# Parameters for Foreman CLI class
+class foreman::cli::params {
+  $foreman_url = undef
+  $manage_root_config = true
+  $username = 'admin'
+  $password = 'changeme'
+  $refresh_cache = false
+  $request_timeout = 120
+}

--- a/spec/classes/foreman_cli_spec.rb
+++ b/spec/classes/foreman_cli_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe 'foreman::cli' do
+  context 'standalone with parameters' do
+    let(:params) do {
+      'foreman_url' => 'http://example.com',
+    } end
+
+    it { should contain_package('foreman-cli').with_ensure('installed') }
+
+    describe '/etc/hammer/cli.modules.d/foreman.yml' do
+      it 'should contain settings' do
+        content = subject.resource('file', '/etc/hammer/cli.modules.d/foreman.yml').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
+          ":foreman:",
+          "  :enable_module: true",
+          "  :host: 'http://example.com'",
+        ]
+      end
+    end
+
+    describe '/root/.hammer/cli.modules.d/foreman.yml' do
+      it { should contain_file('/root/.hammer/cli.modules.d/foreman.yml').with_replace(false) }
+
+      it 'should contain settings' do
+        content = subject.resource('file', '/root/.hammer/cli.modules.d/foreman.yml').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
+          ":foreman:",
+          "  :username: 'admin'",
+          "  :password: 'changeme'",
+          "  :refresh_cache: false",
+          "  :request_timeout: 120",
+        ]
+      end
+    end
+
+    describe 'with manage_root_config=false' do
+      let(:params) do {
+        'foreman_url' => 'http://example.com',
+        'manage_root_config' => false,
+      } end
+
+      it { should_not contain_file('/root/.hammer') }
+      it { should_not contain_file('/root/.hammer/cli.modules.d/foreman.yml') }
+    end
+  end
+
+  context 'with foreman' do
+    let :facts do {
+      :concat_basedir => '/tmp',
+      :operatingsystemrelease => '6.4',
+      :operatingsystem=> 'RedHat',
+      :osfamily => 'RedHat',
+      :fqdn     => 'foreman.example.com',
+    } end
+
+    let :pre_condition do
+      "class { 'foreman': }"
+    end
+
+    it { should contain_package('foreman-cli').with_ensure('installed') }
+
+    describe '/etc/hammer/cli.modules.d/foreman.yml' do
+      it 'should contain settings from foreman' do
+        content = subject.resource('file', '/etc/hammer/cli.modules.d/foreman.yml').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
+          ":foreman:",
+          "  :enable_module: true",
+          "  :host: 'https://#{facts[:fqdn]}'",
+        ]
+      end
+    end
+  end
+end

--- a/templates/hammer_etc.yml.erb
+++ b/templates/hammer_etc.yml.erb
@@ -1,0 +1,6 @@
+:foreman:
+  # Enable/disable foreman commands
+  :enable_module: true
+
+  # Your foreman server address
+  :host: '<%= @foreman_url_real %>'

--- a/templates/hammer_root.yml.erb
+++ b/templates/hammer_root.yml.erb
@@ -1,0 +1,10 @@
+:foreman:
+  # Credentials. You'll be asked for the interactively if you leave them blank here
+  :username: '<%= @username %>'
+  :password: '<%= @password %>'
+
+  # Check API documentation cache status on each request
+  :refresh_cache: <%= @refresh_cache %>
+
+  # API request timeout in seconds, set -1 for infinity
+  :request_timeout: <%= @request_timeout %>


### PR DESCRIPTION
<pre>
[root@foreman-el6 foreman]# foreman-installer --enable-foreman-cli -v
[ INFO 2014-05-14 11:44:49 verbose] Running validation checks
[ INFO 2014-05-14 11:44:50 verbose] Executing hooks in group pre
[ WARN 2014-05-14 11:44:50 verbose] Hook 'Kafo::HookContext' is using block with arguments which is DEPRECATED, access to kafo instance is provided by hook DSL, please remove |kafo| from your hook block
[ INFO 2014-05-14 11:44:50 verbose] All hooks in group pre finished
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/stdlib/lib/facter/facter_dot_d.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/stdlib/lib/facter/root_home.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/stdlib/lib/facter/pe_version.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/stdlib/lib/facter/puppet_vardir.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/concat/lib/facter/concat_basedir.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/firewall/lib/facter/iptables_version.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/firewall/lib/facter/ip6tables_version.rb
[ INFO 2014-05-14 11:44:50 verbose]  Loading facts in /usr/share/foreman-installer/modules/firewall/lib/facter/iptables_persistent_version.rb
[ INFO 2014-05-14 11:44:59 verbose]  Applying configuration version '1400064290'
[ INFO 2014-05-14 11:45:00 verbose] ''
[ WARN 2014-05-14 11:45:00 verbose]  /File[/root/.hammer]/ensure: created
[ WARN 2014-05-14 11:45:00 verbose]  /File[/root/.hammer/cli.modules.d]/ensure: created
[ WARN 2014-05-14 11:45:00 verbose]  /File[/root/.hammer/cli.modules.d/foreman.yml]/ensure: created
[ INFO 2014-05-14 11:45:01 verbose] '
[ INFO 2014-05-14 11:46:48 verbose] '
[ WARN 2014-05-14 11:46:48 verbose]  /Stage[main]/Foreman::Cli/Package[foreman-cli]/ensure: created
[ WARN 2014-05-14 11:46:48 verbose]  /File[/etc/hammer/cli.modules.d/foreman.yml]/content: 
[ INFO 2014-05-14 11:46:48 verbose] --- /etc/hammer/cli.modules.d/foreman.yml   2014-04-30 14:24:33.000000000 +0100
[ INFO 2014-05-14 11:46:48 verbose] +++ /tmp/puppet-file20140514-10631-1mrx0ub-0    2014-05-14 11:46:48.366000087 +0100
[ INFO 2014-05-14 11:46:48 verbose] @@ -1,5 +1,6 @@
[ INFO 2014-05-14 11:46:48 verbose]  :foreman:
[ INFO 2014-05-14 11:46:48 verbose] -    :enable_module: true
[ INFO 2014-05-14 11:46:48 verbose] -    :host: 'https://localhost/'
[ INFO 2014-05-14 11:46:48 verbose] -    :username: 'admin'
[ INFO 2014-05-14 11:46:48 verbose] -    :password: 'changeme'
[ INFO 2014-05-14 11:46:48 verbose] +  # Enable/disable foreman commands
[ INFO 2014-05-14 11:46:48 verbose] +  :enable_module: true
[ INFO 2014-05-14 11:46:48 verbose] +
[ INFO 2014-05-14 11:46:48 verbose] +  # Your foreman server address
[ INFO 2014-05-14 11:46:48 verbose] +  :host: 'https://foreman-el6.example.com'
[ INFO 2014-05-14 11:46:48 verbose]  FileBucket adding {md5}ae7be3b7f719856c73414d033a445880
[ INFO 2014-05-14 11:46:48 verbose]  /File[/etc/hammer/cli.modules.d/foreman.yml]: Filebucketed /etc/hammer/cli.modules.d/foreman.yml to puppet with sum ae7be3b7f719856c73414d033a445880
[ WARN 2014-05-14 11:46:48 verbose]  /File[/etc/hammer/cli.modules.d/foreman.yml]/content: content changed '{md5}ae7be3b7f719856c73414d033a445880' to '{md5}af92bd0108176412a553fac84f44131b'
[ WARN 2014-05-14 11:46:48 verbose]  /File[/etc/hammer/cli.modules.d/foreman.yml]/mode: mode changed '0755' to '0600'
[ WARN 2014-05-14 11:47:06 verbose]  Finished catalog run in 127.85 seconds
[ INFO 2014-05-14 11:47:07 verbose] Puppet has finished, bye!
[ INFO 2014-05-14 11:47:07 verbose] Executing hooks in group post
[ INFO 2014-05-14 11:47:07 verbose] All hooks in group post finished
  Success!
  * Foreman is running at https://foreman-el6.example.com
      Default credentials are 'admin:changeme'
  * Foreman Proxy is running at https://foreman-el6.example.com:8443
  * Puppetmaster is running at port 8140
  The full log is at /var/log/foreman-installer/foreman-installer.log
[root@foreman-el6 foreman]# hammer host list
---|-------------------------|---------------------|---------------|-----------------|------------------
ID | NAME                    | OPERATING SYSTEM ID | HOST GROUP ID | IP              | MAC              
---|-------------------------|---------------------|---------------|-----------------|------------------
2  | foreman-el6.example.com | 1                   |               | 192.168.122.176 | 52:54:00:27:02:f1
---|-------------------------|---------------------|---------------|-----------------|------------------
</pre>
