### PR TITLE
Fix minimum alternatives version for dpkg/mode fix

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   "dependencies": [
     { "name": "theforeman/concat_native", "version_requirement": ">= 1.3.0" },
     { "name": "theforeman/tftp",          "version_requirement": ">= 1.4.0" },
-    { "name": "adrien/alternatives",      "version_requirement": ">= 0.2.0 < 1.0.0" },
+    { "name": "adrien/alternatives",      "version_requirement": ">= 0.3.0 < 1.0.0" },
     { "name": "puppetlabs/apache",        "version_requirement": ">= 1.0.0 < 2.0.0" },
     { "name": "puppetlabs/apt",           "version_requirement": "< 2.0.0" },
     { "name": "puppetlabs/postgresql",    "version_requirement": ">= 3.0.0" },


### PR DESCRIPTION
It was unreleased at the time of b5d8e4f, now it's 0.3.0.