### PR TITLE
fixes #5838 - add logging_level, loggers parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,6 +168,11 @@
 # $websockets_ssl_key::       SSL key file to use when encrypting websocket connections
 # $websockets_ssl_cert::      SSL certificate file to use when encrypting websocket connections
 #
+# $logging_level::            Logging level of the Foreman application (valid values: debug, info, warn, error, fatal)
+#
+# $loggers::                  Enable or disable specific loggers, e.g. {"sql" => true}
+#                             type:hash
+#
 class foreman (
   $foreman_url              = $foreman::params::foreman_url,
   $unattended               = $foreman::params::unattended,
@@ -234,6 +239,8 @@ class foreman (
   $websockets_encrypt       = $foreman::params::websockets_encrypt,
   $websockets_ssl_key       = $foreman::params::websockets_ssl_key,
   $websockets_ssl_cert      = $foreman::params::websockets_ssl_cert,
+  $logging_level            = $foreman::params::logging_level,
+  $loggers                  = $foreman::params::loggers,
 ) inherits foreman::params {
   if $db_adapter == 'UNSET' {
     $db_adapter_real = $foreman::db_type ? {
@@ -248,6 +255,8 @@ class foreman (
     fail("${::hostname}: External authentication via IPA can only be enabled when passenger is used.")
   }
   validate_bool($websockets_encrypt)
+  validate_re($logging_level, '^(debug|info|warn|error|fatal)$')
+  validate_hash($loggers)
 
   class { '::foreman::install': } ~>
   class { '::foreman::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -233,4 +233,8 @@ class foreman::params {
   $websockets_encrypt = true
   $websockets_ssl_key = $server_ssl_key
   $websockets_ssl_cert = $server_ssl_cert
+
+  # Application logging
+  $logging_level = 'info'
+  $loggers = {}
 }

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -35,6 +35,7 @@ describe 'foreman::config' do
           with_content(/^:oauth_consumer_key:\s*\w+$/).
           with_content(/^:oauth_consumer_secret:\s*\w+$/).
           with_content(/^:websockets_encrypt:\s*on$/).
+          with_content(/^:logging:\n\s*:level:\s*info$/).
           with({})
 
         should contain_concat('/etc/foreman/settings.yaml').with({
@@ -192,6 +193,19 @@ describe 'foreman::config' do
         should contain_file('/etc/foreman/database.yml').with_content(/adapter: mysql2/)
       end
     end
+
+    describe 'with loggers' do
+      let :pre_condition do
+        "class { 'foreman':
+          loggers => {'ldap' => true},
+        }"
+      end
+
+      it 'should set loggers config' do
+        should contain_concat__fragment('foreman_settings+01-header.yaml').
+          with_content(/^:loggers:\n\s+:ldap:\n\s+:enabled:\s*true$/)
+      end
+    end
   end
 
   context 'on debian' do
@@ -219,6 +233,8 @@ describe 'foreman::config' do
           with_content(/^:oauth_map_users:\s*false$/).
           with_content(/^:oauth_consumer_key:\s*\w+$/).
           with_content(/^:oauth_consumer_secret:\s*\w+$/).
+          with_content(/^:websockets_encrypt:\s*on$/).
+          with_content(/^:logging:\n\s*:level:\s*info$/).
           with({})
 
         should contain_concat('/etc/foreman/settings.yaml').with({

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -23,3 +23,15 @@
 :websockets_encrypt: <%= scope.lookupvar("foreman::websockets_encrypt") ? 'on' : 'off' %>
 :websockets_ssl_key: <%= scope.lookupvar("foreman::websockets_ssl_key") %>
 :websockets_ssl_cert: <%= scope.lookupvar("foreman::websockets_ssl_cert") %>
+
+# Log settings for the current environment can be adjusted by adding them
+# here. For example, if you want to increase the log level.
+:logging:
+  :level: <%= scope.lookupvar("foreman::logging_level") %>
+
+# Individual logging types can be toggled on/off here
+:loggers:
+<% scope.lookupvar("foreman::loggers").each do |logger,enabled| -%>
+  :<%= logger %>:
+    :enabled: <%= enabled %>
+<% end -%>

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -3,11 +3,7 @@
 ---
 <%= @header %>
 
-#your default puppet server - can be overridden in the host level
-#if none specified, plain "puppet" will be used.
-#:puppet_server: puppet
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
-:puppetconfdir: /etc/puppet/puppet.conf
 :login: <%= scope.lookupvar("foreman::authentication") %>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
 :locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>


### PR DESCRIPTION
1. I took a shortcut with the `loggers` parameter in making it a one-level deep hash so you can only specify whether it's enabled or not, no other fancy options (overriding what's in logging.yaml).  This makes it usable from kafo (e.g. `foreman-installer --foreman-logging-level=debug --foreman-loggers=ldap:true`)
2. I didn't think templating logging.yaml was necessary, the main switches are in settings.yaml (see http://projects.theforeman.org/projects/foreman/wiki/Troubleshooting#How-do-I-enable-debugging).
3. The behaviour of `loggers` depends on ~~https://github.com/theforeman/foreman/pull/2437~~ which makes Foreman merge settings into sane defaults rather than us having to list all loggers here.  Best to wait for that PR before merging this.