### PR TITLE
Initial puppet runs with no internet access cause failures on later runs

### DIFF
--- a/manifests/install/repos/apt.pp
+++ b/manifests/install/repos/apt.pp
@@ -2,10 +2,10 @@
 define foreman::install::repos::apt ($repo) {
   file { "/etc/apt/sources.list.d/${name}.list":
     content => "deb http://deb.theforeman.org/ ${::lsbdistcodename} ${repo}\ndeb http://deb.theforeman.org/ plugins ${repo}\n"
-  } ~>
+  } ->
   exec { "foreman-key-${name}":
-    command     => '/usr/bin/wget -q http://deb.theforeman.org/foreman.asc -O- | /usr/bin/apt-key add -',
-    refreshonly => true
+    command => '/usr/bin/wget -q http://deb.theforeman.org/foreman.asc -O- | /usr/bin/apt-key add -',
+    unless  => '/usr/bin/apt-key list | /bin/grep -q "Foreman Automatic Signing Key"'
   } ~>
   exec { "update-apt-${name}":
     command     => '/usr/bin/apt-get update',


### PR DESCRIPTION
First pull request, let me know if I am doing anything wrong.

On my first puppet runs, I do not have internet access, and I discovered that the resource ordering in the apt repo installation causes later runs to fail as the theforeman deb sources never gets changed (which succeeds offline).