### PR TITLE
allow plugins to be updated

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,9 @@
 # $version::                    foreman package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
 #
+# $plugin_version::             foreman plugins package version, it's passed to ensure parameter of package resource
+#                               can be set to 'installed', 'latest', 'present' only
+#
 # $db_manage::                  if enabled, will install and configure the database server on this host
 #                               type:boolean
 #
@@ -232,6 +235,7 @@ class foreman (
   $selinux                   = $::foreman::params::selinux,
   $gpgcheck                  = $::foreman::params::gpgcheck,
   $version                   = $::foreman::params::version,
+  $plugin_version            = $::foreman::params::plugin_version,
   $db_manage                 = $::foreman::params::db_manage,
   $db_type                   = $::foreman::params::db_type,
   $db_adapter                = 'UNSET',
@@ -311,6 +315,7 @@ class foreman (
   }
   validate_bool($websockets_encrypt)
   validate_re($logging_level, '^(debug|info|warn|error|fatal)$')
+  validate_re($plugin_version, '^(installed|present|latest)$')
   validate_hash($loggers)
   validate_array($serveraliases)
   if $email_delivery_method {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,7 @@ class foreman::params {
   $environment       = 'production'
   $gpgcheck          = true
   $version           = 'present'
+  $plugin_version    = 'present'
 
   $puppetmaster_timeout = 60
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,7 +1,8 @@
 # Installs the package for a given Foreman plugin
 define foreman::plugin(
-  $package     = "${foreman::plugin_prefix}${title}",
-  $config_file = "${foreman::plugin_config_dir}/foreman_${title}.yaml",
+  $version     = $foreman::plugin_version,
+  $package     = "${foreman::params::plugin_prefix}${title}",
+  $config_file = "${foreman::params::plugin_config_dir}/foreman_${title}.yaml",
   $config      = undef,
 ) {
   # Debian gem2deb converts underscores to hyphens
@@ -14,7 +15,7 @@ define foreman::plugin(
     }
   }
   package { $real_package:
-    ensure => installed,
+    ensure => $version,
   }
 
   if $config {

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -31,7 +31,7 @@ describe 'foreman::plugin' do
           when 'Debian'
             package_name = 'ruby-foreman-myplugin'
           end
-          should contain_package(package_name).with_ensure('installed')
+          should contain_package(package_name).with_ensure('present')
         end
 
         it 'should not contain the config file' do
@@ -45,7 +45,7 @@ describe 'foreman::plugin' do
         } end
 
         it 'should install the correct package' do
-          should contain_package('myplugin').with_ensure('installed')
+          should contain_package('myplugin').with_ensure('present')
         end
       end
 
@@ -61,7 +61,7 @@ describe 'foreman::plugin' do
                          when 'Debian'
                            'my-fun-plugin'
                          end
-          should contain_package(package_name).with_ensure('installed')
+          should contain_package(package_name).with_ensure('present')
         end
       end
 


### PR DESCRIPTION
This will allow the plugins to be kept updated.

In case that foreman is set to a fixed version, the version of plugins will need to be set also for all plugins.
