### PR TITLE
Fix foreman_smartproxy provider idempotency

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
     if @proxy
       @proxy
     else
-      @proxy = api.call(:index, :search => "name=#{resource[:name]}")['results'][0]
+      @proxy = api.call(:index, :search => "name=\"#{resource[:name]}\"")['results'][0]
     end
   rescue Exception => e
     raise_error e


### PR DESCRIPTION
Previously, if ::foreman_proxy::registered_name contained spaces, the
provider would not find the already registered proxy when searching
using the API.

This would result in errors like...

```
Error: /Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[Puppet on
proxy.example.com]/ensure: change from absent to present failed: Proxy
Puppet on proxy.example.com cannot be registered (422 Unprocessable
Entity): Name has already been taken URL Only one declaration of a proxy
is allowed
```