### PR TITLE
Adding option to not have module try to add the user for foreman

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,13 +32,15 @@ class foreman::config {
     ensure  => directory,
   }
 
-  user { $foreman::user:
-    ensure  => 'present',
-    shell   => '/bin/false',
-    comment => 'Foreman',
-    home    => $foreman::app_root,
-    gid     => $foreman::group,
-    groups  => $foreman::user_groups,
+  if $manage_user {
+    user { $foreman::user:
+      ensure  => 'present',
+      shell   => '/bin/false',
+      comment => 'Foreman',
+      home    => $foreman::app_root,
+      gid     => $foreman::group,
+      groups  => $foreman::user_groups,
+    }
   }
 
   # remove crons previously installed here, they've moved to the package's

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,7 +32,7 @@ class foreman::config {
     ensure  => directory,
   }
 
-  if $manage_user {
+  if $foreman::manage_user {
     user { $foreman::user:
       ensure  => 'present',
       shell   => '/bin/false',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,8 @@
 #
 # $app_root::                 Name of foreman root directory
 #
+# $manage_user::              Controls whether foreman module will manage the user on the system. (default true)
+#
 # $user::                     User under which foreman will run
 #
 # $group::                    Primary group for the Foreman user
@@ -189,6 +191,7 @@ class foreman (
   $db_sslmode               = 'UNSET',
   $db_pool                  = $foreman::params::db_pool,
   $app_root                 = $foreman::params::app_root,
+  $manage_user              = true,
   $user                     = $foreman::params::user,
   $group                    = $foreman::params::group,
   $user_groups              = $foreman::params::user_groups,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,7 @@
 # $app_root::                 Name of foreman root directory
 #
 # $manage_user::              Controls whether foreman module will manage the user on the system. (default true)
+#                             type:boolean
 #
 # $user::                     User under which foreman will run
 #
@@ -191,7 +192,7 @@ class foreman (
   $db_sslmode               = 'UNSET',
   $db_pool                  = $foreman::params::db_pool,
   $app_root                 = $foreman::params::app_root,
-  $manage_user              = true,
+  $manage_user              = $foreman::params::manage_user,
   $user                     = $foreman::params::user,
   $group                    = $foreman::params::group,
   $user_groups              = $foreman::params::user_groups,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class foreman::params {
   $repo        = 'stable'
   $railspath   = '/usr/share'
   $app_root    = "${railspath}/foreman"
+  $manage_user = true
   $user        = 'foreman'
   $group       = 'foreman'
   $user_groups = ['puppet']


### PR DESCRIPTION
Default behavior is the same as current. However this option allows the option to have user managed in another module. Useful for instances that want UIDs managed centrally to ensure consistency across systems.