### PR TITLE
fixes #3185 - refresh proxy features when foreman_smartproxy notified

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -58,4 +58,8 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
     api.call(:update, :id => id, :url => value)
   end
 
+  def refresh_features!
+    api.call(:refresh, :id => id)
+  end
+
 end

--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -45,4 +45,8 @@ Puppet::Type.newtype(:foreman_smartproxy) do
     defaultto 500
   end
 
+  def refresh
+    provider.refresh_features! if provider.respond_to?(:refresh_features!)
+  end
+
 end


### PR DESCRIPTION
Also tested with https://github.com/theforeman/puppet-foreman_proxy/pull/107 and it neatly refreshes the proxy features when the plugin's installed :)

<pre>
[ INFO 2014-07-23 17:27:46 verbose]  Applying configuration version '1406132856'
[ WARN 2014-07-23 17:27:50 verbose]  /Stage[main]/Foreman_proxy::Config/Foreman_proxy::Settings_file[settings]/File[/etc/foreman-proxy/settings.yml]/content: 
[ INFO 2014-07-23 17:27:50 verbose] --- /etc/foreman-proxy/settings.yml 2014-07-23 17:27:31.121628692 +0100
[ INFO 2014-07-23 17:27:50 verbose] +++ /tmp/puppet-file20140723-23460-5oh346-0 2014-07-23 17:27:50.691974663 +0100
[ INFO 2014-07-23 17:27:50 verbose] @@ -42,4 +42,3 @@
[ INFO 2014-07-23 17:27:50 verbose]  # valid options are
[ INFO 2014-07-23 17:27:50 verbose]  # WARN, DEBUG, Error, Fatal, INFO, UNKNOWN
[ INFO 2014-07-23 17:27:50 verbose]  #:log_level: DEBUG
[ INFO 2014-07-23 17:27:50 verbose] -#foo
[ INFO 2014-07-23 17:27:50 verbose]  FileBucket got a duplicate file {md5}44fa2c71ee9e52ecd3990d954f3d375f
[ INFO 2014-07-23 17:27:50 verbose]  /Stage[main]/Foreman_proxy::Config/Foreman_proxy::Settings_file[settings]/File[/etc/foreman-proxy/settings.yml]: Filebucketed /etc/foreman-proxy/settings.yml to puppet with sum 44fa2c71ee9e52ecd3990d954f3d375f
[ WARN 2014-07-23 17:27:50 verbose]  /Stage[main]/Foreman_proxy::Config/Foreman_proxy::Settings_file[settings]/File[/etc/foreman-proxy/settings.yml]/content: content changed '{md5}44fa2c71ee9e52ecd3990d954f3d375f' to '{md5}b3037a172fe7d0ddb24115bc46ddc1e7'
[ INFO 2014-07-23 17:27:50 verbose]  /Stage[main]/Foreman_proxy::Config/Foreman_proxy::Settings_file[settings]/File[/etc/foreman-proxy/settings.yml]: Scheduling refresh of Class[Foreman_proxy::Service]
[ INFO 2014-07-23 17:27:50 verbose]  Class[Foreman_proxy::Config]: Scheduling refresh of Foreman_proxy::Plugin[pulp]
[ INFO 2014-07-23 17:27:50 verbose]  Class[Foreman_proxy::Service]: Scheduling refresh of Service[foreman-proxy]
[ WARN 2014-07-23 17:27:52 verbose]  /Stage[main]/Foreman_proxy::Service/Service[foreman-proxy]: Triggered 'refresh' from 1 events
[ INFO 2014-07-23 17:27:52 verbose]  Class[Foreman_proxy::Service]: Scheduling refresh of Class[Foreman_proxy::Register]
[ INFO 2014-07-23 17:27:52 verbose]  Class[Foreman_proxy::Register]: Scheduling refresh of Foreman_smartproxy[foreman-el6.example.com]
[ WARN 2014-07-23 17:27:53 verbose]  /Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[foreman-el6.example.com]: Triggered 'refresh' from 1 events
[ WARN 2014-07-23 17:27:53 verbose]  Finished catalog run in 7.59 seconds
[ INFO 2014-07-23 17:27:54 verbose] Puppet has finished, bye!
[ INFO 2014-07-23 17:27:54 verbose] Executing hooks in group post
[ INFO 2014-07-23 17:27:54 verbose] All hooks in group post finished
  Success!
  * Foreman is running at https://foreman-el6.example.com
      Initial credentials are admin / admin
  * Foreman Proxy is running at https://foreman-el6.example.com:8443
  * Puppetmaster is running at port 8140
  The full log is at /var/log/foreman-installer/foreman-installer.log
[root@foreman-el6 foreman-installer]# tail -5 /var/log/foreman/production.log
Started PUT "/api/smart_proxies/3/refresh" for 127.0.0.1 at 2014-07-23 17:27:52 +0100
Processing by Api::V2::SmartProxiesController#refresh as JSON
  Parameters: {"apiv"=>"v2", "id"=>"3", "smart_proxy"=>{}}
Authorized user foreman_api_admin(API Admin)
Completed 200 OK in 239ms (Views: 0.7ms | ActiveRecord: 0.0ms)
</pre>
