### PR TITLE
fix + refactor foreman::plugin::discovery test

### DIFF
--- a/spec/classes/foreman_plugin_discovery_spec.rb
+++ b/spec/classes/foreman_plugin_discovery_spec.rb
@@ -2,18 +2,21 @@ require 'spec_helper'
 
 describe 'foreman::plugin::discovery' do
   on_supported_os.each do |os, facts|
-    if facts[:os] == 'Fedora'
-      let(:facts) { facts }
+    let(:facts) { facts }
 
-      context 'with enabled image installation' do
+    context "on #{os}" do
+
+      it { should contain_foreman__plugin('discovery') }
+
+      describe 'without paramaters' do
+        it { should_not contain_foreman__remote_file('/var/lib/tftpboot/boot/fdi-image-latest.tar') }
+      end
+
+      describe 'with install_images => true' do
         let :params do
           {
             :install_images => true
           }
-        end
-
-        it 'should call the plugin' do
-          should contain_foreman__plugin('discovery')
         end
 
         it 'should download and install tarball' do
@@ -28,23 +31,6 @@ describe 'foreman::plugin::discovery' do
             'cwd' => '/var/lib/tftpboot/boot',
             'creates' => '/var/lib/tftpboot/boot/fdi-image/initrd0.img',
           })
-        end
-
-      end
-
-      context 'with disabled image installation' do
-        let :params do
-          {
-            :install_images => false
-          }
-        end
-
-        it 'should call the plugin' do
-          should contain_foreman__plugin('discovery')
-        end
-
-        it 'should not download and install tarball' do
-          should_not contain_foreman__remote_file('/var/lib/tftpboot/boot/fdi-image-latest.tar')
         end
       end
     end


### PR DESCRIPTION
<img width="1098" alt="screen shot 2015-11-06 at 1 46 20 am" src="https://cloud.githubusercontent.com/assets/15869/10994007/3a2899e8-8428-11e5-8016-2665b075760c.png">

The current test doesn't actually run because of `if facts[:os] == 'Fedora'`, I've included the refactored test from theforeman/puppet-foreman_proxy#203 that resolves the bug and improves the clarity.