### PR TITLE
refs #7234 - install foreman-release-scl on EL clones

### DIFF
--- a/manifests/install/repos/extra.pp
+++ b/manifests/install/repos/extra.pp
@@ -7,7 +7,7 @@ class foreman::install::repos::extra(
 ) {
   $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
 
-  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' and $configure_epel_repo {
+  if $configure_epel_repo {
     $epel_gpgkey = $osreleasemajor ? {
       '7'     => 'https://fedoraproject.org/static/352C64E5.txt',
       default => 'https://fedoraproject.org/static/0608B895.txt',
@@ -23,21 +23,8 @@ class foreman::install::repos::extra(
   }
 
   if $configure_scl_repo {
-    case $::operatingsystem {
-      'CentOS': {
-        package {'centos-release-SCL':
-          ensure => installed,
-        }
-      }
-      'Scientific': {
-        yumrepo { 'SCL':
-          descr    => 'Scientific Linux Software Collections',
-          baseurl  => "http://ftp.scientificlinux.org/linux/scientific/${osreleasemajor}/\$basearch/external_products/softwarecollections/",
-          enabled  => 1,
-          gpgcheck => 1,
-        }
-      }
-      default: {}
+    package {'foreman-release-scl':
+      ensure => installed,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,8 +29,9 @@ class foreman::params {
   # Choose whether you want to enable locations and organizations.
   $locations_enabled      = false
   $organizations_enabled  = false
-  $configure_epel_repo    = true
-  $configure_scl_repo     = true
+  $configure_epel_repo    = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')
+  # Only configure extra SCL repos on EL clones, RHEL itself usually has RHSCL
+  $configure_scl_repo     = ($::osfamily == 'RedHat' and $::operatingsystem != 'RedHat' and $::operatingsystem != 'Fedora')
 
 # Advance configurations - no need to change anything here by default
   # if set to true, no repo will be added by this module, letting you to

--- a/spec/classes/foreman_install_repos_extra_spec.rb
+++ b/spec/classes/foreman_install_repos_extra_spec.rb
@@ -1,114 +1,68 @@
 require 'spec_helper'
 
 describe 'foreman::install::repos::extra' do
-  let(:params) do
-    {
-      :configure_scl_repo  => true,
-      :configure_epel_repo => true,
-    }
-  end
-
-  context 'RHEL' do
-    let :facts do
+  describe 'when fully enabled' do
+    let(:params) do
       {
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '6.4',
-        :osfamily               => 'RedHat',
+        :configure_scl_repo  => true,
+        :configure_epel_repo => true,
       }
     end
 
-    describe 'when fully enabled' do
+    context 'RHEL 6' do
+      let :facts do
+        {
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6.4',
+          :osfamily               => 'RedHat',
+        }
+      end
+
       it { should contain_yumrepo('epel').with({
         :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch',
         :gpgcheck   => 1,
         :gpgkey     => 'https://fedoraproject.org/static/0608B895.txt',
       }) }
-      it { should_not contain_package('centos-release-SCL') }
-      it { should_not contain_yumrepo('SCL') }
-    end
-  end
-
-  context 'RHEL 7' do
-    let :facts do
-      {
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '7.0',
-        :osfamily               => 'RedHat',
-      }
+      it { should contain_package('foreman-release-scl') }
     end
 
-    describe 'when fully enabled' do
+    context 'RHEL 7' do
+      let :facts do
+        {
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '7.0',
+          :osfamily               => 'RedHat',
+        }
+      end
+
       it { should contain_yumrepo('epel').with({
         :mirrorlist => 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch',
         :gpgcheck   => 1,
         :gpgkey     => 'https://fedoraproject.org/static/352C64E5.txt',
       }) }
-      it { should_not contain_package('centos-release-SCL') }
-      it { should_not contain_yumrepo('SCL') }
+      it { should contain_package('foreman-release-scl') }
     end
   end
 
-  context 'CentOS' do
-    let :facts do
+  describe 'when fully disabled' do
+    let(:params) do
       {
-        :operatingsystem        => 'CentOS',
-        :operatingsystemrelease => '6.4',
-        :osfamily               => 'RedHat',
+        :configure_scl_repo  => false,
+        :configure_epel_repo => false,
       }
     end
 
-    describe 'when fully enabled' do
-      it { should contain_yumrepo('epel').with_mirrorlist('https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch') }
-      it { should contain_package('centos-release-SCL') }
-      it { should_not contain_yumrepo('SCL') }
-    end
-  end
+    context 'RHEL 6' do
+      let :facts do
+        {
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6.4',
+          :osfamily               => 'RedHat',
+        }
+      end
 
-  context 'Scientific Linux' do
-    let :facts do
-      {
-        :operatingsystem        => 'Scientific',
-        :operatingsystemrelease => '6.4',
-        :osfamily               => 'RedHat',
-      }
-    end
-
-    describe 'when fully enabled' do
-      it { should contain_yumrepo('epel').with_mirrorlist('https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch') }
-      it { should_not contain_package('centos-release-SCL') }
-      it { should contain_yumrepo('SCL').with_baseurl('http://ftp.scientificlinux.org/linux/scientific/6/$basearch/external_products/softwarecollections/') }
-    end
-  end
-
-  context 'Fedora' do
-    let :facts do
-      {
-        :operatingsystem        => 'Fedora',
-        :operatingsystemrelease => '19',
-        :osfamily               => 'RedHat',
-      }
-    end
-
-    describe 'when fully enabled' do
       it { should_not contain_yumrepo('epel') }
-      it { should_not contain_package('centos-release-SCL') }
-      it { should_not contain_yumrepo('SCL') }
-    end
-  end
-
-  context 'on debian' do
-    let :facts do
-      {
-        :operatingsystem        => 'Debian',
-        :operatingsystemrelease => 'wheezy',
-        :osfamily               => 'Debian',
-      }
-    end
-
-    describe 'when fully enabled' do
-      it { should_not contain_yumrepo('epel') }
-      it { should_not contain_package('centos-release-SCL') }
-      it { should_not contain_yumrepo('SCL') }
+      it { should_not contain_package('foreman-release-scl') }
     end
   end
 end

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -8,7 +8,7 @@ describe 'foreman::install' do
     }
   end
 
-  context 'RedHat' do
+  context 'RHEL' do
     let :facts do
       default_facts.merge({
         :operatingsystem        => 'RedHat',
@@ -24,7 +24,7 @@ describe 'foreman::install' do
 
       it { should contain_foreman__install__repos('foreman') }
       it { should contain_class('foreman::install::repos::extra').with({
-        :configure_scl_repo  => true,
+        :configure_scl_repo  => false,
         :configure_epel_repo => true,
       })}
 
@@ -167,6 +167,48 @@ describe 'foreman::install' do
     end
   end
 
+  context 'CentOS' do
+    let :facts do
+      default_facts.merge({
+        :operatingsystem        => 'CentOS',
+        :operatingsystemrelease => '6.4',
+        :osfamily               => 'RedHat',
+      })
+    end
+
+    describe 'without parameters' do
+      let :pre_condition do
+        "class {'foreman':}"
+      end
+
+      it { should contain_class('foreman::install::repos::extra').with({
+        :configure_scl_repo  => true,
+        :configure_epel_repo => true,
+      })}
+    end
+  end
+
+  context 'Fedora' do
+    let :facts do
+      default_facts.merge({
+        :operatingsystem        => 'Fedora',
+        :operatingsystemrelease => '19',
+        :osfamily               => 'RedHat',
+      })
+    end
+
+    describe 'without parameters' do
+      let :pre_condition do
+        "class {'foreman':}"
+      end
+
+      it { should contain_class('foreman::install::repos::extra').with({
+        :configure_scl_repo  => false,
+        :configure_epel_repo => false,
+      })}
+    end
+  end
+
   context 'on debian' do
     let :facts do
       default_facts.merge({
@@ -183,8 +225,8 @@ describe 'foreman::install' do
 
       it { should contain_foreman__install__repos('foreman') }
       it { should contain_class('foreman::install::repos::extra').with({
-        :configure_scl_repo  => true,
-        :configure_epel_repo => true,
+        :configure_scl_repo  => false,
+        :configure_epel_repo => false,
       })}
 
       it { should contain_package('foreman-postgresql').with_ensure('present') }


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman-packaging/pull/364

Foreman-specific SCL release package will replace per-distro SCL configuration
as it's more complex and more up to date.

configure_*_repo logic moved into parameter defaults which also allows users to
override the logic (e.g. on RHEL self-support, it can now be enabled).
