### PR TITLE
Change foreman::repo inclusion to 'include' keyword

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -326,7 +326,9 @@ class foreman (
   }
   validate_bool($puppetrun)
 
-  class { '::foreman::repo': } ~>
+  include ::foreman::repo
+
+  Class['foreman::repo'] ~>
   class { '::foreman::install': } ~>
   class { '::foreman::config': } ~>
   class { '::foreman::database': } ~>


### PR DESCRIPTION
Allows the class to be included with class parameters from
puppet-foreman_proxy.