### PR TITLE
Remove email separator from lookup_identiy.conf.erb

### DIFF
--- a/templates/lookup_identity.conf.erb
+++ b/templates/lookup_identity.conf.erb
@@ -1,6 +1,6 @@
 
 <LocationMatch ^/users/(ext)?login$>
-  LookupUserAttr email REMOTE_USER_EMAIL " "
+  LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME
   LookupUserGroupsIter REMOTE_USER_GROUP


### PR DESCRIPTION
The space-separated string of email addresses generated by
*mod_lookup_identity* fails validation by Foreman during on-the-fly
registration causing this error:

> **Warning!**
>
> Validation failed: Email address is invalid, Email address is too long
> (maximum is 60 characters)

This occurs even when the resultant string is less than 60 characters.

This commit removes the concatenation separator to prevent the
concatenation behavior.  Instead, *mod_lookup_identity* will return just
the first address for the user.  Foreman will prompt the user for
confirmation so they are still free to input another address.