### PR TITLE
Configure foreman websockets SSL settings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,13 @@
 #                           if you use another module for SSSD configuration
 #                           type:boolean
 #
+# $websockets_encrypt::     Whether to encrypt websocket connections
+#                           type:boolean
+#
+#
+# $websockets_ssl_key::     SSL key file to use when encrypting websocket connections
+# $websockets_ssl_cert::    SSL certificate file to use when encrypting websocket connections
+#
 class foreman (
   $foreman_url            = $foreman::params::foreman_url,
   $unattended             = $foreman::params::unattended,
@@ -196,6 +203,9 @@ class foreman (
   $pam_service            = $foreman::params::pam_service,
   $configure_ipa_repo     = $foreman::params::configure_ipa_repo,
   $ipa_manage_sssd        = $foreman::params::ipa_manage_sssd,
+  $websockets_encrypt     = $foreman::params::websockets_encrypt,
+  $websockets_ssl_key     = $foreman::params::websockets_ssl_key,
+  $websockets_ssl_cert    = $foreman::params::websockets_ssl_cert,
 ) inherits foreman::params {
   if $db_adapter == 'UNSET' {
     $db_adapter_real = $foreman::db_type ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,4 +187,9 @@ class foreman::params {
   $pam_service = 'foreman'
   $configure_ipa_repo = false
   $ipa_manage_sssd = true
+
+  # Websockets
+  $websockets_encrypt = true
+  $websockets_ssl_key = $server_ssl_key
+  $websockets_ssl_cert = $server_ssl_cert
 }

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -18,3 +18,8 @@
 :oauth_map_users: <%= scope.lookupvar("foreman::oauth_map_users") %>
 :oauth_consumer_key: <%= scope.lookupvar("foreman::oauth_consumer_key") %>
 :oauth_consumer_secret: <%= scope.lookupvar("foreman::oauth_consumer_secret") %>
+
+# Websockets
+:websockets_encrypt: <%= scope.lookupvar("foreman::websockets_encrypt") %>
+:websockets_ssl_key: <%= scope.lookupvar("foreman::websockets_ssl_key") %>
+:websockets_ssl_cert: <%= scope.lookupvar("foreman::websockets_ssl_cert") %>


### PR DESCRIPTION
This defaults to the Puppet CA certificate, which is also the default for configuring the apache vhost.

Note that this doesn't serve the entire chain. I have not tested this patch and that may be needed.
