### PR TITLE
Allows sub-uri deployment

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -54,6 +54,14 @@ class foreman::config::passenger(
   validate_bool($prestart)
 
   $docroot = "${app_root}/public"
+  $suburi_parts = split($foreman::foreman_url, '/')
+  $suburi_parts_count = size($suburi_parts) - 1
+  if $suburi_parts_count >= 3 {
+    $suburi_without_slash = join(values_at($suburi_parts, ["3-${suburi_parts_count}"]), '/')
+    if $suburi_without_slash {
+      $suburi = "/${suburi_without_slash}"
+    }
+  }
 
   include ::apache
   include ::apache::mod::headers
@@ -100,7 +108,7 @@ class foreman::config::passenger(
       priority        => '05',
       options         => ['SymLinksIfOwnerMatch'],
       custom_fragment => template('foreman/apache-fragment.conf.erb', 'foreman/_assets.conf.erb',
-                                  'foreman/_virt_host_include.erb'),
+                                  'foreman/_virt_host_include.erb', 'foreman/_suburi.conf.erb'),
     }
 
     if $ssl {
@@ -131,7 +139,7 @@ class foreman::config::passenger(
         ssl_options       => '+StdEnvVars',
         ssl_verify_depth  => '3',
         custom_fragment   => template('foreman/apache-fragment.conf.erb', 'foreman/_assets.conf.erb',
-                                      'foreman/_ssl_virt_host_include.erb'),
+                                      'foreman/_ssl_virt_host_include.erb', 'foreman/_suburi.conf.erb'),
       }
     }
   } else {

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -88,6 +88,8 @@ describe 'foreman::config' do
           with_ruby('/usr/bin/ruby193-ruby').
           that_comes_before('Anchor[foreman::config_end]')
       end
+
+      it { should contain_apache__vhost('foreman').without_custom_fragment(/Alias/) }
     end
 
     describe 'without passenger' do
@@ -140,6 +142,46 @@ describe 'foreman::config' do
           with_content(/^:oauth_consumer_secret:\s*def$/).
           with({})
       end
+    end
+
+    describe 'with url ending with trailing slash' do
+      let :pre_condition do
+        "class {'foreman':
+          foreman_url => 'https://example.com/',
+        }"
+      end
+
+      it { should contain_apache__vhost('foreman').without_custom_fragment(/Alias/) }
+    end
+
+    describe 'with sub-uri' do
+      let :pre_condition do
+        "class {'foreman':
+          foreman_url => 'https://example.com/foreman',
+        }"
+      end
+
+      it { should contain_apache__vhost('foreman').with_custom_fragment(/Alias \/foreman/) }
+    end
+
+    describe 'with sub-uri ending with trailing slash' do
+      let :pre_condition do
+        "class {'foreman':
+          foreman_url => 'https://example.com/foreman/',
+        }"
+      end
+
+      it { should contain_apache__vhost('foreman').with_custom_fragment(/Alias \/foreman/) }
+    end
+
+    describe 'with sub-uri ending with more levels' do
+      let :pre_condition do
+        "class {'foreman':
+          foreman_url => 'https://example.com/apps/foreman/',
+        }"
+      end
+
+      it { should contain_apache__vhost('foreman').with_custom_fragment(/Alias \/apps\/foreman/) }
     end
   end
 

--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -1,4 +1,5 @@
 # Static public dir serving
+<% unless @suburi %>
 <Directory <%= @docroot %>>
 
   <IfVersion < 2.4>
@@ -42,4 +43,4 @@
   </IfModule>
 
 </Directory>
-
+<% end %>

--- a/templates/_suburi.conf.erb
+++ b/templates/_suburi.conf.erb
@@ -1,0 +1,12 @@
+<% if @suburi %>
+SetEnv RAILS_RELATIVE_URL_ROOT <%= @suburi %>
+Alias <%= @suburi -%> <%= @docroot %>
+<Location <%= @suburi -%>>
+  PassengerBaseURI /
+  PassengerAppRoot <%= @app_root %>
+</Location>
+
+<Directory <%= @docroot -%>>
+  Options -MultiViews
+</Directory>
+<% end %>

--- a/templates/apache-fragment.conf.erb
+++ b/templates/apache-fragment.conf.erb
@@ -1,4 +1,6 @@
+<% unless @suburi %>
 PassengerAppRoot <%= @app_root %>
+<% end %>
 <% if @ruby and !@ruby.empty? -%>
 PassengerRuby <%= @ruby %>
 <% end -%>


### PR DESCRIPTION
With this patch you can install foreman to sub-uri like this
```
foreman-installer --foreman-foreman-url="https://example.com/foreman" --foreman-proxy-foreman-base-url="https://example.com/foreman"
```