### PR TITLE
refs #7970 - don't let Ruby alternative switch to 1.9 on Ubuntu 12.04

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    alternatives:     'git://github.com/adrienthebo/puppet-alternatives'
     apache:           'git://github.com/puppetlabs/puppetlabs-apache'
     apt:              'git://github.com/puppetlabs/puppetlabs-apt'
     concat:           'git://github.com/puppetlabs/puppetlabs-concat'

--- a/manifests/install/repos/extra.pp
+++ b/manifests/install/repos/extra.pp
@@ -41,5 +41,11 @@ class foreman::install::repos::extra(
   if $configure_brightbox_repo {
     include apt
     apt::ppa { 'ppa:brightbox/ruby-ng': }
+
+    # Setting alternatives to manual mode prevents the installation of 1.9 from later
+    # automatically switching them
+    alternatives { ['ruby', 'gem']:
+      mode => 'manual',
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,7 @@
   "dependencies": [
     { "name": "theforeman/concat_native", "version_requirement": ">= 1.3.0" },
     { "name": "theforeman/tftp",          "version_requirement": ">= 1.4.0" },
+    { "name": "adrien/alternatives",      "version_requirement": ">= 0.2.0 < 1.0.0" },
     { "name": "puppetlabs/apache",        "version_requirement": ">= 1.0.0 < 2.0.0" },
     { "name": "puppetlabs/apt",           "version_requirement": "< 2.0.0" },
     { "name": "puppetlabs/postgresql",    "version_requirement": ">= 3.0.0" },

--- a/spec/classes/foreman_install_repos_extra_spec.rb
+++ b/spec/classes/foreman_install_repos_extra_spec.rb
@@ -64,6 +64,8 @@ describe 'foreman::install::repos::extra' do
 
       it { should contain_class('apt') }
       it { should contain_apt__ppa('ppa:brightbox/ruby-ng') }
+      it { should contain_alternatives('ruby') }
+      it { should contain_alternatives('gem') }
     end
   end
 


### PR DESCRIPTION
Ensures other applications, including hammer, work as 1.8's the expected
default version.

Needs https://github.com/theforeman/foreman-packaging/pull/398

Needs https://github.com/adrienthebo/puppet-alternatives/pull/17, so https://github.com/theforeman/foreman-installer/pull/129 updates foreman-installer.
