### PR TITLE
fixes #5924 - selinux context of node.rb is set explicitly

### DIFF
--- a/manifests/config/enc.pp
+++ b/manifests/config/enc.pp
@@ -17,6 +17,7 @@ class foreman::config::enc (
     mode    => '0550',
     owner   => 'puppet',
     group   => 'puppet',
+    seltype => 'foreman_enc_t',
   }
   file { "${puppet_home}/yaml":
     ensure                  => directory,


### PR DESCRIPTION
I need to make sure foreman-selinux package is installed PRIOR to this. Can you
experienced guys tell me how to do this? Thanks.
