### PR TITLE
fixes #9449 - drop usage of lsb facts

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -75,11 +75,8 @@ class foreman::config::passenger(
   # RedHat distros come with this enabled. Newer Debian and Ubuntu distros
   # comes also with this enabled. Only old Debian and Ubuntu distros (squeeze,
   # lucid, precise) needs hand-holding.
-  case $::lsbdistcodename {
-    'squeeze','lucid','precise': {
-      ::apache::mod { 'version': }
-    }
-    default: {}
+  if ($::operatingsystemrelease == '12.04') and ($::operatingsystem == 'Ubuntu') {
+    ::apache::mod { 'version': }
   }
 
   if $use_vhost {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,13 +128,17 @@ class foreman::params {
       $init_config = '/etc/default/foreman'
       $init_config_tmpl = 'foreman.default'
 
-      case $::lsbdistcodename {
-        /^(squeeze|precise)$/: {
+      $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
+
+      case $osreleasemajor {
+        '12': {
+          # 12 is Ubuntu/precise here, once precise support is dropped,
+          # this should be dropped to not collide with Debian 12
           $passenger_prestart = false
           $passenger_min_instances = undef
           $passenger_start_timeout = undef
         }
-        /^wheezy$/: {
+        '7': {
           $passenger_prestart = false
           $passenger_min_instances = 1
           $passenger_start_timeout = undef

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -19,14 +19,9 @@ class foreman::puppetmaster (
   $report_api       = 'v2'
 ) inherits foreman::params {
 
-  case $::operatingsystem {
-    'Debian','Ubuntu': {
-      case $::lsbdistcodename {
-        'squeeze': { $json_package = 'libjson-ruby' }
-        default:   { $json_package = 'ruby-json' }
-      }
-    }
-    default:       { $json_package = 'rubygem-json' }
+  case $::osfamily {
+    'Debian': { $json_package = 'ruby-json' }
+    default:  { $json_package = 'rubygem-json' }
   }
 
   package { $json_package:

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     { "operatingsystem": "CentOS",     "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "Scientific", "operatingsystemrelease": [ "6", "7" ] },
     { "operatingsystem": "Fedora",     "operatingsystemrelease": [ "19" ] },
-    { "operatingsystem": "Debian",     "operatingsystemrelease": [ "6", "7" ] },
+    { "operatingsystem": "Debian",     "operatingsystemrelease": [ "7" ] },
     { "operatingsystem": "Ubuntu",     "operatingsystemrelease": [ "12.04", "14.04" ] }
   ]
 }


### PR DESCRIPTION
where possible, so there's still one occurence in ```manifests/install/repos/apt.pp```.
Support for Debian/squeeze was dropped for Foreman 1.7, so desupport it here as well.