### PR TITLE
Pin puppetlabs/apache to 1.7.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 1.2.0 < 2.0.0"
+      "version_requirement": ">= 1.2.0 < 1.8.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
The update to puppetlabs/apache 1.8.0 included moving mod configuration
files to /etc/httpd/conf.modules.d on EL7. The mod_passenger package
currently places its configuration file in /etc/httpd/conf.d which
gets wiped out by puppet. The configuration file deployed by puppet
does not include the proper default directives to set the PassengerRoot
which results in Foreman being unaccessible. See:

https://github.com/puppetlabs/puppetlabs-apache/commit/e825422b0080e66b32cd05ed51b5ccae69325c74