### PR TITLE
update for non-english windows clients

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -14,7 +14,9 @@ $settings_file = "/etc/puppet/foreman.yaml"
 SETTINGS = YAML.load_file($settings_file)
 
 # Default external encoding
-Encoding.default_external = Encoding::UTF_8
+if defined?(Encoding)
+  Encoding.default_external = Encoding::UTF_8
+end
 
 def url
   SETTINGS[:url] || raise("Must provide URL in #{$settings_file}")

--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -13,6 +13,9 @@ $settings_file = "/etc/puppet/foreman.yaml"
 
 SETTINGS = YAML.load_file($settings_file)
 
+# Default external encoding
+Encoding.default_external = Encoding::UTF_8
+
 def url
   SETTINGS[:url] || raise("Must provide URL in #{$settings_file}")
 end
@@ -101,6 +104,14 @@ def build_body(certname,filename)
   facts        = File.read(filename)
   puppet_facts = YAML::load(facts.gsub(/\!ruby\/object.*$/,''))
   hostname     = puppet_facts['values']['fqdn'] || certname
+  
+  # filter any non-printable char from the value, if it is a String
+  puppet_facts['values'].each do |key, val|
+    if val.is_a? String
+      puppet_facts['values'][key] = val.scan(/[[:print:]]/).join
+    end
+  end
+  
   {'facts' => puppet_facts['values'], 'name' => hostname, 'certname' => certname}
 end
 


### PR DESCRIPTION
foreman 1.7.1, puppet 3.7.3
1) Default external encoding ( global )
2) filter any non-printable char from the value, if it is a String ( def build_body(certname,filename) )
    http://projects.puppetlabs.com/issues/12702#note-8