### PR TITLE
The --foreman-configure-ipa-repo option is no longer required

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,10 +155,6 @@
 #
 # $pam_service::                PAM service used for host-based access control in IPA
 #
-# $configure_ipa_repo::         DEPRECATED: Enable custom yum repo with packages needed for external authentication via IPA,
-#                               this was needed on RHEL 6.5 and older, no longer required
-#                               type:boolean
-#
 # $ipa_manage_sssd::            If ipa_authentication is true, should the installer manage SSSD? You can disable it
 #                               if you use another module for SSSD configuration
 #                               type:boolean
@@ -256,7 +252,6 @@ class foreman (
   $ipa_authentication        = $::foreman::params::ipa_authentication,
   $http_keytab               = $::foreman::params::http_keytab,
   $pam_service               = $::foreman::params::pam_service,
-  $configure_ipa_repo        = $::foreman::params::configure_ipa_repo,
   $ipa_manage_sssd           = $::foreman::params::ipa_manage_sssd,
   $websockets_encrypt        = $::foreman::params::websockets_encrypt,
   $websockets_ssl_key        = $::foreman::params::websockets_ssl_key,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,13 +39,6 @@ class foreman::install {
       ensure  => $::foreman::version,
       require => $repo,
     }
-    if $::foreman::ipa_authentication and $::foreman::configure_ipa_repo and $::foreman::osreleasemajor == '6' {
-      package { 'mod_lookup_identity-selinux':
-        ensure  => installed,
-        require => $repo,
-      }
-      notice ('Using configure_ipa_repo is deprecated and no longer required.')
-    }
   }
 
   if $::foreman::passenger and $::foreman::passenger_ruby_package {

--- a/manifests/install/repos/extra.pp
+++ b/manifests/install/repos/extra.pp
@@ -3,7 +3,6 @@ class foreman::install::repos::extra(
   $configure_epel_repo      = $::foreman::configure_epel_repo,
   $configure_scl_repo       = $::foreman::configure_scl_repo,
   $ipa_authentication       = $::foreman::ipa_authentication,
-  $configure_ipa_repo       = $::foreman::configure_ipa_repo,
   $configure_brightbox_repo = $::foreman::configure_brightbox_repo,
 ) {
   $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
@@ -27,16 +26,6 @@ class foreman::install::repos::extra(
     package {'foreman-release-scl':
       ensure => installed,
     }
-  }
-
-  if $ipa_authentication and $configure_ipa_repo {
-    yumrepo { 'adelton-identity':
-      enabled  => 1,
-      gpgcheck => 0,
-      baseurl  => "http://copr-be.cloud.fedoraproject.org/results/adelton/identity_demo/epel-${osreleasemajor}-\$basearch/",
-      before   => Package['mod_authnz_pam', 'mod_lookup_identity', 'mod_intercept_form_submit', 'sssd-dbus'],
-    }
-    notice ('Using configure_ipa_repo is deprecated and no longer needed. If you have already used it, disable and delete the repo.')
   }
 
   if $configure_brightbox_repo {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -249,7 +249,6 @@ class foreman::params {
   $ipa_authentication = false
   $http_keytab = '/etc/httpd/conf/http.keytab'
   $pam_service = 'foreman'
-  $configure_ipa_repo = false
   $ipa_manage_sssd = true
 
   # Websockets


### PR DESCRIPTION
The --foreman-configure-ipa-repo option is no longer required since the
packages are included in RHEL/CentOS versions 6 and 7 now.

This feature was needed in older RHEL/CentOS versions, in which some
packages weren't available. Now there is no need for it.

After including a deprecation warning (pull request #333), we believe
that with new release the option can be removed completely.