### PR TITLE
The --foreman-configure-ipa-repo option is no longer required

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -153,8 +153,8 @@
 #
 # $pam_service::               	PAM service used for host-based access control in IPA
 #
-# $configure_ipa_repo::        	Enable custom yum repo with packages needed for external authentication via IPA,
-#                              	this may be needed on RHEL 6.5 and older.
+# $configure_ipa_repo::        	DEPRECATED: Enable custom yum repo with packages needed for external authentication via IPA,
+#                              	this was needed on RHEL 6.5 and older, no longer required
 #                              	type:boolean
 #
 # $ipa_manage_sssd::           	If ipa_authentication is true, should the installer manage SSSD? You can disable it

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,7 @@ class foreman::install {
         ensure  => installed,
         require => $repo,
       }
+      notice ('Using configure_ipa_repo is deprecated and no longer required.')
     }
   }
 

--- a/manifests/install/repos/extra.pp
+++ b/manifests/install/repos/extra.pp
@@ -36,6 +36,7 @@ class foreman::install::repos::extra(
       baseurl  => "http://copr-be.cloud.fedoraproject.org/results/adelton/identity_demo/epel-${osreleasemajor}-\$basearch/",
       before   => Package['mod_authnz_pam', 'mod_lookup_identity', 'mod_intercept_form_submit', 'sssd-dbus'],
     }
+    notice ('Using configure_ipa_repo is deprecated and no longer needed. If you have already used it, disable and delete the repo.')
   }
 
   if $configure_brightbox_repo {


### PR DESCRIPTION
The --foreman-configure-ipa-repo option is no longer required since the packages are included in RHEL/CentOS versions 6 and 7 now.

This feature was needed in older RHEL/CentOS versions, in which some packages weren't available. Now there is no need for it. We wanted to remove it from the documentation first and then from the code, after the comment from theforeman.org and discussion with @ares we decided to change it to deprecated and notify the user if he wants to use it.