### PR TITLE
pin rspec-puppet-facts for Ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,10 @@ gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2
 
 if RUBY_VERSION.start_with? '1.8'
   gem 'rspec', '>= 3', '< 3.2'
+  gem 'rspec-puppet-facts', '< 1.4.0'
 else
   gem 'rspec', '~> 3.0'
+  gem 'rspec-puppet-facts'
 end
 gem 'rake'
 gem 'rspec-puppet', '~> 2.3'
@@ -28,7 +30,6 @@ gem 'simplecov'
 gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}
 gem 'rest-client', '< 1.7', {"platforms"=>["ruby_18"], "groups"=>["development"]}
 gem 'mime-types', '~> 1.0', {"platforms"=>["ruby_18"], "groups"=>["development"]}
-gem 'rspec-puppet-facts'
 gem 'metadata-json-lint'
 gem 'json'
 gem 'webmock'


### PR DESCRIPTION
closes GH-396

will open a PR for modulesync, once this is merged here.