### PR TITLE
Correct foreman_report comment about settings path

### DIFF
--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -1,7 +1,7 @@
 # copy this file to your report dir - e.g. /usr/lib/ruby/1.8/puppet/reports/
 # add this report in your puppetmaster reports - e.g, in your puppet.conf add:
 # reports=log, foreman # (or any other reports you want)
-# configuration is in /etc/foreman/puppet.yaml
+# configuration is in /etc/puppet/foreman.yaml
 
 require 'puppet'
 require 'net/http'


### PR DESCRIPTION
In foreman_report the comment still refers to the situation before
commit 70f302417414a39559fb4e69f3f6136d800d4297 where the configuration
was stored in /etc/foreman/puppet.yaml.

This commit fixes the comment to reflect the new situation.
