### PR TITLE
Fix function spec failures under rspec-puppet 2.4.0

### DIFF
--- a/spec/functions/ensure_value_in_string_spec.rb
+++ b/spec/functions/ensure_value_in_string_spec.rb
@@ -1,67 +1,49 @@
 require 'spec_helper'
 
 describe 'ensure_value_in_string' do
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it 'should exist' do
     expect(Puppet::Parser::Functions.function('ensure_value_in_string')).to eq 'function_ensure_value_in_string'
   end
 
   it 'should throw an error with bad number of arguments' do
-    expect {
-      scope.function_ensure_value_in_string([])
-    }.to raise_error(Puppet::ParseError)
-
-    expect {
-      scope.function_ensure_value_in_string(['string'])
-    }.to raise_error(Puppet::ParseError)
-
-    expect {
-      scope.function_ensure_value_in_string(['string', [], ', ', 'additional'])
-    }.to raise_error(Puppet::ParseError)
+    is_expected.to run.with_params().and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params('string').and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params('string', [], ', ', 'additional').and_raise_error(Puppet::ParseError)
   end
 
   it 'should append values to the end' do
-    expect(scope.function_ensure_value_in_string(['one,two', ['three']])).to eq 'one,two,three'
+    is_expected.to run.with_params('one,two', ['three']).and_return('one,two,three')
   end
 
   it 'should append values to the end in same order' do
-    expect(scope.function_ensure_value_in_string(['one,two', ['three', 'four']])).to eq 'one,two,three,four'
+    is_expected.to run.with_params('one,two', ['three', 'four']).and_return('one,two,three,four')
   end
 
   it 'should not append values existing in original string' do
-    expect(scope.function_ensure_value_in_string(['one,two', ['two', 'three']])).to eq 'one,two,three'
-    expect(scope.function_ensure_value_in_string(['one,two', ['one', 'three']])).to eq 'one,two,three'
-    expect(scope.function_ensure_value_in_string(['one,two', ['one', 'two']])).to eq 'one,two'
+    is_expected.to run.with_params('one,two', ['two', 'three']).and_return('one,two,three')
+    is_expected.to run.with_params('one,two', ['one', 'three']).and_return('one,two,three')
+    is_expected.to run.with_params('one,two', ['one', 'two']).and_return('one,two')
   end
 
   it 'should append even to empty strings' do
-    expect(scope.function_ensure_value_in_string(['', ['two', 'three']])).to eq 'two,three'
+    is_expected.to run.with_params('', ['two', 'three']).and_return('two,three')
   end
 
   it 'should append even empty array' do
-    expect(scope.function_ensure_value_in_string(['one,two', []])).to eq 'one,two'
+    is_expected.to run.with_params('one,two', []).and_return('one,two')
   end
 
   it 'should not allow using wrong types and undefined values' do
-    expect {
-      scope.function_ensure_value_in_string([nil, ['two', 'three']])
-    }.to raise_error(Puppet::ParseError)
-
-    expect {
-      scope.function_ensure_value_in_string([:undef, ['two', 'three']])
-    }.to raise_error(Puppet::ParseError)
-
-    expect {
-      scope.function_ensure_value_in_string(['one', 'two'])
-    }.to raise_error(Puppet::ParseError)
+    is_expected.to run.with_params(nil, ['two', 'three']).and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params(:undef, ['two', 'three']).and_raise_error(Puppet::ParseError)
+    is_expected.to run.with_params('one', 'two').and_raise_error(Puppet::ParseError)
   end
 
   it 'should ignore whitespaces but preserve it' do
-    expect(scope.function_ensure_value_in_string(['one, two,   three    ,    four', ['five']])).to eq 'one, two,   three    ,    four,five'
+    is_expected.to run.with_params('one, two,   three    ,    four', ['five']).and_return('one, two,   three    ,    four,five')
   end
 
   it 'should accept third argument as a custom separator' do
-    expect(scope.function_ensure_value_in_string(['one,two', ['two', 'three'], ', '])).to eq 'one,two, three'
+    is_expected.to run.with_params('one,two', ['two', 'three'], ', ').and_return('one,two, three')
   end
 end

--- a/spec/functions/foreman_spec.rb
+++ b/spec/functions/foreman_spec.rb
@@ -1,18 +1,12 @@
 require 'spec_helper'
 
 describe 'foreman' do
-  let(:facts) { { 'hardwaremodel' => 'x86_64'} }
-  let(:node) { 'test.example.com' }
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it 'should exist' do
     expect(Puppet::Parser::Functions.function('foreman')).to eq 'function_foreman'
   end
 
   it 'should throw an error with no arguments' do
-    expect(lambda {
-      scope.function_foreman([])
-    }). to raise_error(Puppet::ParseError)
+    is_expected.to run.with_params().and_raise_error(Puppet::ParseError)
   end
 
   # TODO: Test functionality of the actual function.

--- a/spec/functions/smartvar_spec.rb
+++ b/spec/functions/smartvar_spec.rb
@@ -1,20 +1,12 @@
 require 'spec_helper'
-require 'uri'
-require 'net/http'
 
 describe 'smartvar' do
-  let(:facts) { { 'hardwaremodel' => 'x86_64'} }
-  let(:node) { 'test.example.com' }
-  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
-
   it 'should exist' do
     expect(Puppet::Parser::Functions.function('smartvar')).to eq 'function_smartvar'
   end
 
   it 'should throw an error with no arguments' do
-    expect(lambda {
-      scope.function_smartvar([])
-    }).to raise_error(Puppet::ParseError)
+    is_expected.to run.with_params().and_raise_error(Puppet::ParseError)
   end
 
   # TODO: Test functionality of the actual function.


### PR DESCRIPTION
Specs are rewritten to use the documented function testing helpers,
which fixes the errors seen under Puppet 4 with 2.4.0 due to changes
in initialisation.

    Puppet::DevError:
    Function ensure_value_in_string not defined despite being loaded!