### PR TITLE
Fixes #4611,#7353 - control the db_pending_migration/db_pending_seed from installer

### DIFF
--- a/lib/puppet/provider/foreman_config_entry/cli.rb
+++ b/lib/puppet/provider/foreman_config_entry/cli.rb
@@ -6,43 +6,66 @@ Puppet::Type.type(:foreman_config_entry).provide(:cli) do
 
   mk_resource_methods
 
-  def self.instances
+  def self.run_foreman_config(args = "", options = {})
     Dir.chdir('/usr/share/foreman') do
-      Puppet::Util::Execution.execute(
-        '/usr/share/foreman/script/foreman-config',
-        :failonfail      => true,
-        :combine         => true,
-        :uid             => 'foreman',
-        :gid             => 'foreman'
-      ).split("\n").map do |line|
+      output = Puppet::Util::Execution.execute(
+        "/usr/share/foreman/script/foreman-config #{args}",
+        { :failonfail      => false,
+          :combine         => false,
+          :uid             => 'foreman',
+          :gid             => 'foreman' }.merge(options)
+      )
+      if $?.success?
+        output
+      end
+    end
+  end
+
+  def run_foreman_config(*args)
+    self.class.run_foreman_config(*args)
+  end
+
+  def self.instances
+    output = run_foreman_config
+    return if output.nil?
+    output.split("\n").map do |line|
         name, value = line.split(':')
         new(
           :name  => name,
           :value => value.strip
         ) unless value.nil?
-      end.compact
-    end
+    end.compact
   end
 
   def self.prefetch(resources)
     entries = instances
-    resources.keys.each do |name|
-      if provider = entries.find{ |entry| entry.name == name }
-        resources[name].provider = provider
+    return if entries.nil?
+    resources.each do |name, resource|
+      provider = entries.find { |entry| entry.name == name }
+      if provider.nil? && resource[:ignore_missing]
+        # just consider it has a value we exepcted
+        provider = new(:name => name, :value => resource[:value])
       end
+      resources[name].provider = provider
+    end
+  end
+
+  def value
+    if @property_hash[:value].nil?
+      value = run_foreman_config("-k '#{name}'").to_s.chomp
+      if value.empty? && resource[:ignore_missing]
+        @property_hash[:value] = resource[:value]
+      else
+        @property_hash[:value] = value
+      end
+    else
+      @property_hash[:value]
     end
   end
 
   def value=(value)
-    Dir.chdir('/usr/share/foreman') do
-      Puppet::Util::Execution.execute(
-        "/usr/share/foreman/script/foreman-config -k '#{name}' -v '#{value}'",
-        :failonfail      => true,
-        :combine         => true,
-        :uid             => 'foreman',
-        :gid             => 'foreman'
-      )
-    end
+    return if dry
+    run_foreman_config("-k '#{name}' -v '#{value}'", :combine => true, :failonfail => true)
     @property_hash[:value] = value
   end
 

--- a/lib/puppet/type/foreman_config_entry.rb
+++ b/lib/puppet/type/foreman_config_entry.rb
@@ -8,6 +8,16 @@ Puppet::Type.newtype(:foreman_config_entry) do
 
   newproperty(:value) do
     desc 'The value of the parameter.'
+
+    munge { |val| val.to_s }
+  end
+
+  newparam(:dry) do
+    desc "Don't update the value."
+  end
+
+  newparam(:ignore_missing) do
+    desc "Do nothing when the config option is not available."
   end
 
 end

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -24,7 +24,9 @@ describe 'foreman::install' do
 
       it { should contain_class('foreman::database::postgresql') }
 
+      it { should contain_foreman_config_entry('db_pending_migration') }
       it { should contain_foreman__rake('db:migrate') }
+      it { should contain_foreman_config_entry('db_pending_seed') }
       it { should contain_foreman__rake('db:seed') }
       it { should contain_foreman__rake('apipie:cache') }
     end
@@ -63,7 +65,9 @@ describe 'foreman::install' do
 
       it { should contain_class('foreman::database::postgresql') }
 
+      it { should contain_foreman_config_entry('db_pending_migration') }
       it { should contain_foreman__rake('db:migrate') }
+      it { should contain_foreman_config_entry('db_pending_seed') }
       it { should contain_foreman__rake('db:seed') }
       it { should contain_foreman__rake('apipie:cache') }
     end


### PR DESCRIPTION
This allows tracking the state of migration/seeding in the installer and
making sure the rake tasks are done on subsequential when something goes wrong
the first time.

Also, as part of the `foreman-rake config` calls, we ensure that the settings
are initiated before the httpd starts (preventing the race-conditions
happening when the httpd and rake db:seed start at the same time)
