### PR TITLE
added the param  puppetrun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+* New or changed parameters:
+    * Add puppetrun parameter to foreman init class. This allows you to enable the
+      "Run puppet" button(and functionality) on individual host pages.
+      Please make sure to set this param to true if you have already set it to
+      true in the UI. As the default value in the params class is "false", and it
+      will override your manual setting in the database.
+
 ## 5.1.0
 * New or changed parameters:
     * Add address and dashboard_address paramters to foreman::plugin::puppetdb

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,9 @@
 #
 # $foreman_url::                URL on which foreman is going to run
 #
+# $puppetrun::                  Should foreman be able to start puppetruns on nodes
+#                               type: boolean
+#
 # $unattended::                 Should foreman manage host provisioning as well
 #                               type:boolean
 #
@@ -192,6 +195,7 @@
 #
 class foreman (
   $foreman_url               = $::foreman::params::foreman_url,
+  $puppetrun                 = $::foreman::params::puppetrun,
   $unattended                = $::foreman::params::unattended,
   $authentication            = $::foreman::params::authentication,
   $passenger                 = $::foreman::params::passenger,
@@ -287,6 +291,7 @@ class foreman (
   if $email_delivery_method {
     validate_re($email_delivery_method, ['^sendmail$', '^smtp$'], "email_delivery_method can be either sendmail or smtp, not ${email_delivery_method}")
   }
+  validate_bool($puppetrun)
 
   class { '::foreman::install': } ~>
   class { '::foreman::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -256,4 +256,7 @@ class foreman::params {
   # Application logging
   $logging_level = 'info'
   $loggers = {}
+
+  # Starting puppet runs with foreman
+  $puppetrun = false
 }

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -25,6 +25,7 @@ describe 'foreman::config' do
             with_content(/^:require_ssl:\s*true$/).
             with_content(/^:locations_enabled:\s*false$/).
             with_content(/^:organizations_enabled:\s*false$/).
+            with_content(/^:puppetrun:\s*false$/).
             with_content(/^:oauth_active:\s*true$/).
             with_content(/^:oauth_map_users:\s*false$/).
             with_content(/^:oauth_consumer_key:\s*\w+$/).

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -8,6 +8,7 @@
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
 :locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>
 :organizations_enabled: <%= scope.lookupvar("foreman::organizations_enabled") %>
+:puppetrun: <%= scope.lookupvar("foreman::puppetrun") %>
 
 # The following values are used for providing default settings during db migrate
 :oauth_active: <%= scope.lookupvar("foreman::oauth_active") %>


### PR DESCRIPTION
Added the param "puppetrun" to the foreman settings.yaml template (and params+init manifests) to toggle the puppetrun functionality in foreman. This enables the "Run Puppet" button on individual host pages. default value is false, since that was the default before.