### PR TITLE
fixes #7063 - use explicit apipie-bindings cache dir as $HOME can't be expanded in a daemon

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -17,8 +17,10 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
       },
       :timeout => resource[:timeout],
       :headers => {
-        :foreman_user => resource[:effective_user]
-      }}).resource(:smart_proxies)
+        :foreman_user => resource[:effective_user],
+      },
+      :apidoc_cache_base_dir => File.join(Puppet[:server_datadir], 'apipie_bindings')
+    }).resource(:smart_proxies)
   end
 
   # proxy hash or nil


### PR DESCRIPTION
Uses https://github.com/Apipie/apipie-bindings/pull/14 when released/available.

Tested OK on EL6 with master/agent and installer modes.
