### PR TITLE
fixes #8944 - renaming facts parameter to receive_facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,8 +10,8 @@ class foreman::params {
   $enc          = true
   # Should foreman receive reports from puppet
   $reports      = true
-  # Should foreman recive facts from puppet
-  $facts        = true
+  # Should foreman receive facts from puppet
+  $receive_facts = true
   # should foreman manage host provisioning as well
   $unattended   = true
   # Enable users authentication (default user:admin pw:changeme)

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -6,7 +6,7 @@ class foreman::puppetmaster (
   $foreman_password = $foreman::params::foreman_password,
   $reports          = $foreman::params::reports,
   $enc              = $foreman::params::enc,
-  $facts            = $foreman::params::facts,
+  $receive_facts    = $foreman::params::receive_facts,
   $puppet_home      = $foreman::params::puppet_home,
   $puppet_user      = $foreman::params::puppet_user,
   $puppet_group     = $foreman::params::puppet_group,

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -7,6 +7,6 @@
 :password: "<%= @foreman_password %>"
 :puppetdir: "<%= @puppet_home %>"
 :puppetuser: "<%= @puppet_user %>"
-:facts: <%= @facts %>
+:facts: <%= @receive_facts %>
 :timeout: 10
 :threads: null


### PR DESCRIPTION
This is just a rename of the ```$facts``` parameter, as it's a reserved keyword when ```trusted_node_data = true```.