### PR TITLE
fix configure_openscap_repo variable value

### DIFF
--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -9,7 +9,7 @@
 #
 class foreman::plugin::openscap (
   $configure_openscap_repo = $foreman::plugin::openscap::params::configure_openscap_repo,
-) {
+) inherits foreman::plugin::openscap::params {
   validate_bool($configure_openscap_repo)
 
   if $configure_openscap_repo {


### PR DESCRIPTION
Because the main class doesn't inherit the params class, the variable configure_openscap_repo is not set correctly.