### PR TITLE
Wrap API parameters so apipie-bindings validation for required params passes

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -42,8 +42,10 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
 
   def create
     api.call(:create, {
-      'name' => resource[:name],
-      'url' => resource[:url]
+      :smart_proxy => {
+        :name => resource[:name],
+        :url  => resource[:url]
+      }
     })
   end
 
@@ -57,7 +59,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
   end
 
   def url=(value)
-    api.call(:update, :id => id, :url => value)
+    api.call(:update, { :id => id, :smart_proxy => { :url => value } })
   end
 
   def refresh_features!


### PR DESCRIPTION
Should now exactly match the APIv2 documentation

---

This is a priority, as this + the apipie-bindings 0.10.0 release has caused our nightly tests to fail.

I've tested creation, deletion, refresh and updates on EL7 and it goes through fine against Foreman nightly.  If you'd like to test, apipie-bindings 0.0.10 RPMs are here:

http://koji.katello.org/koji/buildinfo?buildID=14776 el6
http://koji.katello.org/koji/buildinfo?buildID=14777 el7
http://koji.katello.org/koji/buildinfo?buildID=14778 f19
