### PR TITLE
Change openstack/rackspace compute resource packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Thus 'master' will support the upcoming major version and the current stable.
 The latest release (git tag, Puppet Forge) should support current and the
 previous stable release.
 
+### Foreman 1.11 compatibility notes
+
+* `foreman::compute::openstack` and `foreman::compute::rackspace` need
+  `package => 'foreman-compute'` on Foreman 1.11 or older, as the package has
+  been split up in newer versions.
+
 ### Foreman 1.8/1.9 compatibility notes
 
 On EL or Amazon, set:

--- a/manifests/compute/openstack.pp
+++ b/manifests/compute/openstack.pp
@@ -1,4 +1,20 @@
+# = Foreman OpenStack compute resource support
+#
 # Provides support for OpenStack compute resources
-class foreman::compute::openstack {
-  include ::foreman::compute::foreman_compute
+#
+# === Parameters:
+#
+# $version::  Package version to install, defaults to installed
+#
+# $package::  Package name to install, use foreman-compute on Foreman 1.11 or older
+#
+class foreman::compute::openstack($package = 'foreman-openstack', $version = 'installed') {
+  if $package == 'foreman-compute' {
+    include ::foreman::compute::foreman_compute
+  } else {
+    package { $package:
+      ensure => $version,
+      tag    => [ 'foreman-compute', ],
+    }
+  }
 }

--- a/manifests/compute/rackspace.pp
+++ b/manifests/compute/rackspace.pp
@@ -1,4 +1,20 @@
+# = Foreman Rackspace compute resource support
+#
 # Provides support for Rackspace compute resources
-class foreman::compute::rackspace {
-  include ::foreman::compute::foreman_compute
+#
+# === Parameters:
+#
+# $version::  Package version to install, defaults to installed
+#
+# $package::  Package name to install, use foreman-compute on Foreman 1.11 or older
+#
+class foreman::compute::rackspace($package = 'foreman-rackspace', $version = 'installed') {
+  if $package == 'foreman-compute' {
+    include ::foreman::compute::foreman_compute
+  } else {
+    package { $package:
+      ensure => $version,
+      tag    => [ 'foreman-compute', ],
+    }
+  }
 }


### PR DESCRIPTION
foreman-openstack/rackspace subpackages are provided on Foreman 1.12,
per ticket #14368. Compatibility with 1.11 and older is provided through
the $package parameter.