### PR TITLE
refs #6445 - purge configuration which is no longer needed.

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -82,10 +82,12 @@ class foreman::config::passenger(
     }
 
     file { "${apache::confd_dir}/05-foreman.d":
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      purge   => true,
+      recurse => inf,
     }
 
     apache::vhost { 'foreman':


### PR DESCRIPTION
After running, `foreman-installer --foreman-ipa-authentication=true`, content in `/etc/httpd/conf.d/05-foreman-ssl.d` gets populated. When then rerunning the installer with `--foreman-ipa-authentication=false`, the execution fails because httpd cannot be restarted because config files in that directory use directives supported by modules that are no longer loaded. This will purge those extra files.
