### PR TITLE
Add foreman::providers to install provider dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ If using `foreman::plugin::ovirt_provision`, puppetdb or tasks, also set the
 * `foreman::compute::ec2` needs `package => 'foreman-compute'` on Foreman 1.7,
   as the package has been renamed in newer versions.
 
+## Types and providers
+
+`foreman_config_entry` can be used to manage settings in Foreman's database, as
+seen in _Administer > Settings_. Provides:
+
+* `cli` provider uses `foreman-rake` to change settings (default)
+
+`foreman_hostgroup` can create and manage host group in Foreman's database.
+Providers:
+
+* `rest_v2` provider uses API v2 with apipie-bindings and OAuth (default)
+
+`foreman_smartproxy` can create and manage registered smart proxies in
+Foreman's database. Providers:
+
+* `rest_v2` provider uses API v2 with apipie-bindings and OAuth (default)
+* `rest` provider uses API v1 with the foreman_api gem and OAuth (deprecated)
+
 # Contributing
 
 * Fork the project

--- a/lib/puppet/provider/foreman_smartproxy/rest.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest.rb
@@ -1,3 +1,6 @@
+# Uses foreman_api to manage smart proxies
+#
+# This provider is deprecated and will be removed, prefer rest_v2.
 Puppet::Type.type(:foreman_smartproxy).provide(:rest) do
 
   confine :feature => :foreman_api

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -339,6 +339,10 @@ class foreman (
   Package <| tag == 'foreman::cli' |> ~>
   Class['foreman']
 
+  Class['foreman::repo'] ~>
+  Package <| tag == 'foreman::providers' |> ->
+  Class['foreman']
+
   # lint:ignore:spaceship_operator_without_tag
   Class['foreman::database']~>
   Foreman::Plugin <| |> ~>

--- a/manifests/providers.pp
+++ b/manifests/providers.pp
@@ -1,0 +1,41 @@
+# = foreman_* providers support
+#
+# Installs dependencies to use the foreman_* types and providers.
+#
+# Default parameters should point to the latest packages required for
+# the current version of the providers.
+#
+# === Parameters:
+#
+# $apipie_bindings::          Install apipie-bindings dependency
+#                             type:boolean
+#
+# $apipie_bindings_package::  Name of apipie-bindings package
+#
+# $foreman_api::              Install foreman_api dependency (deprecated)
+#                             type:boolean
+#
+# $foreman_api_package::      Name of foreman_api package
+#
+class foreman::providers(
+  $apipie_bindings         = $::foreman::providers::params::apipie_bindings,
+  $apipie_bindings_package = $::foreman::providers::params::apipie_bindings_package,
+  $foreman_api             = $::foreman::providers::params::foreman_api,
+  $foreman_api_package     = $::foreman::providers::params::foreman_api_package,
+) inherits foreman::providers::params {
+  validate_bool($apipie_bindings, $foreman_api)
+  validate_string($apipie_bindings_package, $foreman_api_package)
+
+  if $apipie_bindings {
+    package { $apipie_bindings_package:
+      ensure => installed,
+    }
+  }
+
+  if $foreman_api {
+    warning('Using foreman_api providers is deprecated, use rest_v2 with apipie-bindings instead')
+    package { $foreman_api_package:
+      ensure => installed,
+    }
+  }
+}

--- a/manifests/providers/params.pp
+++ b/manifests/providers/params.pp
@@ -1,0 +1,36 @@
+# foreman::providers default parameters
+class foreman::providers::params {
+  # Dependency packages for different providers supplied in this module
+  $apipie_bindings = true
+  $foreman_api = false
+
+  # OS specific package names
+  case $::osfamily {
+    'RedHat': {
+      $apipie_bindings_package = 'rubygem-apipie-bindings'
+      $foreman_api_package = 'rubygem-foreman_api'
+    }
+    'Debian': {
+      $apipie_bindings_package = 'ruby-apipie-bindings'
+      $foreman_api_package = 'ruby-foreman-api'
+    }
+    'FreeBSD': {
+      $apipie_bindings_package = 'rubygem-apipie-bindings'
+      $foreman_api_package = 'rubygem-foreman_api'
+    }
+    'Linux': {
+      case $::operatingsystem {
+        'Amazon': {
+          $apipie_bindings_package = 'rubygem-apipie-bindings'
+          $foreman_api_package = 'rubygem-foreman_api'
+        }
+        default: {
+          fail("${::hostname}: This class does not support operatingsystem ${::operatingsystem}")
+        }
+      }
+    }
+    default: {
+      fail("${::hostname}: This class does not support osfamily ${::osfamily}")
+    }
+  }
+}

--- a/spec/classes/foreman_providers_spec.rb
+++ b/spec/classes/foreman_providers_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'foreman::providers' do
+
+  on_supported_os.each do |os, facts|
+    next if only_test_os() and not only_test_os.include?(os)
+    next if exclude_test_os() and exclude_test_os.include?(os)
+
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      case facts[:osfamily]
+      when 'RedHat'
+        apipie_bindings = 'rubygem-apipie-bindings'
+        foreman_api = 'rubygem-foreman_api'
+      when 'Debian'
+        apipie_bindings = 'ruby-apipie-bindings'
+        foreman_api = 'ruby-foreman-api'
+      end
+
+      context 'with defaults' do
+        it { should contain_package(apipie_bindings).with_ensure('installed') }
+        it { should_not contain_package(foreman_api) }
+      end
+
+      context 'with foreman_api only' do
+        let(:params) do {
+          'apipie_bindings' => false,
+          'foreman_api' => true,
+        } end
+
+        it { should_not contain_package(apipie_bindings) }
+        it { should contain_package(foreman_api).with_ensure('installed') }
+      end
+    end
+  end
+end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -27,6 +27,18 @@ describe 'foreman' do
         it { is_expected.to compile.with_all_deps }
         it { should contain_package('foreman-cli').that_subscribes_to('Class[foreman::repo]') }
       end
+
+      describe 'with foreman::providers' do
+        let :pre_condition do
+          "class { 'foreman': }
+           class { 'foreman::providers':
+             apipie_bindings_package => 'apipie-bindings',
+           }"
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_package('apipie-bindings').that_subscribes_to('Class[foreman::repo]') }
+      end
     end
   end
 end


### PR DESCRIPTION
This will replace the package resource in foreman_proxy and help when
using the providers here outside of foreman_proxy.