### PR TITLE
Added support for tar-based discovery image 2.0

### DIFF
--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -4,44 +4,44 @@
 #
 # === Parameters:
 #
-# $version::         version string of discovery image, in form of x.y.z-r
-#
-# $source::          mirror url from which the image files should be obtained, you
-#                    can use http(s):// or file://
-#
-# $initrd::          name of initrd image file
-#
-# $kernel::          name of kernel file
-#
 # $install_images::  should the installer download and setup discovery images
 #                    for you? the average size is few hundreds of MB
 #                    type:boolean
 #
+# $tftp_root::       tftp root to install image into
+#
+# $source_url::      source URL to download from
+#
+# $image_name::      tarball with images
+#
 class foreman::plugin::discovery (
-  $version        = $foreman::plugin::discovery::params::version,
-  $source         = $foreman::plugin::discovery::params::source,
-  $initrd         = $foreman::plugin::discovery::params::initrd,
-  $kernel         = $foreman::plugin::discovery::params::kernel,
   $install_images = $foreman::plugin::discovery::params::install_images,
+  $tftp_root      = $foreman::plugin::discovery::params::tftp_root,
+  $source_url     = $foreman::plugin::discovery::params::source_url,
+  $image_name     = $foreman::plugin::discovery::params::image_name,
 ) inherits foreman::plugin::discovery::params {
 
+  $tftp_root_clean = regsubst($tftp_root, '/$', '')
   validate_bool($install_images)
+  validate_absolute_path($tftp_root_clean)
+  validate_string($source_url)
+  validate_string($image_name)
 
   foreman::plugin {'discovery':
   }
 
   if $install_images {
-    include ::tftp::params
 
-    foreman::remote_file {"${::tftp::params::root}boot/${kernel}":
-      remote_location => "${source}${kernel}",
+    foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
+      remote_location => "${source_url}${image_name}",
       mode            => 0644,
-      require         => File["${::tftp::params::root}boot"],
-    }
-    foreman::remote_file {"${::tftp::params::root}boot/${initrd}":
-      remote_location => "${source}${initrd}",
-      mode            => 0644,
-      require         => File["${::tftp::params::root}boot"],
+      require         => File["${tftp_root_clean}/boot"],
+      notify          => Exec["untar ${image_name}"],
+    } ~> exec { "untar ${image_name}":
+      command => "tar xf ${image_name}",
+      path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      cwd     => "${tftp_root_clean}/boot",
+      creates => "${tftp_root_clean}/boot/fdi-image/initrd0.img",
     }
   }
 }

--- a/manifests/plugin/discovery/params.pp
+++ b/manifests/plugin/discovery/params.pp
@@ -1,8 +1,9 @@
 # Default parameters for foreman::plugin::discovery
 class foreman::plugin::discovery::params {
-  $version         = 'latest'
-  $source          = 'http://downloads.theforeman.org/discovery/releases/latest/'
-  $initrd          = "foreman-discovery-image-${version}.el6.iso-img"
-  $kernel          = "foreman-discovery-image-${version}.el6.iso-vmlinuz"
-  $install_images  = false
+  include ::tftp::params
+
+  $install_images = false
+  $tftp_root      = $::tftp::params::root
+  $source_url     = 'http://downloads.theforeman.org/discovery/releases/latest/'
+  $image_name     = 'fdi-image-latest.tar'
 }

--- a/spec/classes/foreman_plugin_discovery_spec.rb
+++ b/spec/classes/foreman_plugin_discovery_spec.rb
@@ -11,10 +11,6 @@ describe 'foreman::plugin::discovery' do
   context 'with enabled image installation' do
     let :params do
       {
-          :version => 'latest',
-          :source => 'http://yum.theforeman.org/discovery/releases/latest/',
-          :initrd => 'foreman-discovery-image-latest.el6.iso-img',
-          :kernel => 'foreman-discovery-image-latest.el6.iso-vmlinuz',
           :install_images => true
       }
     end
@@ -23,24 +19,25 @@ describe 'foreman::plugin::discovery' do
       should contain_foreman__plugin('discovery')
     end
 
-    it 'should download and install kernel file' do
-      should contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-vmlinuz").
-                 with_remote_location('http://yum.theforeman.org/discovery/releases/latest/foreman-discovery-image-latest.el6.iso-vmlinuz')
+    it 'should download and install tarball' do
+      should contain_foreman__remote_file("/var/lib/tftpboot/boot/fdi-image-latest.tar").
+        with_remote_location('http://downloads.theforeman.org/discovery/releases/latest/fdi-image-latest.tar')
+    end
+    
+    it 'should extract the tarball' do
+      should contain_exec('untar fdi-image-latest.tar').with({
+        'command'     => "tar xf fdi-image-latest.tar",
+        'path'        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        'cwd'         => '/var/lib/tftpboot/boot',
+        'creates'     => "/var/lib/tftpboot/boot/fdi-image/initrd0.img",
+      })
     end
 
-    it 'should download and install initrd file' do
-      should contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-img").
-                 with_remote_location('http://yum.theforeman.org/discovery/releases/latest/foreman-discovery-image-latest.el6.iso-img')
-    end
   end
 
   context 'with disabled image installation' do
     let :params do
       {
-          :version => 'latest',
-          :source => 'http://yum.theforeman.org/discovery/releases/latest/',
-          :initrd => 'foreman-discovery-image-latest.el6.iso-img',
-          :kernel => 'foreman-discovery-image-latest.el6.iso-vmlinuz',
           :install_images => false
       }
     end
@@ -49,12 +46,8 @@ describe 'foreman::plugin::discovery' do
       should contain_foreman__plugin('discovery')
     end
 
-    it 'should not download and install kernel file' do
-      should_not contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-vmlinuz")
-    end
-
-    it 'should not download and install initrd file' do
-      should_not contain_foreman__remote_file("/var/lib/tftpboot/boot/foreman-discovery-image-latest.el6.iso-img")
+    it 'should not download and install tarball' do
+      should_not contain_foreman__remote_file("/var/lib/tftpboot/boot/fdi-image-latest.tar")
     end
   end
 end


### PR DESCRIPTION
Tests are green, but I struggle testing this. When I do

`foreman-installer -v --foreman-plugin-discovery-install-images=true`

nothing happens. I am not sure if kafo caches the parameters or something (they
changed a bit). @ares any tips for me?

Thanks