### PR TITLE
Fix nil provider assignment in foreman_config_entry.

### DIFF
--- a/lib/puppet/provider/foreman_config_entry/cli.rb
+++ b/lib/puppet/provider/foreman_config_entry/cli.rb
@@ -53,10 +53,10 @@ Puppet::Type.type(:foreman_config_entry).provide(:cli) do
     resources.each do |name, resource|
       provider = entries.find { |entry| entry.name == name }
       if provider.nil? && resource[:ignore_missing]
-        # just consider it has a value we exepcted
+        # just assume it already has the value we expect
         provider = new(:name => name, :value => resource[:value])
       end
-      resources[name].provider = provider
+      resources[name].provider = provider if provider
     end
   end
 


### PR DESCRIPTION
Provider `cli` for `foreman_config_entry` can pass nil instead of a
valid provider during prefetch if a config_entry is not found.

This breaks puppet during prefetch:

    Error: Could not prefetch foreman_config_entry provider 'cli': undefined
    method `intern' for nil:NilClass
    /opt/ruby2.0/lib/vendor_ruby/2.0.0/puppet/type.rb:1715:in `provider'
    /opt/ruby2.0/lib/vendor_ruby/2.0.0/puppet/type.rb:1928:in `provider='
    /var/lib/puppet/lib/puppet/provider/foreman_config_entry/cli.rb:59:in `block in prefetch'
    /var/lib/puppet/lib/puppet/provider/foreman_config_entry/cli.rb:53:in `each'
    /var/lib/puppet/lib/puppet/provider/foreman_config_entry/cli.rb:53:in `prefetch'
    /opt/ruby2.0/lib/vendor_ruby/2.0.0/puppet/transaction.rb:307:in `prefetch'

This commit, correctly, skips provider assignment for config entries that
don't exist.
