### PR TITLE
Actually load the util/sssd.

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -1,4 +1,4 @@
-require 'facter/util/sssd'
+require 'util/sssd'
 
 # == Fact: default_ipa_realm
 # == Fact: default_ipa_server


### PR DESCRIPTION
With /usr/share/foreman-installer/modules/foreman/lib/facter/facts.rb from Foreman nightly (foreman-installer-1.8.0-0.develop.201411040324git9cc1f6f.el6.noarch), `foreman-installer -v` reports

```
[ INFO 2014-11-04 11:35:42 verbose]  Loading facts in /usr/share/foreman-installer/modules/foreman/lib/facter/facts.rb
[ WARN 2014-11-04 11:35:42 verbose]  Could not load fact file /usr/share/foreman-installer/modules/foreman/lib/facter/facts.rb: no such file to load -- facter/util/sssd
```

This patch seems to fix the problem.

The regression was caused by https://github.com/theforeman/puppet-foreman/pull/239 and it's probably also the reason why the 40 MB of RAM was saved -- Augeas was likely never loaded.

Surely, even better would be to turn failed requires to errors, not just warnings.
