### PR TITLE
Make CRL optional in use with kafo

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -127,9 +127,12 @@ class foreman::config::passenger(
         true  => "https://${servername}",
         false => undef,
       }
-      $ssl_crl_check = $ssl_crl ? {
-        undef   => undef,
-        default => 'chain',
+      if $ssl_crl and $ssl_crl != '' {
+        $ssl_crl_real = $ssl_crl
+        $ssl_crl_check = 'chain'
+      } else {
+        $ssl_crl_real = undef
+        $ssl_crl_check = undef
       }
 
       file { "${apache::confd_dir}/05-foreman-ssl.d":
@@ -160,7 +163,7 @@ class foreman::config::passenger(
         ssl_key                 => $ssl_key,
         ssl_chain               => $ssl_chain,
         ssl_ca                  => $ssl_ca,
-        ssl_crl                 => $ssl_crl,
+        ssl_crl                 => $ssl_crl_real,
         ssl_crl_check           => $ssl_crl_check,
         ssl_verify_client       => 'optional',
         ssl_options             => '+StdEnvVars',

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -132,6 +132,28 @@ describe 'foreman::config::passenger' do
         should contain_apache__vhost('foreman-ssl').without_ssl_crl_chain
       end
     end
+
+    describe 'with vhost and ssl, no CRL explicitly' do
+      let :params do {
+        :app_root      => '/usr/share/foreman',
+        :use_vhost     => true,
+        :servername    => facts[:fqdn],
+        :ssl           => true,
+        :ssl_cert      => 'cert.pem',
+        :ssl_key       => 'key.pem',
+        :ssl_ca        => 'ca.pem',
+        :ssl_crl       => '',
+        :prestart      => true,
+        :min_instances => '1',
+        :start_timeout => '600',
+        :ruby          => '/usr/bin/ruby193-ruby'
+      } end
+
+      it do
+        should contain_apache__vhost('foreman-ssl').without_ssl_crl
+        should contain_apache__vhost('foreman-ssl').without_ssl_crl_chain
+      end
+    end
   end
 
   context 'on debian' do


### PR DESCRIPTION
When this class is used from kafo we don't have a way to disable CRL
configuration, since the parameter is String. It can't be set to false
and it's always present.