### PR TITLE
Updating repos::apt to puppetlabs-apt standards

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@ fixtures:
   repositories:
     alternatives:     'git://github.com/adrienthebo/puppet-alternatives'
     apache:           'git://github.com/puppetlabs/puppetlabs-apache'
-    apt:
-      repo:           'git://github.com/puppetlabs/puppetlabs-apt'
-      branch:         '1.8.x'
+    apt:              'git://github.com/puppetlabs/puppetlabs-apt'
     concat:           'git://github.com/puppetlabs/puppetlabs-concat'
     mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'

--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -1,14 +1,26 @@
 # Install an apt repo
 define foreman::repos::apt ($repo) {
-  file { "/etc/apt/sources.list.d/${name}.list":
-    content => "deb http://deb.theforeman.org/ ${::lsbdistcodename} ${repo}\ndeb http://deb.theforeman.org/ plugins ${repo}\n",
-  } ->
-  exec { "foreman-key-${name}":
-    command => '/usr/bin/wget -q http://deb.theforeman.org/foreman.asc -O- | /usr/bin/apt-key add -',
-    unless  => '/usr/bin/apt-key list | /bin/grep -q "Foreman Automatic Signing Key"',
-  } ~>
-  exec { "update-apt-${name}":
-    command     => '/usr/bin/apt-get update',
-    refreshonly => true,
+
+  include ::apt
+
+  Apt::Source {
+    location => 'http://deb.theforeman.org/',
+    key      => {
+      id     => 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
+      source => 'https://pgp.mit.edu/pks/lookup?op=get&search=0x6F8600B9563278F6',
+    },
+    include  => {
+      src => false,
+    },
   }
+
+  ::apt::source { $name:
+    repos => $repo,
+  }
+
+  ::apt::source { "${name}-plugins":
+    release => 'plugins',
+    repos   => $repo,
+  }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": "< 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/defines/foreman_repos_apt_spec.rb
+++ b/spec/defines/foreman_repos_apt_spec.rb
@@ -4,33 +4,77 @@ describe 'foreman::repos::apt' do
   let(:title) { 'foreman' }
 
   let :facts do
-    on_supported_os['debian-7-x86_64']
+    on_supported_os['debian-8-x86_64']
   end
 
   context 'with repo => stable' do
     let(:params) { {:repo => 'stable'} }
 
+    it { should contain_class('apt') }
+
     it 'should add the stable repo' do
-      should contain_file('/etc/apt/sources.list.d/foreman.list') \
-        .with_content("deb http://deb.theforeman.org/ wheezy stable\ndeb http://deb.theforeman.org/ plugins stable\n")
+      should contain_apt__source('foreman').
+        with_location('http://deb.theforeman.org/').
+        with_repos('stable')
+
+      should contain_file('/etc/apt/sources.list.d/foreman.list').
+        with_content(/deb http:\/\/deb.theforeman.org\/ jessie stable/)
+
+      should contain_apt__source('foreman-plugins').
+        with_location('http://deb.theforeman.org/').
+        with_release('plugins').
+        with_repos('stable')
     end
+
+    let(:apt_key) do
+      'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6'
+    end
+    let(:apt_key_title) do
+      "Add key: #{apt_key} from Apt::Source foreman"
+    end
+
+    it { should contain_apt_key(apt_key_title) }
+    it { should contain_apt_key(apt_key_title).with_id(apt_key) }
+    it { should contain_apt_key(apt_key_title).with_source(/#{apt_key[-16..-1]}/) }
   end
 
-  context 'with repo => 1.7' do
-    let(:params) { {:repo => '1.7'} }
+  context 'with repo => 1.11' do
+    let(:params) { {:repo => '1.11'} }
 
-    it 'should add the 1.7 repo' do
-      should contain_file('/etc/apt/sources.list.d/foreman.list') \
-        .with_content("deb http://deb.theforeman.org/ wheezy 1.7\ndeb http://deb.theforeman.org/ plugins 1.7\n")
+    it { should contain_class('apt') }
+
+    it 'should add the 1.11 repo' do
+      should contain_apt__source('foreman').
+        with_location('http://deb.theforeman.org/').
+        with_repos('1.11')
+
+      should contain_file('/etc/apt/sources.list.d/foreman.list').
+        with_content(/deb http:\/\/deb.theforeman.org\/ jessie 1.11/)
+
+      should contain_apt__source('foreman-plugins').
+        with_location('http://deb.theforeman.org/').
+        with_release('plugins').
+        with_repos('1.11')
     end
   end
 
   context 'with repo => nightly' do
     let(:params) { {:repo => 'nightly'} }
 
+    it { should contain_class('apt') }
+
     it 'should add the nightly repo' do
-      should contain_file('/etc/apt/sources.list.d/foreman.list') \
-        .with_content("deb http://deb.theforeman.org/ wheezy nightly\ndeb http://deb.theforeman.org/ plugins nightly\n")
+      should contain_apt__source('foreman').
+        with_location('http://deb.theforeman.org/').
+        with_repos('nightly')
+
+      should contain_file('/etc/apt/sources.list.d/foreman.list').
+        with_content(/deb http:\/\/deb.theforeman.org\/ jessie nightly/)
+
+      should contain_apt__source('foreman-plugins').
+        with_location('http://deb.theforeman.org/').
+        with_release('plugins').
+        with_repos('nightly')
     end
   end
 


### PR DESCRIPTION
This will also require puppetlabs-apt > 2.0.0 because the provider has recommended new parameter style.

fixes GH-428

Things to discuss:
- [x] puppetlabs-apt update to > 2.0.0
- [x] key retrieval via keyserver by default? (key id is and should be mandatory with the current key)

Tests:
- [x] Debian jessie (Puppet Master + Foreman + Proxy)
- [x] Debian jessie (Proxy only)

