### PR TITLE
Configure Passenger to use foreman-ruby symlink

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,10 +135,7 @@ class foreman::params {
       $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
       $puppet_etcdir = '/etc/puppet'
       $puppet_home = '/var/lib/puppet'
-      $passenger_ruby = $::operatingsystemrelease ? {
-        '12.04' => '/usr/bin/ruby1.9.1',
-        default => undef,
-      }
+      $passenger_ruby = '/usr/bin/foreman-ruby'
       $passenger_ruby_package = $::operatingsystemrelease ? {
         '12.04' => 'passenger-common1.9.1',
         default => undef,

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -90,8 +90,8 @@ describe 'foreman::config' do
         it 'should contain foreman::config::passenger' do
           if facts[:osfamily] == 'RedHat' and facts[:operatingsystem] != 'Fedora'
             passenger_ruby = '/usr/bin/tfm-ruby'
-          elsif os == 'ubuntu-12-x86_64'
-            passenger_ruby = '/usr/bin/ruby1.9.1'
+          elsif facts[:osfamily] == 'Debian'
+            passenger_ruby = '/usr/bin/foreman-ruby'
           else
             passenger_ruby = nil
           end


### PR DESCRIPTION
Using the foreman-ruby symlink installed by our packages by default on
all Debian-based OSes will make upgrades easier, as users won't need to
reconfigure Apache if we change the Ruby version used by the packages.