### PR TITLE
Leading zeros need to be quoted

### DIFF
--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -33,7 +33,7 @@ class foreman::plugin::discovery (
   if $install_images {
     foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
       remote_location => "${source_url}${image_name}",
-      mode            => 0644,
+      mode            => '0644',
       require         => File["${tftp_root_clean}/boot"],
     } ~> exec { "untar ${image_name}":
       command => "tar xf ${image_name}",

--- a/manifests/remote_file.pp
+++ b/manifests/remote_file.pp
@@ -1,5 +1,5 @@
 # Downloads a file from a URL to a local file given by the title
-define foreman::remote_file($remote_location, $mode=0644) {
+define foreman::remote_file($remote_location, $mode='0644') {
   exec {"retrieve_${title}":
     command => "/usr/bin/curl -s ${remote_location} -o ${title}",
     creates => $title,


### PR DESCRIPTION
This fix is required to migration to the future parser.