### PR TITLE
Update fixtures to use puppetlabs-concat to match pl-apache dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,13 +1,9 @@
 fixtures:
   repositories:
     apache:           'git://github.com/puppetlabs/puppetlabs-apache'
-    concat:
-      repo:           'git://github.com/ripienaar/puppet-concat'
-      ref:            '04356974f72b90a1d0f57346a00e95a717924e43'
+    concat:           'git://github.com/puppetlabs/puppetlabs-concat'
     concat_native:    'git://github.com/theforeman/puppet-concat'
-    mysql:
-      repo:           'git://github.com/puppetlabs/puppetlabs-mysql'
-      ref:            '52fb70ebdeb74f66bedc54196c0884c2b84699f3'
+    mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'


### PR DESCRIPTION
Should fix the test failures which were because pl-apache added the "ensure" parameter to a concat resource and now requires pl-concat >= 1.1.0.
