### PR TITLE
use foreman-rake instead of foreman-config (also in 3.0)

### DIFF
--- a/lib/puppet/provider/foreman_config_entry/cli.rb
+++ b/lib/puppet/provider/foreman_config_entry/cli.rb
@@ -2,13 +2,13 @@ Puppet::Type.type(:foreman_config_entry).provide(:cli) do
 
   desc "foreman_config_entry's CLI provider"
 
-  confine :exists => '/usr/share/foreman/script/foreman-config'
+  confine :exists => '/usr/sbin/foreman-rake'
 
   mk_resource_methods
 
   def self.run_foreman_config(args = "", options = {})
     Dir.chdir('/usr/share/foreman') do
-      command = "/usr/share/foreman/script/foreman-config #{args}"
+      command = "/usr/sbin/foreman-rake -- config #{args}"
       if Puppet::PUPPETVERSION.to_f < 3.4
         old_home = ENV['HOME']
         begin


### PR DESCRIPTION
(cherry picked from commit da98ce43634af1e4440c726804ba3b5357e97099)

I'd like to have this also in 3.0 and a 3.0.2 tagged and released, so 1.8 packages for Debian/jessie are possible.