### PR TITLE
Set explicit permissions

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -63,6 +63,7 @@ class foreman::puppetmaster (
       ensure                  => directory,
       owner                   => $puppet_user,
       group                   => $puppet_group,
+      mode                    => '0750',
       selinux_ignore_defaults => true,
     }
 


### PR DESCRIPTION
This matches the puppet default and it reduces differences if you set a
global default in site.pp.