### PR TITLE
fixes #9928 - set HOME for foreman-config on all Puppet versions

### DIFF
--- a/lib/puppet/provider/foreman_config_entry/cli.rb
+++ b/lib/puppet/provider/foreman_config_entry/cli.rb
@@ -19,10 +19,11 @@ Puppet::Type.type(:foreman_config_entry).provide(:cli) do
         end
       else
         output = Puppet::Util::Execution.execute(command,
-          { :failonfail      => false,
-            :combine         => false,
-            :uid             => 'foreman',
-            :gid             => 'foreman' }.merge(options)
+          { :failonfail         => false,
+            :combine            => false,
+            :custom_environment => { 'HOME' => '/usr/share/foreman' },
+            :uid                => 'foreman',
+            :gid                => 'foreman' }.merge(options)
         )
         status = $?
       end


### PR DESCRIPTION
http://projects.theforeman.org/issues/9928

I haven't figured out why our nightly tests don't hit it, but our 1.8 tests did and I can reproduce it on both a nightly and 1.8 installation on 14.04.  You should see a `foreman-installer -v` tries to re-migrate/seed, or `puppet resource foreman_config_entry --modulepath /usr/share/foreman-installer/modules` simply fails with an error about collect.

The HOME var, like on the < 3.4 code path needed setting for rb-readline as foreman-config loads it and fails quietly otherwise.