### PR TITLE
Enable foreman-release-scl on RHEL

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,8 +35,8 @@ class foreman::params {
 
   # Additional software repos
   $configure_epel_repo      = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')
-  # Only configure extra SCL repos on EL clones, RHEL itself usually has RHSCL
-  $configure_scl_repo       = ($::osfamily == 'RedHat' and $::operatingsystem != 'RedHat' and $::operatingsystem != 'Fedora')
+  # Only configure extra SCL repos on EL
+  $configure_scl_repo       = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')
   # Only configure Brightbox PPA on Ubuntu 12.04 (precise)
   $configure_brightbox_repo = ($::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '12.04')
 

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -19,7 +19,7 @@ describe 'foreman::install' do
 
         case facts[:osfamily]
         when 'RedHat'
-          configure_scl_repo = (facts[:operatingsystem] != 'RedHat' and facts[:operatingsystem] != 'Fedora')
+          configure_scl_repo = (facts[:operatingsystem] != 'Fedora')
 
           it { should contain_foreman__repos('foreman') }
           it { should contain_class('foreman::repos::extra').with({


### PR DESCRIPTION
Foreman 1.12 requires it for access to the CentOS SCLo repositories
containing sclo-ror42.