### PR TITLE
Remove ordering constraints around theforeman/puppet

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -47,7 +47,6 @@ class foreman::puppetmaster (
       group   => 'root',
       source  => "puppet:///modules/${module_name}/foreman-report_${report_api}.rb",
       require => Exec['Create Puppet Reports dir'],
-      notify  => Class['::puppet::server::service'],
     }
   }
 
@@ -64,14 +63,12 @@ class foreman::puppetmaster (
       owner                   => $puppet_user,
       group                   => $puppet_group,
       selinux_ignore_defaults => true,
-      require                 => Class['::puppet::server::install'],
     }
 
     file { "${puppet_home}/yaml/foreman":
-      ensure  => directory,
-      owner   => $puppet_user,
-      group   => $puppet_group,
-      require => Class['::puppet::server::install'],
+      ensure => directory,
+      owner  => $puppet_user,
+      group  => $puppet_group,
     }
   }
 }


### PR DESCRIPTION
Depends on https://github.com/theforeman/puppet-puppet/issues/248

foreman::puppetmaster should be usable without our 'puppet' module.  Instead
for theforeman/puppet users, puppet::server::config is being updated to
correctly anchor the foreman::puppetmaster class.

Closes GH-129

---

I tested the two together just now, changed /etc/puppet/node.rb, re-ran the installer and it correctly refreshed the puppet master service, so the notification part of anchoring is working correctly.