### PR TITLE
Fixes #9286 - node.rb timeout too low and not configurable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,8 @@ class foreman::params {
   $gpgcheck    = true
   $version     = 'present'
 
+  $puppetmaster_timeout = 60
+
   # when undef, foreman-selinux will be installed if SELinux is enabled
   # setting to false/true will override this check (e.g. set to false on 1.1)
   $selinux     = undef

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -11,6 +11,7 @@ class foreman::puppetmaster (
   $puppet_user      = $foreman::params::puppet_user,
   $puppet_group     = $foreman::params::puppet_group,
   $puppet_basedir   = $foreman::params::puppet_basedir,
+  $timeout          = $foreman::params::puppetmaster_timeout,
   $ssl_ca           = $foreman::params::client_ssl_ca,
   $ssl_cert         = $foreman::params::client_ssl_cert,
   $ssl_key          = $foreman::params::client_ssl_key,

--- a/spec/classes/foreman_puppetmaster_spec.rb
+++ b/spec/classes/foreman_puppetmaster_spec.rb
@@ -50,6 +50,7 @@ describe 'foreman::puppetmaster' do
           with_content(/^:password: ""$/).
           with_content(/^:puppetdir: "\/var\/lib\/puppet"$/).
           with_content(/^:facts: true$/).
+          with_content(/^:timeout: 60$/).
           with({
             :mode  => '0640',
             :owner => 'root',

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -8,5 +8,5 @@
 :puppetdir: "<%= @puppet_home %>"
 :puppetuser: "<%= @puppet_user %>"
 :facts: <%= @receive_facts %>
-:timeout: 10
+:timeout: <%= @timeout %>
 :threads: null


### PR DESCRIPTION
Make the node.rb timeout configurable. This is useful for use cases when
catalog compilation takes more time and/or the node.rb request to
Foreman is being handled by a freshly spawned Passenger worker.