### PR TITLE
Notify foreman-tasks service on remote execution install

### DIFF
--- a/manifests/plugin/remote_execution.pp
+++ b/manifests/plugin/remote_execution.pp
@@ -4,5 +4,6 @@ class foreman::plugin::remote_execution {
   include ::foreman::plugin::tasks
 
   foreman::plugin {'remote_execution':
+    notify => Service['foreman-tasks'],
   }
 }

--- a/spec/classes/foreman_plugin_remote_execution_spec.rb
+++ b/spec/classes/foreman_plugin_remote_execution_spec.rb
@@ -8,7 +8,7 @@ describe 'foreman::plugin::remote_execution' do
     let(:facts) { facts }
 
     context "on #{os}" do
-      it { should contain_foreman__plugin('remote_execution') }
+      it { should contain_foreman__plugin('remote_execution').that_notifies('Service[foreman-tasks]') }
       it { should contain_foreman__plugin('tasks') }
     end
   end


### PR DESCRIPTION
It can happen that tasks is configured and started before the remote execution plugin is installed.