### PR TITLE
Use puppetlabs-concat instead of theforeman-concat_native

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,6 @@ fixtures:
     concat:
       repo:           'git://github.com/puppetlabs/puppetlabs-concat'
       branch:         '1.2.x'
-    concat_native:    'git://github.com/theforeman/puppet-concat'
     file_concat:      'git://github.com/electrical/puppet-lib-file_concat'
     mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,19 +1,15 @@
 # Configure foreman
 class foreman::config {
-  concat_build {'foreman_settings':
-    order => ['*.yaml'],
-  }
-
-  concat_fragment {'foreman_settings+01-header.yaml':
+  concat::fragment {'foreman_settings+01-header.yaml':
+    target  => '/etc/foreman/settings.yaml',
     content => template('foreman/settings.yaml.erb'),
+    order   => '01',
   }
 
-  file {'/etc/foreman/settings.yaml':
-    source  => concat_output('foreman_settings'),
-    require => Concat_build['foreman_settings'],
-    owner   => 'root',
-    group   => $foreman::group,
-    mode    => '0640',
+  concat {'/etc/foreman/settings.yaml':
+    owner => 'root',
+    group => $foreman::group,
+    mode  => '0640',
   }
 
   file { '/etc/foreman/database.yml':
@@ -135,8 +131,10 @@ class foreman::config {
         }
       }
 
-      concat_fragment {'foreman_settings+02-authorize_login_delegation.yaml':
+      concat::fragment {'foreman_settings+02-authorize_login_delegation.yaml':
+        target  => '/etc/foreman/settings.yaml',
         content => template('foreman/settings-external-auth.yaml.erb'),
+        order   => '02',
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
   ],
   "dependencies": [
     {
-      "name": "theforeman/concat_native",
-      "version_requirement": ">= 1.3.0 < 2.0.0"
-    },
-    {
       "name": "theforeman/tftp",
       "version_requirement": ">= 1.4.0 < 2.0.0"
     },
@@ -31,6 +27,10 @@
     {
       "name": "puppetlabs/apt",
       "version_requirement": "< 2.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/postgresql",

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -24,9 +24,7 @@ describe 'foreman::config' do
       end
 
       it 'should set up the config' do
-        should contain_concat_build('foreman_settings').with_order(['*.yaml'])
-
-        should contain_concat_fragment('foreman_settings+01-header.yaml').
+        should contain_concat__fragment('foreman_settings+01-header.yaml').
           with_content(/^:unattended:\s*true$/).
           with_content(/^:login:\s*true$/).
           with_content(/^:require_ssl:\s*true$/).
@@ -39,9 +37,7 @@ describe 'foreman::config' do
           with_content(/^:websockets_encrypt:\s*on$/).
           with({})
 
-        should contain_file('/etc/foreman/settings.yaml').with({
-          'source'  => %r{/concat_native/output/foreman_settings.out$},
-          'require' => 'Concat_build[foreman_settings]',
+        should contain_concat('/etc/foreman/settings.yaml').with({
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',
@@ -131,7 +127,7 @@ describe 'foreman::config' do
       end
 
       it 'should have changed parameters' do
-        should contain_concat_fragment('foreman_settings+01-header.yaml').
+        should contain_concat__fragment('foreman_settings+01-header.yaml').
           with_content(/^:unattended:\s*false$/).
           with_content(/^:login:\s*false$/).
           with_content(/^:require_ssl:\s*false$/).
@@ -213,9 +209,7 @@ describe 'foreman::config' do
       end
 
       it 'should set up settings.yaml' do
-        should contain_concat_build('foreman_settings').with_order(['*.yaml'])
-
-        should contain_concat_fragment('foreman_settings+01-header.yaml').
+        should contain_concat__fragment('foreman_settings+01-header.yaml').
           with_content(/^:unattended:\s*true$/).
           with_content(/^:login:\s*true$/).
           with_content(/^:require_ssl:\s*true$/).
@@ -227,9 +221,7 @@ describe 'foreman::config' do
           with_content(/^:oauth_consumer_secret:\s*\w+$/).
           with({})
 
-        should contain_file('/etc/foreman/settings.yaml').with({
-          'source'  => %r{/concat_native/output/foreman_settings.out$},
-          'require' => 'Concat_build[foreman_settings]',
+        should contain_concat('/etc/foreman/settings.yaml').with({
           'owner'   => 'root',
           'group'   => 'foreman',
           'mode'    => '0640',


### PR DESCRIPTION
This works with either puppetlabs-concat 1.2.x or 2.x so can be merge without waiting for dependencies to be compatible with puppetlabs-concat 2.x IMHO.