### PR TITLE
Fix undefined foreman_url error on EL6

### DIFF
--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -36,10 +36,6 @@ Puppet::Reports.register_report(:foreman) do
       # check for report metrics
       raise(Puppet::ParseError, "Invalid report: can't find metrics information for #{self.host}") if self.metrics.nil?
 
-      def foreman_url
-        SETTINGS[:url] || raise(Puppet::Error, "Must provide URL in #{$settings_file}")
-      end
-
       uri = URI.parse(foreman_url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl     = uri.scheme == 'https'
@@ -178,6 +174,10 @@ Puppet::Reports.register_report(:foreman) do
                 else
                   @format = 0
                 end
+  end
+
+  def foreman_url
+    SETTINGS[:url] || raise(Puppet::Error, "Must provide URL in #{$settings_file}")
   end
 
 end


### PR DESCRIPTION
I don't know why exactly this is causing a problem, as in theory it's valid.  Unit tests and little examples I create seem to be fine.

However, reality differs: <pre>Jul 29 14:58:29 localhost puppet-master[21334]: Report processor failed: undefined local variable or method `foreman_url' for #Puppet::Transaction::Report:0x7f7005f7f6d0</pre>
