### PR TITLE
[plugins:puppetdb] Fix debian package name

### DIFF
--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -12,7 +12,7 @@ class foreman::plugin::puppetdb {
       }
     }
     'Debian': {
-      $package = 'ruby-puppetdb_foreman'
+      $package = 'ruby-puppetdb-foreman'
     }
     'Linux': {
       case $::operatingsystem {

--- a/spec/classes/foreman_plugin_puppetdb_spec.rb
+++ b/spec/classes/foreman_plugin_puppetdb_spec.rb
@@ -6,6 +6,6 @@ describe 'foreman::plugin::puppetdb' do
   } end
 
   it 'should call the plugin' do
-    should contain_foreman__plugin('puppetdb').with_package('ruby-puppetdb_foreman')
+    should contain_foreman__plugin('puppetdb').with_package('ruby-puppetdb-foreman')
   end
 end


### PR DESCRIPTION
As it can be seen in

http://deb.theforeman.org/dists/plugins/nightly/binary-amd64/Packages

the package is ruby-puppetdb-foreman, hyphenated as all other foreman
plugin debian packages.
