### PR TITLE
Fix foreman_config_entry checking of dry

### DIFF
--- a/lib/puppet/provider/foreman_config_entry/cli.rb
+++ b/lib/puppet/provider/foreman_config_entry/cli.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:foreman_config_entry).provide(:cli) do
   end
 
   def value=(value)
-    return if dry
+    return if resource[:dry]
     run_foreman_config("-k '#{name}' -v '#{value}'", :combine => true, :failonfail => true)
     @property_hash[:value] = value
   end


### PR DESCRIPTION
The 'dry' method just returns :absent so always appears to be trueish, when it
should have been checking the dry parameter on the user's resource.