### PR TITLE
Fixes #14852 - do not pass in "data" param unless needed

### DIFF
--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
     OAuth::AccessToken.new(oauth_consumer)
   end
 
-  def request(method, path, params = {}, data = nil, headers = {})
+  def request(method, path, params = {}, data = {}, headers = {})
     base_url = resource[:base_url]
     base_url += '/' unless base_url.end_with?('/')
 
@@ -70,7 +70,11 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
     attempts = 0
     begin
       debug("Making #{method} request to #{uri}")
-      response = oauth_consumer.request(method, uri.to_s, generate_token, {}, data, headers)
+      if [:post, :put, :patch].include?(method)
+        response = oauth_consumer.request(method, uri.to_s, generate_token, {}, data, headers)
+      else
+        response = oauth_consumer.request(method, uri.to_s, generate_token, {}, headers)
+      end
       debug("Received response #{response.code} from request to #{uri}")
       response
     rescue Timeout::Error => te

--- a/spec/unit/foreman_resource_rest_v3_spec.rb
+++ b/spec/unit/foreman_resource_rest_v3_spec.rb
@@ -74,12 +74,12 @@ describe provider_class do
 
     it 'makes request via consumer and returns response' do
       response = mock(:code => '200')
-      consumer.expects(:request).with(:get, 'https://foreman.example.com/api/v2/example', is_a(OAuth::AccessToken), {}, nil, is_a(Hash)).returns(response)
+      consumer.expects(:request).with(:get, 'https://foreman.example.com/api/v2/example', is_a(OAuth::AccessToken), {}, is_a(Hash)).returns(response)
       expect(provider.request(:get, 'api/v2/example')).to eq(response)
     end
 
     it 'specifies foreman_user header' do
-      consumer.expects(:request).with(:get, anything, anything, anything, anything, has_entry('foreman_user', 'admin')).returns(mock(:code => '200'))
+      consumer.expects(:request).with(:get, anything, anything, anything, has_entry('foreman_user', 'admin')).returns(mock(:code => '200'))
       provider.request(:get, 'api/v2/example')
     end
 
@@ -89,12 +89,12 @@ describe provider_class do
     end
 
     it 'passes data' do
-      consumer.expects(:request).with(:get, anything, anything, anything, 'test', anything).returns(mock(:code => '200'))
-      provider.request(:get, 'api/v2/example', {}, 'test')
+      consumer.expects(:request).with(:post, anything, anything, anything, 'test', anything).returns(mock(:code => '200'))
+      provider.request(:post, 'api/v2/example', {}, 'test')
     end
 
     it 'merges headers' do
-      consumer.expects(:request).with(:get, anything, anything, anything, anything, has_entries('test' => 'value', 'Accept' => 'application/json')).returns(mock(:code => '200'))
+      consumer.expects(:request).with(:get, anything, anything, anything, has_entries('test' => 'value', 'Accept' => 'application/json')).returns(mock(:code => '200'))
       provider.request(:get, 'api/v2/example', {}, nil, {'test' => 'value'})
     end
 


### PR DESCRIPTION
Previously, the "data" param was passed to all oauth requests. This caused
issues with `GET` requests, since `data` and `headers` gets mashed into
`*arguments`, and then the oauth gem will `shift` off the first argument if
there's a `POST` or `PUT` method. The end result was that headers weren't being
sent on `GET` requests.

Instead, only supply the "data" param if we are doing a `POST` or `PUT`.