### PR TITLE
Load the Facter utility class on Puppet 2

### DIFF
--- a/lib/facter/facts.rb
+++ b/lib/facter/facts.rb
@@ -1,4 +1,9 @@
-require 'facter/util/sssd'
+begin
+  require 'facter/util/sssd'
+rescue LoadError
+  # Puppet 2 compatibility, facter/ dir is the load path, not lib/
+  require 'util/sssd'
+end
 
 # == Fact: default_ipa_realm
 # == Fact: default_ipa_server


### PR DESCRIPTION
It appears that lib/facter/ is set as the load path with Puppet 2.7.25, while
Puppet 3 uses lib/.  To load the utility, we need to try both.

Replaces #247.
