### PR TITLE
Pin addressable to pre-2.4 for Ruby 1.8 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,11 @@ Gemfile:
   extra:
     - gem: json
     - gem: webmock
+    - gem: addressable
+      version: '< 2.4'
+      options:
+        platforms:
+        - 'ruby_18'
 Rakefile:
   param_docs_pattern:
     - manifests/cli.pp

--- a/Gemfile
+++ b/Gemfile
@@ -28,5 +28,6 @@ gem 'metadata-json-lint'
 gem 'rspec', '< 3.2.0', {"platforms"=>["ruby_18"]}
 gem 'json'
 gem 'webmock'
+gem 'addressable', '< 2.4', {"platforms"=>["ruby_18"]}
 
 # vim:ft=ruby


### PR DESCRIPTION
Scheduled to be released in 2.4.0:
https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-240

Pre-emptive PR, as I happened to notice the deprecation warning.  It only affects puppet-foreman, since it's only a dependency of webmock.