### PR TITLE
Order foreman::cli after repo setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -332,6 +332,10 @@ class foreman (
   Package <| tag == 'foreman-compute' |> ~>
   Class['foreman::service']
 
+  Class['foreman::repo'] ~>
+  Package <| tag == 'foreman::cli' |> ~>
+  Class['foreman']
+
   # lint:ignore:spaceship_operator_without_tag
   Class['foreman::database']~>
   Foreman::Plugin <| |> ~>

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -17,6 +17,16 @@ describe 'foreman' do
       it { should contain_class('foreman::config') }
       it { should contain_class('foreman::database') }
       it { should contain_class('foreman::service') }
+
+      describe 'with foreman::cli' do
+        let :pre_condition do
+          "class { 'foreman': }
+           class { 'foreman::cli': }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_package('foreman-cli').that_subscribes_to('Class[foreman::repo]') }
+      end
     end
   end
 end


### PR DESCRIPTION
1b552f0 seems to have triggered this condition in our nightly tests, where adding both foreman and foreman::cli classes causes the foreman-cli package to be installed before repos are configured.

I don't think any dependency has ever been present, and it's because foreman-cli now depends on SCL packages on EL OSes that it's especially relevant now.