### PR TITLE
ensure json_package is installed via ensure_packages

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -25,9 +25,7 @@ class foreman::puppetmaster (
     default:  { $json_package = 'rubygem-json' }
   }
 
-  package { $json_package:
-    ensure  => installed,
-  }
+  ensure_packages([$json_package])
 
   file {"${puppet_etcdir}/foreman.yaml":
     content => template("${module_name}/puppet.yaml.erb"),

--- a/spec/classes/foreman_puppetmaster_spec.rb
+++ b/spec/classes/foreman_puppetmaster_spec.rb
@@ -67,7 +67,7 @@ describe 'foreman::puppetmaster' do
         end
 
         it 'should install json package' do
-          should contain_package(json_package).with_ensure('installed')
+          should contain_package(json_package).with_ensure('present')
         end
 
         it 'should create puppet.yaml' do
@@ -140,7 +140,7 @@ describe 'foreman::puppetmaster' do
       end
 
       it 'should install json package' do
-        should contain_package('rubygem-json').with_ensure('installed')
+        should contain_package('rubygem-json').with_ensure('present')
       end
     end
   end


### PR DESCRIPTION
This commit changes the installation of rubygem-json from an explicit
package definition to ensure_packages. This may prevent a duplicate
declaration of the package resource.