### PR TITLE
cherry-pick test fixes to 5.0-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ else
   gem 'rspec', '~> 3.0'
 end
 gem 'rake'
-gem 'rspec-puppet', '~> 2.0'
+gem 'rspec-puppet', '~> 2.3'
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
 gem 'puppet-lint', '>= 1'
 gem 'puppet-lint-unquoted_string-check'

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,10 @@ gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2
 
 if RUBY_VERSION.start_with? '1.8'
   gem 'rspec', '>= 3', '< 3.2'
+  gem 'rspec-puppet-facts', '< 1.4.0'
 else
   gem 'rspec', '~> 3.0'
+  gem 'rspec-puppet-facts'
 end
 gem 'rake'
 gem 'rspec-puppet', '~> 2.3'
@@ -28,7 +30,6 @@ gem 'simplecov'
 gem 'puppet-blacksmith', '>= 3.1.0', {"groups"=>["development"]}
 gem 'rest-client', '< 1.7', {"platforms"=>["ruby_18"], "groups"=>["development"]}
 gem 'mime-types', '~> 1.0', {"platforms"=>["ruby_18"], "groups"=>["development"]}
-gem 'rspec-puppet-facts'
 gem 'metadata-json-lint'
 gem 'json'
 gem 'webmock'

--- a/Rakefile
+++ b/Rakefile
@@ -4,13 +4,16 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-# blacksmith isn't always present, e.g. on Travis with --without development
-begin
-  require 'puppet_blacksmith/rake_tasks'
-  Blacksmith::RakeTask.new do |t|
-    t.tag_pattern = "%s"
+# blacksmith is broken with ruby 1.8.7
+if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')
+  # blacksmith isn't always present, e.g. on Travis with --without development
+  begin
+    require 'puppet_blacksmith/rake_tasks'
+    Blacksmith::RakeTask.new do |t|
+      t.tag_pattern = "%s"
+    end
+  rescue LoadError
   end
-rescue LoadError
 end
 
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,29 +50,6 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
     expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
 
-# See https://github.com/rodjek/rspec-puppet/issues/329
-# Without this patch the @@cache variable grows huge and causes memory usage issues
-# with a large amount of examples.
-module RSpec::Puppet
-  module Support
-    def build_catalog(*args)
-      if @@cache.has_key?(args)
-        @@cache[args]
-      else
-        @@cache = {}
-        @@cache[args] ||= self.build_catalog_without_cache(*args)
-      end
-    end
-  end
-end
-
-# See https://github.com/rodjek/rspec-puppet/pull/333
-# Prevents each generated catalog being held in memory after the example group has
-# completed.
-RSpec.configure do |c|
-  c.after(:each) { @catalogue = nil }
-end
-
 def static_fixture_path
   File.join(File.dirname(__FILE__), 'static_fixtures')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
     expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
 
-# See https://github.com/rodjek/rspec-puppet/issues/215
+# See https://github.com/rodjek/rspec-puppet/issues/329
 # Without this patch the @@cache variable grows huge and causes memory usage issues
 # with a large amount of examples.
 module RSpec::Puppet
@@ -64,6 +64,13 @@ module RSpec::Puppet
       end
     end
   end
+end
+
+# See https://github.com/rodjek/rspec-puppet/pull/333
+# Prevents each generated catalog being held in memory after the example group has
+# completed.
+RSpec.configure do |c|
+  c.after(:each) { @catalogue = nil }
 end
 
 def static_fixture_path


### PR DESCRIPTION
Unsure if we need that and it's still broken for Puppet 2.7, but I think this is better than before.