### PR TITLE
Added parameters and template for managing email settings in foreman

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,15 @@ class foreman::params {
   # Apipie doc generation method (1.8+ should use index only)
   $apipie_task = 'apipie:cache:index'
 
+  # Configure foreman email settings (email.yaml)
+  $email_conf                = 'email.yaml'
+  $email_source              = 'email.yaml.erb'
+  $email_delivery_method     = 'smtp'
+  $email_smtp_address        = 'smtp.example.com'
+  $email_smtp_port           = '25'
+  $email_smtp_domain         = 'example.com'
+  $email_smtp_authentication = 'none'
+
   # OS specific paths
   case $::osfamily {
     'RedHat': {

--- a/templates/email.yaml.erb
+++ b/templates/email.yaml.erb
@@ -1,0 +1,9 @@
+# Outgoing email settings
+
+production:
+  delivery_method: :<%= @email_delivery_method %>
+  smtp_settings:
+    address: <%= @email_smtp_address %>
+    port: <%= @email_smtp_port %>
+    domain: <%= @email_smtp_domain %>
+    authentication: :<%= @email_smtp_authentication %>


### PR DESCRIPTION
This will allow to manage email settings (through emails.yaml) through puppet parameters.