### PR TITLE
Do not include mysql class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,9 +5,7 @@ fixtures:
     apt:              'git://github.com/puppetlabs/puppetlabs-apt'
     concat:           'git://github.com/puppetlabs/puppetlabs-concat'
     concat_native:    'git://github.com/theforeman/puppet-concat'
-    mysql:
-      repo:           'git://github.com/puppetlabs/puppetlabs-mysql'
-      ref:            '52fb70ebdeb74f66bedc54196c0884c2b84699f3'
+    mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -5,7 +5,7 @@ class foreman::database::mysql {
     default => $foreman::db_database,
   }
 
-  include ::mysql, ::mysql::server, ::mysql::server::account_security
+  include ::mysql::server, ::mysql::server::account_security
   ::mysql::db { $dbname:
     user     => $foreman::db_username,
     password => $foreman::db_password,

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -183,6 +183,18 @@ describe 'foreman::config' do
 
       it { should contain_apache__vhost('foreman').with_custom_fragment(/Alias \/apps\/foreman/) }
     end
+
+    describe 'with mysql db_type' do
+      let :pre_condition do
+        "class { 'foreman':
+          db_type => 'mysql',
+        }"
+      end
+
+      it 'should configure the mysql database' do
+        should contain_file('/etc/foreman/database.yml').with_content(/adapter: mysql2/)
+      end
+    end
   end
 
   context 'on debian' do

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -50,6 +50,24 @@ describe 'foreman::install' do
         end
         it { should contain_foreman__rake('apipie:cache') }
       end
+
+      describe 'with mysql db_type' do
+        let :pre_condition do
+          "class { 'foreman':
+            db_type => 'mysql'
+          }"
+        end
+
+        it { should_not contain_class('foreman::database::postgresql') }
+        it { should contain_class('foreman::database::mysql') }
+        it { should contain_class('mysql::server') }
+        it { should contain_class('mysql::server::account_security') }
+        it {
+          should contain_mysql__db('foreman').with({
+            :user => 'foreman',
+          })
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Fix support for mysql by removing inclusion of mysql class which was removed by puppetlabs/mysql in version 3.0.0

Resolves issue #308 