### PR TITLE
whitelist FreeBSD also in plugins

### DIFF
--- a/manifests/plugin/ovirt_provision/params.pp
+++ b/manifests/plugin/ovirt_provision/params.pp
@@ -24,6 +24,9 @@ class foreman::plugin::ovirt_provision::params {
         }
       }
     }
+    /^(FreeBSD|DragonFly)$/: {
+      # do nothing to not break foreman-installer
+    }
     default: {
       fail("${::hostname}: ovirt_provision_plugin does not support osfamily ${::osfamily}")
     }

--- a/manifests/plugin/puppetdb/params.pp
+++ b/manifests/plugin/puppetdb/params.pp
@@ -24,6 +24,9 @@ class foreman::plugin::puppetdb::params {
         }
       }
     }
+    /^(FreeBSD|DragonFly)$/: {
+      # do nothing to not break foreman-installer
+    }
     default: {
       fail("${::hostname}: puppetdb_foreman does not support osfamily ${::osfamily}")
     }

--- a/manifests/plugin/tasks/params.pp
+++ b/manifests/plugin/tasks/params.pp
@@ -16,6 +16,10 @@ class foreman::plugin::tasks::params {
       $package = 'ruby-foreman-tasks'
       $service = 'ruby-foreman-tasks'
     }
+    /^(FreeBSD|DragonFly)$/: {
+      # do nothing to not break foreman-installer
+    }
+
     default: {
       fail("${::hostname}: foreman-tasks does not support osfamily ${::osfamily}")
     }


### PR DESCRIPTION
otherwise foreman-installer won't work, even with the foreman module disabled:
`Error: fibsd: ovirt_provision_plugin does not support osfamily FreeBSD at /usr/local/share/foreman-installer/modules/foreman/manifests/plugin/ovirt_provision/params.pp:28 on node fibsd.local`