### PR TITLE
add 'puppetmaster' fact value

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -112,6 +112,13 @@ def build_body(certname,filename)
   puppet_facts = YAML::load(facts.gsub(/\!ruby\/object.*$/,''))
   hostname     = puppet_facts['values']['fqdn'] || certname
   
+  begin
+    require 'facter'
+    puppet_facts['values']['puppetmaster_fqdn'] = Facter.value(:fqdn).to_s
+  rescue LoadError => e
+    puppet_facts['values']['puppetmaster_fqdn'] = `hostname -f`.strip
+  end
+  
   # filter any non-printable char from the value, if it is a String
   puppet_facts['values'].each do |key, val|
     if val.is_a? String


### PR DESCRIPTION
This fact allow to determine which puppet master is used by agent when using use_srv_records and srv_domain puppet settings. Furthermore it allow analize proxy load by adding this fact to trend counters.