### PR TITLE
adjust puppetlabs-postgresql version constraint

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     { "name": "adrien/alternatives",      "version_requirement": ">= 0.3.0 < 1.0.0" },
     { "name": "puppetlabs/apache",        "version_requirement": ">= 1.2.0 < 2.0.0" },
     { "name": "puppetlabs/apt",           "version_requirement": "< 2.0.0" },
-    { "name": "puppetlabs/postgresql",    "version_requirement": ">= 3.0.0 < 4.0.0" },
+    { "name": "puppetlabs/postgresql",    "version_requirement": ">= 3.0.0 < 5.0.0" },
     { "name": "puppetlabs/stdlib",        "version_requirement": ">= 4.2.0 < 5.0.0" }
   ],
   "requirements": [


### PR DESCRIPTION
I tested the installer with puppetlabs-postgresql 4.1.0 on CentOS 7, Debian/wheezy and Ubuntu/trusty. Also, the changelog of 4.0.0 doesn't seem to list anything incompatible for this module.