### PR TITLE
Change apipie rake task to rebuild API doc indexes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ previous stable release.
 
 ### Foreman 1.7 compatibility notes
 
+* set `apipie_task => 'apipie:cache'` as Foreman 1.7 packages didn't have
+  precompiled API docs
 * `foreman::compute::ec2` needs `package => 'foreman-compute'` on Foreman 1.7,
   as the package has been renamed in newer versions.
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -1,7 +1,8 @@
 # Set up the foreman database
 class foreman::database {
   if $::foreman::db_manage {
-    validate_string($::foreman::admin_username, $::foreman::admin_password)
+    validate_string($::foreman::admin_username, $::foreman::admin_password, $::foreman::apipie_task)
+    validate_re($::foreman::apipie_task, '^apipie:')
 
     $db_class = "foreman::database::${::foreman::db_type}"
     $seed_env = {
@@ -35,7 +36,7 @@ class foreman::database {
     foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
     } ~>
-    foreman::rake { 'apipie:cache':
+    foreman::rake { $::foreman::apipie_task:
       timeout => 0,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,9 @@
 # $db_pool::                  Database 'production' size of connection pool
 #                             type:integer
 #
+# $apipie_task::              Rake task to generate API documentation.
+#                             Use 'apipie:cache' on 1.7 or older, 'apipie:cache:index' on 1.8 or newer.
+#
 # $app_root::                 Name of foreman root directory
 #
 # $manage_user::              Controls whether foreman module will manage the user on the system. (default true)
@@ -193,6 +196,7 @@ class foreman (
   $db_password              = $foreman::params::db_password,
   $db_sslmode               = 'UNSET',
   $db_pool                  = $foreman::params::db_pool,
+  $apipie_task              = $foreman::params::apipie_task,
   $app_root                 = $foreman::params::app_root,
   $manage_user              = $foreman::params::manage_user,
   $user                     = $foreman::params::user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,9 @@ class foreman::params {
   # Default database connection pool
   $db_pool = 5
 
+  # Apipie doc generation method (1.8+ should use index only)
+  $apipie_task = 'apipie:cache:index'
+
   # OS specific paths
   case $::osfamily {
     'RedHat': {

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -22,7 +22,7 @@ describe 'foreman::install' do
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }
-        it { should contain_foreman__rake('apipie:cache') }
+        it { should contain_foreman__rake('apipie:cache:index') }
       end
 
       describe 'with seed parameters' do
@@ -40,6 +40,15 @@ describe 'foreman::install' do
             'SEED_ADMIN_PASSWORD' => 'secret',
           })
         }
+      end
+
+      describe 'with apipie_task' do
+        let :pre_condition do
+          "class {'foreman':
+             apipie_task => 'apipie:cache',
+           }"
+        end
+        it { should contain_foreman__rake('apipie:cache') }
       end
     end
   end


### PR DESCRIPTION
[Ticket #4478](http://projects.theforeman.org/issues/4478) in Foreman 1.8 changed our packages to provide prebuilt API docs
for resources, so Foreman packages provide hosts, domains etc, and plugin
packages provide things like containers, disks etc.

Packages and the installer then need to call apipie:cache:index to rebuild just
the indexes instead of needing to rebuild every resource file, resulting in a
large speed boost (especially as API docs are now multilingual).

The apipie_task parameter retains 1.7 compatibility, as all API docs need
building on this version.

---

Marked as do not merge as the Debian packaging PR is open: https://github.com/theforeman/foreman-packaging/pull/568.  I hope to have done shortly so we don't have this 1-2 minute rake task in our default 1.8 installation.