### PR TITLE
Update install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,7 @@ class foreman::install {
     }
   }
 
-  if $::foreman::passenger_ruby_package {
+  if $::foreman::passenger and $::foreman::passenger_ruby_package {
     package { $::foreman::passenger_ruby_package:
       ensure  => installed,
       require => Class['apache'],


### PR DESCRIPTION
If passenger is set to `false`, we shouldn't install the `passenger ruby packages`.