### PR TITLE
Use the timeout setting in the http request

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -198,6 +198,7 @@ def upload_facts(certname, req)
   uri = URI.parse("#{url}/api/hosts/facts")
   begin
     res = initialize_http(uri)
+    res.read_timeout = SETTINGS[:timeout]
     res.start { |http| http.request(req) }
     cache("#{certname}-push-facts", "Facts from this host were last pushed to #{uri} at #{Time.now}\n")
   rescue => e


### PR DESCRIPTION
Upload facts can timeout before the specified script timeout, which causes the script to exit 1. Since we have an overall timeout, just use that as the timeout setting for the http request. 