### PR TITLE
Openscap plugin scap client

### DIFF
--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -1,0 +1,46 @@
+# = Foreman OpenSCAP plugin
+#
+# This class installs OpenSCAP plugin
+#
+# === Parameters:
+#
+# $configure_openscap_repo::  Enable custom yum repo with packages needed for foreman_openscap,
+#                             type:boolean
+#
+class foreman::plugin::openscap (
+  $configure_openscap_repo = true,
+) {
+  validate_bool($configure_openscap_repo)
+
+  case $::osfamily {
+    'RedHat': {
+
+      if $configure_openscap_repo {
+        $repo = $::operatingsystem ? {
+          'Fedora' => 'fedora',
+          default  => 'epel',
+        }
+
+        if $::operatingsystemmajrelease == undef {
+          $versions_array = split($::operatingsystemrelease, '\.') # facter 1.6
+          $major = $versions_array[0]
+        } else {
+          $major = $::operatingsystemmajrelease # facter 1.7+
+        }
+
+        yumrepo { 'isimluk-openscap':
+          enabled  => 1,
+          gpgcheck => 0,
+          baseurl  => "http://copr-be.cloud.fedoraproject.org/results/isimluk/OpenSCAP/${repo}-${major}-\$basearch/",
+          before   => [ Foreman::Plugin['openscap'] ],
+        }
+      }
+
+      foreman::plugin {'openscap': }
+
+    }
+    default: {
+      fail("Unsupported osfamily ${::osfamily}")
+    }
+  }
+}

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -7,8 +7,13 @@
 # $configure_openscap_repo::  Enable custom yum repo with packages needed for foreman_openscap,
 #                             type:boolean
 #
+# $scap_client_module_dir::   if you set a directory here, installer will upload foreman_scap_client
+#                             puppet module into this directory for you
+#                             e.g. /etc/puppet/environments/production/modules
+#
 class foreman::plugin::openscap (
   $configure_openscap_repo = true,
+  $scap_client_module_dir  = undef,
 ) {
   validate_bool($configure_openscap_repo)
 
@@ -37,6 +42,14 @@ class foreman::plugin::openscap (
       }
 
       foreman::plugin {'openscap': }
+
+      if $scap_client_module_dir {
+        file { "${scap_client_module_dir}/foreman_scap_client":
+          ensure  => directory,
+          source  => '/usr/share/foreman-installer/modules/foreman_scap_client',
+          recurse => true,
+        }
+      }
 
     }
     default: {

--- a/spec/classes/foreman_plugin_openscap_spec.rb
+++ b/spec/classes/foreman_plugin_openscap_spec.rb
@@ -26,7 +26,22 @@ describe 'foreman::plugin::openscap' do
           end
         end
 
-        context 'with disabled repository installation' do
+        context 'with scap_client_module_dir set to directory' do
+          let :params do
+            {
+              :configure_openscap_repo => true,
+              :scap_client_module_dir => '/etc/puppet/environments/production/modules'
+            }
+          end
+
+          it 'should copy foreman_scap_client module to specified module directory' do
+            should contain_file("/etc/puppet/environments/production/modules/foreman_scap_client").
+                     with_source('/usr/share/foreman-installer/modules/foreman_scap_client').
+                     with_ensure('directory')
+          end
+        end
+
+        context 'with disabled repository installation and without module dir' do
           let :params do
             {
               :configure_openscap_repo => false
@@ -39,6 +54,10 @@ describe 'foreman::plugin::openscap' do
 
           it 'should not install custom openscap repo' do
             should_not contain_yumrepo("isimluk-openscap")
+          end
+
+          it 'should not copy foreman_scap_client module to specified module directory' do
+            should_not contain_file("/etc/puppet/environments/production/modules/foreman_scap_client")
           end
         end
       end

--- a/spec/classes/foreman_plugin_openscap_spec.rb
+++ b/spec/classes/foreman_plugin_openscap_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::openscap' do
+  on_supported_os.each do |os, facts|
+    if facts[:osfamily] == 'RedHat'
+      context "on #{os}" do
+        let :facts do
+          facts
+        end
+
+        repo_base = facts[:operatingsystem] == 'Fedora' ? 'fedora' : 'epel'
+        context 'with configure_openscap_repo set to true' do
+          let :params do
+            {
+              :configure_openscap_repo => true
+            }
+          end
+
+          it 'should call the plugin' do
+            should contain_foreman__plugin('openscap')
+          end
+
+          it 'should install custom openscap repo' do
+            should contain_yumrepo("isimluk-openscap").
+                     with_baseurl("http://copr-be.cloud.fedoraproject.org/results/isimluk/OpenSCAP/#{repo_base}-#{facts[:operatingsystemmajrelease]}-$basearch/")
+          end
+        end
+
+        context 'with disabled repository installation' do
+          let :params do
+            {
+              :configure_openscap_repo => false
+            }
+          end
+
+          it 'should call the plugin' do
+            should contain_foreman__plugin('openscap')
+          end
+
+          it 'should not install custom openscap repo' do
+            should_not contain_yumrepo("isimluk-openscap")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR would allow to install foreman_scap_client puppet module to puppet master

Based on #273, link to original discussion https://github.com/theforeman/puppet-foreman/pull/273#discussion_r23518477

There are other possible approaches:
* move the logic to puppet-puppet module, since it's more related to puppetmaster than foreman itself
* implement as foreman-installer hook since it's mainly intended for installer support, on the other hand why not allow this to be used within puppet master as well

@ekohl what are your thoughts? Should we raise broader discussion on mailing list first?