### PR TITLE
Allow newer apt module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": "< 2.0.0"
+      "version_requirement": "< 3.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
I need a newer version of apt for other module dependencies.
So far this does not break anything in foreman, for me.