### PR TITLE
Move puppet config to /etc/puppet/foreman.yaml

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -9,7 +9,7 @@
 
 require 'yaml'
 
-$settings_file = "/etc/foreman/puppet.yaml"
+$settings_file = "/etc/puppet/foreman.yaml"
 
 SETTINGS = YAML.load_file($settings_file)
 

--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -23,7 +23,7 @@ rescue LoadError
   end
 end
 
-$settings_file = "/etc/foreman/puppet.yaml"
+$settings_file = "/etc/puppet/foreman.yaml"
 
 SETTINGS = YAML.load_file($settings_file)
 

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -30,14 +30,7 @@ class foreman::puppetmaster (
     ensure  => installed,
   }
 
-  file {'/etc/foreman':
-    ensure  => directory,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-  }
-
-  file {'/etc/foreman/puppet.yaml':
+  file {'/etc/puppet/foreman.yaml':
     content => template("${module_name}/puppet.yaml.erb"),
     mode    => '0640',
     owner   => 'root',

--- a/spec/classes/foreman_puppetmaster_spec.rb
+++ b/spec/classes/foreman_puppetmaster_spec.rb
@@ -40,18 +40,8 @@ describe 'foreman::puppetmaster' do
         should contain_package('rubygem-json').with_ensure('installed')
       end
 
-      it 'should create /etc/foreman' do
-        should contain_file('/etc/foreman').
-          with_ensure('directory').
-          with({
-            :mode    => '0755',
-            :owner   => 'root',
-            :group   => 'root',
-          })
-      end
-
       it 'should create puppet.yaml' do
-        should contain_file('/etc/foreman/puppet.yaml').
+        should contain_file('/etc/puppet/foreman.yaml').
           with_content(/^:url: "https:\/\/#{facts[:fqdn]}"$/).
           with_content(/^:ssl_ca: "\/var\/lib\/puppet\/ssl\/certs\/ca.pem"$/).
           with_content(/^:ssl_cert: "\/var\/lib\/puppet\/ssl\/certs\/#{facts[:fqdn]}.pem"$/).

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -9,7 +9,7 @@ class Enc
 :puppet_home: "/var/lib/puppet"
   EOF
   yaml = YAML.load(yaml_text)
-  YAML.stubs(:load_file).with("/etc/foreman/puppet.yaml").returns(yaml)
+  YAML.stubs(:load_file).with("/etc/puppet/foreman.yaml").returns(yaml)
   YAML.stubs(:load_file).with("/dev/null").returns({})
   eval File.read(File.join(File.dirname(__FILE__), '../..', 'files', 'external_node_v2.rb'))
 end

--- a/spec/unit/foreman_report_processor_spec.rb
+++ b/spec/unit/foreman_report_processor_spec.rb
@@ -9,7 +9,7 @@ describe 'foreman_report_processor' do
 :puppet_home: "/var/lib/puppet"
   EOF
   yaml = YAML.load(yaml_text)
-  YAML.stubs(:load_file).with("/etc/foreman/puppet.yaml").returns(yaml)
+  YAML.stubs(:load_file).with("/etc/puppet/foreman.yaml").returns(yaml)
   eval File.read(File.join(File.dirname(__FILE__), '../..', 'files', 'foreman-report_v2.rb'))
   let(:processor) { Puppet::Reports.report(:foreman) }
 


### PR DESCRIPTION
Previously it was in /etc/foreman/puppet.yaml, but this makes little sense
because foreman does not need to be installed on a puppet master.
