### PR TITLE
Directory recursion is problematic in large environments

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -62,7 +62,6 @@ class foreman::puppetmaster (
 
     file { "${puppet_home}/yaml":
       ensure                  => directory,
-      recurse                 => true,
       owner                   => 'puppet',
       group                   => 'puppet',
       selinux_ignore_defaults => true,


### PR DESCRIPTION
I manage a large environment; we started seeing significant performance hits on our puppetmasters when we got to 15,000 nodes.  The recurse on the directory forces stats of each of the yaml files in all the subdirs, which causes high CPU utilization and memory utilization of the puppet agent process.  We addressed this by removing the recurse parameter from the file resource.

Also, since there is potentially sensitive data in those yaml files, maybe it would be a good idea to set more restrictive permissions, such as 750, in those directories?  I can add the "normal" subdirectories {facts,node} in this pull request as well, if you'd like.  (Or create a separate PR for that.)
