### PR TITLE
refs #7063 - change cache path so installer (root) doesn't conflict with master (puppet) user

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
       :headers => {
         :foreman_user => resource[:effective_user],
       },
-      :apidoc_cache_base_dir => File.join(Puppet[:server_datadir], 'apipie_bindings')
+      :apidoc_cache_base_dir => File.join(Puppet[:vardir], 'apipie_bindings')
     }).resource(:smart_proxies)
   end
 


### PR DESCRIPTION
On Fedora 19 at least, our tests are failing as the installer is causing /var/lib/puppet/server_data to be owned by root (user under which the installer runs), which means the Puppet master (which is "puppet") can't manage it.

```
Sep  2 03:51:09 server-163 puppet-master[10771]: failed to set mode 755 on /var/lib/puppet/server_data: Operation not permitted - /var/lib/puppet/server_data
```

My putting the cache under this directory was a bad idea, so moved back to the shared vardir.
