### PR TITLE
refs #8389 - lower case Foreman hostname to match foreman_proxy

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,9 @@
 # The foreman default parameters
 class foreman::params {
+  $lower_fqdn = downcase($::fqdn)
 
 # Basic configurations
-  $foreman_url      = "https://${::fqdn}"
+  $foreman_url      = "https://${lower_fqdn}"
   $foreman_user     = undef
   $foreman_password = undef
   # Should foreman act as an external node classifier (manage puppet class
@@ -214,7 +215,6 @@ class foreman::params {
   }
   $puppet_user = 'puppet'
   $puppet_group = 'puppet'
-  $lower_fqdn = downcase($::fqdn)
 
   # If CA is specified, remote Foreman host will be verified in reports/ENC scripts
   $client_ssl_ca   = "${puppet_home}/ssl/certs/ca.pem"


### PR DESCRIPTION
Lower case FQDN used in the Foreman URL for apipie-bindings (in Hammer)
to work correctly and also to match foreman_proxy to ensure correct
ordering of foreman_smartproxy resources in init.pp's resource
collector.

---

Fixes the issue I noted in https://github.com/theforeman/puppet-foreman_proxy/pull/148#issuecomment-158368123, simply due to case sensitive comparisons in the init.pp resource collector.