### PR TITLE
Don't qualified call to defined resource type

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -16,7 +16,8 @@ class foreman::database::postgresql {
   }
 
   include ::postgresql::client, ::postgresql::server
-  ::postgresql::server::db { $dbname:
+  
+  postgresql::server::db { $dbname:
     user     => $::foreman::db_username,
     password => $password,
     owner    => $::foreman::db_username,


### PR DESCRIPTION
- resource names are not limited by scope.
- it is considered a bad practice in Puppet 3
- it isn't tolerated anymore in Puppet 4.