### PR TITLE
Change foreman::providers package resources to ensure_package()

### DIFF
--- a/manifests/providers.pp
+++ b/manifests/providers.pp
@@ -41,27 +41,19 @@ class foreman::providers(
   validate_string($oauth_package, $json_package, $apipie_bindings_package, $foreman_api_package)
 
   if $oauth {
-    package { $oauth_package:
-      ensure => installed,
-    }
+    ensure_packages([$oauth_package])
   }
 
   if $json {
-    package { $json_package:
-      ensure => installed,
-    }
+    ensure_packages([$json_package])
   }
 
   if $apipie_bindings {
-    package { $apipie_bindings_package:
-      ensure => installed,
-    }
+    ensure_packages([$apipie_bindings_package])
   }
 
   if $foreman_api {
     warning('Using foreman_api providers is deprecated, use rest_v2 with apipie-bindings instead')
-    package { $foreman_api_package:
-      ensure => installed,
-    }
+    ensure_packages([$foreman_api_package])
   }
 }

--- a/spec/classes/foreman_providers_spec.rb
+++ b/spec/classes/foreman_providers_spec.rb
@@ -24,7 +24,7 @@ describe 'foreman::providers' do
 
       context 'with defaults' do
         if facts[:rubyversion].start_with?('1.8')
-          it { should contain_package(json).with_ensure('installed') }
+          it { should contain_package(json).with_ensure('present') }
         else
           it { should_not contain_package(json) }
         end
@@ -34,12 +34,12 @@ describe 'foreman::providers' do
 
       context 'with defaults on Puppet 3' do
         let(:facts) { facts.merge(:puppetversion => '3.8.6') }
-        it { should contain_package(oauth_os).with_ensure('installed') }
+        it { should contain_package(oauth_os).with_ensure('present') }
       end
 
       context 'with defaults on Puppet 4' do
         let(:facts) { facts.merge(:puppetversion => '4.0.0') }
-        it { should contain_package('puppet-agent-oauth').with_ensure('installed') }
+        it { should contain_package('puppet-agent-oauth').with_ensure('present') }
       end
 
       context 'with foreman_api only' do
@@ -49,7 +49,7 @@ describe 'foreman::providers' do
         } end
 
         it { should_not contain_package(apipie_bindings) }
-        it { should contain_package(foreman_api).with_ensure('installed') }
+        it { should contain_package(foreman_api).with_ensure('present') }
       end
 
       context 'with apipie_bindings => true' do
@@ -57,7 +57,7 @@ describe 'foreman::providers' do
           'apipie_bindings' => true,
         } end
 
-        it { should contain_package(apipie_bindings).with_ensure('installed') }
+        it { should contain_package(apipie_bindings).with_ensure('present') }
       end
 
       context 'with json => true' do
@@ -65,7 +65,7 @@ describe 'foreman::providers' do
           'json' => true,
         } end
 
-        it { should contain_package(json).with_ensure('installed') }
+        it { should contain_package(json).with_ensure('present') }
       end
 
       context 'with oauth => true' do
@@ -74,7 +74,7 @@ describe 'foreman::providers' do
           'oauth' => true,
         } end
 
-        it { should contain_package(oauth_os).with_ensure('installed') }
+        it { should contain_package(oauth_os).with_ensure('present') }
       end
     end
   end


### PR DESCRIPTION
Prevents duplicate resources between foreman::providers and
foreman::puppetmaster on ruby/rubygem-json.