### PR TITLE
use Timeout.timeout in node.rb

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -340,7 +340,7 @@ if __FILE__ == $0 then
       # query External node
       begin
         result = ""
-        timeout(tsecs) do
+        Timeout.timeout(tsecs) do
           result = enc(certname)
           cache(certname, result)
         end


### PR DESCRIPTION
timeout alone is deprecated in Ruby 2.3:

`/etc/puppet/node.rb:343:in <main>: Object#timeout is deprecated, use Timeout.timeout instead.`