### PR TITLE
refs #4841 - change EL OSes to use 'tfm' SCL prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ Thus 'master' will support the upcoming major version and the current stable.
 The latest release (git tag, Puppet Forge) should support current and the
 previous stable release.
 
+### Foreman 1.8/1.9 compatibility notes
+
+On EL or Amazon, set:
+
+    passenger_ruby         => '/usr/bin/ruby193-ruby`,
+    passenger_ruby_package => 'ruby193-rubygem-passenger-native',
+    plugin_prefix          => 'ruby193-rubygem-foreman_',
+
+If using `foreman::plugin::ovirt_provision`, puppetdb or tasks, also set the
+`package` parameter as appropriate to:
+
+    ruby193-rubygem-foreman-tasks
+    ruby193-rubygem-ovirt_provision_plugin
+    ruby193-rubygem-puppetdb_foreman
+
 ### Foreman 1.7 compatibility notes
 
 * set `apipie_task => 'apipie:cache'` as Foreman 1.7 packages didn't have

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,9 +121,9 @@ class foreman::params {
             default => '/usr/share/ruby/vendor_ruby/puppet',
           }
           # add passenger::install::scl as EL uses SCL on Foreman 1.2+
-          $passenger_ruby = '/usr/bin/ruby193-ruby'
-          $passenger_ruby_package = 'ruby193-rubygem-passenger-native'
-          $plugin_prefix = 'ruby193-rubygem-foreman_'
+          $passenger_ruby = '/usr/bin/tfm-ruby'
+          $passenger_ruby_package = 'tfm-rubygem-passenger-native'
+          $plugin_prefix = 'tfm-rubygem-foreman_'
           $passenger_prestart = true
           $passenger_min_instances = 1
           $passenger_start_timeout = 600
@@ -176,9 +176,9 @@ class foreman::params {
           $puppet_home = '/var/lib/puppet'
           $yumcode = 'el6'
           # add passenger::install::scl as EL uses SCL on Foreman 1.2+
-          $passenger_ruby = '/usr/bin/ruby193-ruby'
-          $passenger_ruby_package = 'ruby193-rubygem-passenger-native'
-          $plugin_prefix = 'ruby193-rubygem-foreman_'
+          $passenger_ruby = '/usr/bin/tfm-ruby'
+          $passenger_ruby_package = 'tfm-rubygem-passenger-native'
+          $plugin_prefix = 'tfm-rubygem-foreman_'
           $init_config = '/etc/sysconfig/foreman'
           $init_config_tmpl = 'foreman.sysconfig'
           $passenger_prestart = true

--- a/manifests/plugin/ovirt_provision.pp
+++ b/manifests/plugin/ovirt_provision.pp
@@ -1,34 +1,14 @@
-# Installs ovirt_provision plugin
-class foreman::plugin::ovirt_provision {
-  case $::osfamily {
-    'RedHat': {
-      case $::operatingsystem {
-        'fedora': {
-          $package = 'rubygem-ovirt_provision_plugin'
-        }
-        default: {
-          $package = 'ruby193-rubygem-ovirt_provision_plugin'
-        }
-      }
-    }
-    'Debian': {
-      $package = 'ruby-ovirt-provision-plugin'
-    }
-    'Linux': {
-      case $::operatingsystem {
-        'Amazon': {
-          $package = 'ruby193-ovirt_provision_plugin'
-        }
-        default: {
-          fail("${::hostname}: ovirt_provision_plugin does not support operatingsystem ${::operatingsystem}")
-        }
-      }
-    }
-    default: {
-      fail("${::hostname}: ovirt_provision_plugin does not support osfamily ${::osfamily}")
-    }
-  }
-
+# = oVirt Provisioning Plugin
+#
+# Installs the ovirt_provision plugin
+#
+# === Parameters:
+#
+# $package:: Package name to install, use ruby193-rubygem-ovirt_provision_plugin on Foreman 1.8/1.9 on EL
+#
+class foreman::plugin::ovirt_provision (
+  $package = $foreman::plugin::ovirt_provision::params::package,
+) inherits foreman::plugin::ovirt_provision::params {
   foreman::plugin {'ovirt_provision':
     package => $package,
   }

--- a/manifests/plugin/ovirt_provision/params.pp
+++ b/manifests/plugin/ovirt_provision/params.pp
@@ -1,0 +1,31 @@
+# Data for the ovirt_provision plugin
+class foreman::plugin::ovirt_provision::params {
+  case $::osfamily {
+    'RedHat': {
+      case $::operatingsystem {
+        'fedora': {
+          $package = 'rubygem-ovirt_provision_plugin'
+        }
+        default: {
+          $package = 'tfm-rubygem-ovirt_provision_plugin'
+        }
+      }
+    }
+    'Debian': {
+      $package = 'ruby-ovirt-provision-plugin'
+    }
+    'Linux': {
+      case $::operatingsystem {
+        'Amazon': {
+          $package = 'tfm-rubygem-ovirt_provision_plugin'
+        }
+        default: {
+          fail("${::hostname}: ovirt_provision_plugin does not support operatingsystem ${::operatingsystem}")
+        }
+      }
+    }
+    default: {
+      fail("${::hostname}: ovirt_provision_plugin does not support osfamily ${::osfamily}")
+    }
+  }
+}

--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -1,34 +1,14 @@
-# Installs puppetdb_foreman plugin
-class foreman::plugin::puppetdb {
-  case $::osfamily {
-    'RedHat': {
-      case $::operatingsystem {
-        'fedora': {
-          $package = 'rubygem-puppetdb_foreman'
-        }
-        default: {
-          $package = 'ruby193-rubygem-puppetdb_foreman'
-        }
-      }
-    }
-    'Debian': {
-      $package = 'ruby-puppetdb-foreman'
-    }
-    'Linux': {
-      case $::operatingsystem {
-        'Amazon': {
-          $package = 'ruby193-rubygem-puppetdb_foreman'
-        }
-        default: {
-          fail("${::hostname}: puppetdb_foreman does not support operatingsystem ${::operatingsystem}")
-        }
-      }
-    }
-    default: {
-      fail("${::hostname}: puppetdb_foreman does not support osfamily ${::osfamily}")
-    }
-  }
-
+# = PuppetDB Foreman plugin
+#
+# Installs the puppetdb_foreman plugin
+#
+# === Parameters:
+#
+# $package:: Package name to install, use ruby193-rubygem-puppetdb_foreman on Foreman 1.8/1.9 on EL
+#
+class foreman::plugin::puppetdb(
+  $package = $foreman::plugin::puppetdb::params::package,
+) inherits foreman::plugin::puppetdb::params {
   foreman::plugin {'puppetdb':
     package => $package,
   }

--- a/manifests/plugin/puppetdb/params.pp
+++ b/manifests/plugin/puppetdb/params.pp
@@ -1,0 +1,31 @@
+# Data for the puppetdb_foreman plugin
+class foreman::plugin::puppetdb::params {
+  case $::osfamily {
+    'RedHat': {
+      case $::operatingsystem {
+        'fedora': {
+          $package = 'rubygem-puppetdb_foreman'
+        }
+        default: {
+          $package = 'tfm-rubygem-puppetdb_foreman'
+        }
+      }
+    }
+    'Debian': {
+      $package = 'ruby-puppetdb-foreman'
+    }
+    'Linux': {
+      case $::operatingsystem {
+        'Amazon': {
+          $package = 'tfm-rubygem-puppetdb_foreman'
+        }
+        default: {
+          fail("${::hostname}: puppetdb_foreman does not support operatingsystem ${::operatingsystem}")
+        }
+      }
+    }
+    default: {
+      fail("${::hostname}: puppetdb_foreman does not support osfamily ${::osfamily}")
+    }
+  }
+}

--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -1,26 +1,17 @@
-# Installs foreman-tasks plugin
-class foreman::plugin::tasks {
-  case $::osfamily {
-    'RedHat': {
-      $service = 'foreman-tasks'
-      case $::operatingsystem {
-        'fedora': {
-          $package = 'rubygem-foreman-tasks'
-        }
-        default: {
-          $package = 'ruby193-rubygem-foreman-tasks'
-        }
-      }
-    }
-    'Debian': {
-      $package = 'ruby-foreman-tasks'
-      $service = 'ruby-foreman-tasks'
-    }
-    default: {
-      fail("${::hostname}: foreman-tasks does not support osfamily ${::osfamily}")
-    }
-  }
-
+# = Foreman Tasks
+#
+# Installs the foreman-tasks plugin
+#
+# === Parameters:
+#
+# $package:: Package name to install, use ruby193-rubygem-foreman-tasks on Foreman 1.8/1.9 on EL
+#
+# $service:: Service name
+#
+class foreman::plugin::tasks(
+  $package = $foreman::plugin::tasks::params::package,
+  $service = $foreman::plugin::tasks::params::service,
+) inherits foreman::plugin::tasks::params {
   foreman::plugin { 'tasks':
     package => $package,
   } ~>

--- a/manifests/plugin/tasks/params.pp
+++ b/manifests/plugin/tasks/params.pp
@@ -1,0 +1,23 @@
+# Data for the foreman-tasks plugin
+class foreman::plugin::tasks::params {
+  case $::osfamily {
+    'RedHat': {
+      $service = 'foreman-tasks'
+      case $::operatingsystem {
+        'fedora': {
+          $package = 'rubygem-foreman-tasks'
+        }
+        default: {
+          $package = 'tfm-rubygem-foreman-tasks'
+        }
+      }
+    }
+    'Debian': {
+      $package = 'ruby-foreman-tasks'
+      $service = 'ruby-foreman-tasks'
+    }
+    default: {
+      fail("${::hostname}: foreman-tasks does not support osfamily ${::osfamily}")
+    }
+  }
+}

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -46,7 +46,7 @@ describe 'foreman::config::passenger' do
         :prestart      => true,
         :min_instances => '1',
         :start_timeout => '600',
-        :ruby          => '/usr/bin/ruby193-ruby'
+        :ruby          => '/usr/bin/tfm-ruby'
       } end
 
       it 'should contain the docroot' do
@@ -78,7 +78,7 @@ describe 'foreman::config::passenger' do
           :passenger_min_instances => '1',
           :passenger_pre_start     => "http://#{facts[:fqdn]}",
           :passenger_start_timeout => '600',
-          :passenger_ruby          => "/usr/bin/ruby193-ruby",
+          :passenger_ruby          => "/usr/bin/tfm-ruby",
           :custom_fragment         => %r{^<Directory #{params[:app_root]}/public>$},
         })
       end
@@ -96,7 +96,7 @@ describe 'foreman::config::passenger' do
           :passenger_min_instances => '1',
           :passenger_pre_start     => "https://#{facts[:fqdn]}",
           :passenger_start_timeout => '600',
-          :passenger_ruby          => "/usr/bin/ruby193-ruby",
+          :passenger_ruby          => "/usr/bin/tfm-ruby",
           :ssl                     => true,
           :ssl_cert                => params[:ssl_cert],
           :ssl_key                 => params[:ssl_key],
@@ -124,7 +124,7 @@ describe 'foreman::config::passenger' do
         :prestart      => true,
         :min_instances => '1',
         :start_timeout => '600',
-        :ruby          => '/usr/bin/ruby193-ruby'
+        :ruby          => '/usr/bin/tfm-ruby'
       } end
 
       it do
@@ -146,7 +146,7 @@ describe 'foreman::config::passenger' do
         :prestart      => true,
         :min_instances => '1',
         :start_timeout => '600',
-        :ruby          => '/usr/bin/ruby193-ruby'
+        :ruby          => '/usr/bin/tfm-ruby'
       } end
 
       it do

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -83,7 +83,7 @@ describe 'foreman::config' do
       it 'should contain foreman::config::passenger' do
         should contain_class('foreman::config::passenger').
           with_listen_on_interface(nil).
-          with_ruby('/usr/bin/ruby193-ruby').
+          with_ruby('/usr/bin/tfm-ruby').
           that_comes_before('Anchor[foreman::config_end]')
       end
 

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -32,7 +32,7 @@ describe 'foreman::install' do
       it { should contain_package('foreman-postgresql').with_ensure('present') }
       it { should contain_package('foreman-postgresql').that_requires('Foreman::Install::Repos[foreman]') }
       it { should contain_package('foreman-postgresql').that_requires('Class[foreman::install::repos::extra]') }
-      it { should contain_package('ruby193-rubygem-passenger-native') }
+      it { should contain_package('tfm-rubygem-passenger-native') }
     end
 
     describe 'with version' do

--- a/spec/classes/foreman_plugin_ovirt_provision_spec.rb
+++ b/spec/classes/foreman_plugin_ovirt_provision_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'foreman::plugin::puppetdb' do
+describe 'foreman::plugin::ovirt_provision' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
@@ -9,15 +9,15 @@ describe 'foreman::plugin::puppetdb' do
 
       if facts[:operatingsystem] == 'Fedora'
         it 'should call the plugin' do
-          should contain_foreman__plugin('puppetdb').with_package('rubygem-puppetdb_foreman')
+          should contain_foreman__plugin('ovirt_provision').with_package('rubygem-ovirt_provision_plugin')
         end
       elsif facts[:osfamily] == 'RedHat'
         it 'should call the plugin' do
-          should contain_foreman__plugin('puppetdb').with_package('tfm-rubygem-puppetdb_foreman')
+          should contain_foreman__plugin('ovirt_provision').with_package('tfm-rubygem-ovirt_provision_plugin')
         end
       elsif facts[:osfamily] == 'Debian'
         it 'should call the plugin' do
-          should contain_foreman__plugin('puppetdb').with_package('ruby-puppetdb-foreman')
+          should contain_foreman__plugin('ovirt_provision').with_package('ruby-ovirt-provision-plugin')
         end
       end
     end

--- a/spec/classes/foreman_plugin_tasks_spec.rb
+++ b/spec/classes/foreman_plugin_tasks_spec.rb
@@ -24,7 +24,7 @@ describe 'foreman::plugin::tasks' do
     end
 
     it 'should call the plugin' do
-      should contain_foreman__plugin('tasks').with_package('ruby193-rubygem-foreman-tasks')
+      should contain_foreman__plugin('tasks').with_package('tfm-rubygem-foreman-tasks')
       should contain_service('foreman-tasks').with('ensure' => 'running', 'enable' => 'true', 'name' => 'foreman-tasks')
     end
   end

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -16,7 +16,7 @@ describe 'foreman::plugin' do
     } end
 
     it 'should install the correct package' do
-      should contain_package('ruby193-rubygem-foreman_myplugin').with_ensure('installed')
+      should contain_package('tfm-rubygem-foreman_myplugin').with_ensure('installed')
     end
 
     it 'should not contain the config file' do


### PR DESCRIPTION
Parameters are supplied on the main foreman class to revert behaviour
for Foreman 1.9 and prior, plus on three plugin classes with
non-standard package names.

---

Merge after https://github.com/theforeman/foreman-packaging/pull/249