### PR TITLE
fixes #9101 - refresh db:migrate if DB class changes or settings are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,6 @@ Thus 'master' will support the upcoming major version and the current stable.
 The latest release (git tag, Puppet Forge) should support current and the
 previous stable release.
 
-## Foreman 1.6 support
-
-On Ubuntu 12.04 with Foreman 1.6, the move to configure Ruby 1.9 with Brightbox
-should be disabled:
-
-    class { 'foreman':
-      configure_brightbox_repo => false,
-      passenger_ruby           => '',
-      passenger_ruby_package   => '',
-    }
-
 # Contributing
 
 * Fork the project

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -20,19 +20,17 @@ class foreman::database {
       $foreman_service = Class['foreman::service']
     }
 
-    class { $db_class: } ->
+    class { $db_class: } ~>
     foreman_config_entry { 'db_pending_migration':
-      value          => false,
-      dry            => true,
-      ignore_missing => true,
+      value => false,
+      dry   => true,
     } ~>
-    foreman::rake { 'db:migrate': } ->
+    foreman::rake { 'db:migrate': } ~>
     foreman_config_entry { 'db_pending_seed':
-      value          => false,
-      dry            => true,
-      ignore_missing => true,
+      value  => false,
+      dry    => true,
       # to address #7353: settings initialization race condition
-      before         => $foreman_service,
+      before => $foreman_service,
     } ~>
     foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),


### PR DESCRIPTION
When the DB is missing, the foreman::database::${type} class will refresh as
it recreates it, and now triggers the migration.  On a clean install, this was
working mostly by luck as foreman::config refreshed everything.

foreman_config_entry didn't cause a refresh due to ignore_missing, which meant
it would only help when Foreman settings had been initialised, but before the
migration had completed.  With an empty DB, it wouldn't work.

Removing ignore_missing means foreman_config_entry will also continue to
refresh the db:migrate until the setting is populated, and the migration
completes.

Only compatible with Foreman 1.7+ as it'll cause continuous refreshes on older
versions without the setting.

(cc @ehelms, @iNecas)

---

I was going to just add the refreshes in at first, but removing ignore_missing is better as then the foreman_config_entry will refresh the db:migrate too when the DB is present but empty.