### PR TITLE
Wrong report status with Puppet master 3.7.1

### DIFF
--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -104,7 +104,7 @@ Puppet::Reports.register_report(:foreman) do
       report_status["failed"] += 1
     end
     # fix for Puppet non-resource errors (i.e. failed catalog fetches before falling back to cache)
-    report_status["failed"] += report.logs.find_all {|l| l.source == 'Puppet' && l.level.to_s == 'err' }.count
+    report_status["failed"] += report.logs.find_all {|l| l.source =~ /Puppet$/ && l.level.to_s == 'err' }.count
 
     return report_status
   end

--- a/spec/static_fixtures/report-log-preprocessed.yaml
+++ b/spec/static_fixtures/report-log-preprocessed.yaml
@@ -1,0 +1,290 @@
+--- !ruby/object:Puppet::Transaction::Report
+  kind: apply
+  time: 2012-11-09 15:39:28.292927 +00:00
+  configuration_version: 1352475569
+  report_format: 3
+  logs: 
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:28.378352 +00:00
+      level: !ruby/sym info
+      message: "Retrieving plugin"
+      tags: 
+        - info
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.134836 +00:00
+      level: !ruby/sym info
+      message: "Caching catalog for puppetmaster.vm1"
+      tags: 
+        - info
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.251560 +00:00
+      level: !ruby/sym info
+      message: "Applying configuration version '1352475569'"
+      tags: 
+        - info
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.262587 +00:00
+      level: !ruby/sym notice
+      message: yay
+      tags: 
+        - notice
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.263250 +00:00
+      file: /etc/puppet/manifests/site.pp
+      level: !ruby/sym notice
+      message: "defined 'message' as 'yay'"
+      tags: 
+        - notice
+        - notify
+        - yay
+        - node
+        - default
+        - class
+      source: /Stage[main]//Node[default]/Notify[yay]/message
+      line: 2
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.270773 +00:00
+      level: !ruby/sym info
+      message: "Creating state file /var/lib/puppet/state/state.yaml"
+      tags: 
+        - info
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.448142 +00:00
+      level: !ruby/sym notice
+      message: "Finished catalog run in 0.20 seconds"
+      tags: 
+        - notice
+      source: //puppetmaster.vm1/Puppet
+    - !ruby/object:Puppet::Util::Log
+      time: 2012-11-09 15:39:29.448142 +00:00
+      level: !ruby/sym err
+      tags:
+        - err
+      message: "Could not retrieve catalog from remote server: Error 400 on SERVER: Undefined variable \x22::repository\x22; Undefined variable \x22repository\x22 at /etc/puppet/environments/production/manifests/site.pp:17 on node puppetmaster.vm1"
+      source: //puppetmaster.vm1/Puppet
+  resource_statuses: 
+    Schedule[monthly]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[monthly]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - monthly
+      time: 2012-11-09 15:39:29.256862 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: monthly
+      skipped: true
+      failed: false
+    Filebucket[puppet]: !ruby/object:Puppet::Resource::Status
+      resource: Filebucket[puppet]
+      file: 
+      line: 
+      evaluation_time: 0.000216
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - filebucket
+        - puppet
+      time: 2012-11-09 15:39:29.267517 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Filebucket
+      title: puppet
+      skipped: false
+      failed: false
+    Notify[yay]: !ruby/object:Puppet::Resource::Status
+      resource: Notify[yay]
+      file: /etc/puppet/manifests/site.pp
+      line: 2
+      evaluation_time: 0.0019
+      change_count: 1
+      out_of_sync_count: 1
+      tags: 
+        - notify
+        - yay
+        - node
+        - default
+        - class
+      time: 2012-11-09 15:39:29.262048 +00:00
+      events: 
+        - !ruby/object:Puppet::Transaction::Event
+          audited: false
+          property: message
+          previous_value: !ruby/sym absent
+          desired_value: yay
+          historical_value: 
+          message: "defined 'message' as 'yay'"
+          name: !ruby/sym message_changed
+          status: success
+          time: 2012-11-09 15:39:29.262382 +00:00
+      out_of_sync: true
+      changed: true
+      resource_type: Notify
+      title: yay
+      skipped: false
+      failed: false
+    Schedule[never]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[never]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - never
+      time: 2012-11-09 15:39:29.266601 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: never
+      skipped: true
+      failed: false
+    Schedule[weekly]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[weekly]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - weekly
+      time: 2012-11-09 15:39:29.268075 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: weekly
+      skipped: true
+      failed: false
+    Schedule[puppet]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[puppet]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - puppet
+      time: 2012-11-09 15:39:29.268353 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: puppet
+      skipped: true
+      failed: false
+    Schedule[daily]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[daily]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - daily
+      time: 2012-11-09 15:39:29.256512 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: daily
+      skipped: true
+      failed: false
+    Schedule[hourly]: !ruby/object:Puppet::Resource::Status
+      resource: Schedule[hourly]
+      file: 
+      line: 
+      change_count: 0
+      out_of_sync_count: 0
+      tags: 
+        - schedule
+        - hourly
+      time: 2012-11-09 15:39:29.257131 +00:00
+      events: []
+      out_of_sync: false
+      changed: false
+      resource_type: Schedule
+      title: hourly
+      skipped: true
+      failed: false
+  status: changed
+  puppet_version: "3.0.1"
+  metrics: 
+    time: !ruby/object:Puppet::Util::Metric
+      name: time
+      label: Time
+      values: 
+        - - notify
+          - Notify
+          - 0.0019
+        - - config_retrieval
+          - "Config retrieval"
+          - 0.389333963394165
+        - - total
+          - Total
+          - 0.391449963394165
+        - - filebucket
+          - Filebucket
+          - 0.000216
+    resources: !ruby/object:Puppet::Util::Metric
+      name: resources
+      label: Resources
+      values: 
+        - - failed
+          - Failed
+          - 0
+        - - changed
+          - Changed
+          - 1
+        - - scheduled
+          - Scheduled
+          - 0
+        - - total
+          - Total
+          - 8
+        - - restarted
+          - Restarted
+          - 0
+        - - failed_to_restart
+          - "Failed to restart"
+          - 0
+        - - out_of_sync
+          - "Out of sync"
+          - 1
+        - - skipped
+          - Skipped
+          - 6
+    events: !ruby/object:Puppet::Util::Metric
+      name: events
+      label: Events
+      values: 
+        - - failure
+          - Failure
+          - 0
+        - - total
+          - Total
+          - 1
+        - - success
+          - Success
+          - 1
+    changes: !ruby/object:Puppet::Util::Metric
+      name: changes
+      label: Changes
+      values: 
+        - - total
+          - Total
+          - 1
+  host: puppetmaster.vm1
+  environment: production

--- a/spec/unit/foreman_report_processor_spec.rb
+++ b/spec/unit/foreman_report_processor_spec.rb
@@ -57,7 +57,7 @@ describe 'foreman_report_processor' do
   describe "report should support failure metrics" do
     subject { YAML.load_file("#{static_fixture_path}/report-2.6.5-errors.yaml").extend(processor) }
     it {
-      subject.generate_report['status']['failed'].should eql(1)
+      subject.generate_report['status']['failed'].should eql(3)
     }
   end
 
@@ -94,6 +94,13 @@ describe 'foreman_report_processor' do
 
   describe "report should show failure metrics for failed catalog fetches" do
     subject { YAML.load_file("#{static_fixture_path}/report-3.5.1-catalog-errors.yaml").extend(processor) }
+    it {
+      subject.generate_report['status']['failed'].should eql(1)
+    }
+  end
+
+  describe "report should properly bypass log processor changes" do
+    subject { YAML.load_file("#{static_fixture_path}/report-log-preprocessed.yaml").extend(processor) }
     it {
       subject.generate_report['status']['failed'].should eql(1)
     }


### PR DESCRIPTION
Using a Puppet master 3.7.1 (and 3.6.2 as an agent), log sources are not tagged as `Puppet` (anymore?) but as `//foo.example.com/Puppet` instead (using the node certname), this makes https://github.com/theforeman/puppet-foreman/blob/master/files/foreman-report_v2.rb#L107 not match, and thus fails to report failed catalog compilations as failed nodes when the cached catalog works.

I was able to fix this by using:

``` ruby
    report_status["failed"] += report.logs.find_all {|l| l.source =~ /Puppet$/ && l.level.to_s == 'err' }.count
```
