### PR TITLE
Fixes #6015: Enable EPEL7 GPG checking

### DIFF
--- a/manifests/install/repos/extra.pp
+++ b/manifests/install/repos/extra.pp
@@ -8,17 +8,17 @@ class foreman::install::repos::extra(
   $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
 
   if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' and $configure_epel_repo {
-    $epel_gpgcheck = $osreleasemajor ? {
-      '7'     => 0,
-      default => 1,
+    $epel_gpgkey = $osreleasemajor ? {
+      '7'     => 'https://fedoraproject.org/static/352C64E5.txt',
+      default => 'https://fedoraproject.org/static/0608B895.txt',
     }
     yumrepo { 'epel':
       descr      => "Extra Packages for Enterprise Linux ${osreleasemajor} - \$basearch",
       mirrorlist => "https://mirrors.fedoraproject.org/metalink?repo=epel-${osreleasemajor}&arch=\$basearch",
       baseurl    => "http://download.fedoraproject.org/pub/epel/${osreleasemajor}/\$basearch",
       enabled    => 1,
-      gpgcheck   => $epel_gpgcheck,
-      gpgkey     => 'https://fedoraproject.org/static/0608B895.txt',
+      gpgcheck   => 1,
+      gpgkey     => $epel_gpgkey,
     }
   }
 

--- a/spec/classes/foreman_install_repos_extra_spec.rb
+++ b/spec/classes/foreman_install_repos_extra_spec.rb
@@ -21,6 +21,7 @@ describe 'foreman::install::repos::extra' do
       it { should contain_yumrepo('epel').with({
         :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :gpgcheck   => 1,
+        :gpgkey     => 'https://fedoraproject.org/static/0608B895.txt',
       }) }
       it { should_not contain_package('centos-release-SCL') }
       it { should_not contain_yumrepo('SCL') }
@@ -39,7 +40,8 @@ describe 'foreman::install::repos::extra' do
     describe 'when fully enabled' do
       it { should contain_yumrepo('epel').with({
         :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch',
-        :gpgcheck   => 0,
+        :gpgcheck   => 1,
+        :gpgkey     => 'https://fedoraproject.org/static/352C64E5.txt',
       }) }
       it { should_not contain_package('centos-release-SCL') }
       it { should_not contain_yumrepo('SCL') }


### PR DESCRIPTION
Since EPEL7 is now out of beta, we can enable GPG checking.
