### PR TITLE
Revert default rest_v3 request data to nil

### DIFF
--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
     OAuth::AccessToken.new(oauth_consumer)
   end
 
-  def request(method, path, params = {}, data = {}, headers = {})
+  def request(method, path, params = {}, data = nil, headers = {})
     base_url = resource[:base_url]
     base_url += '/' unless base_url.end_with?('/')
 

--- a/spec/unit/foreman_resource_rest_v3_spec.rb
+++ b/spec/unit/foreman_resource_rest_v3_spec.rb
@@ -72,10 +72,16 @@ describe provider_class do
     let(:consumer) { mock('oauth_consumer') }
     let(:effective_user) { 'admin' }
 
-    it 'makes request via consumer and returns response' do
+    it 'makes GET request via consumer and returns response' do
       response = mock(:code => '200')
       consumer.expects(:request).with(:get, 'https://foreman.example.com/api/v2/example', is_a(OAuth::AccessToken), {}, is_a(Hash)).returns(response)
       expect(provider.request(:get, 'api/v2/example')).to eq(response)
+    end
+
+    it 'makes PUT request via consumer and returns response' do
+      response = mock(:code => '200')
+      consumer.expects(:request).with(:put, 'https://foreman.example.com/api/v2/example', is_a(OAuth::AccessToken), {}, nil, is_a(Hash)).returns(response)
+      expect(provider.request(:put, 'api/v2/example')).to eq(response)
     end
 
     it 'specifies foreman_user header' do


### PR DESCRIPTION
Fixes refreshing of smart proxies against Foreman, since the PUT
request data defaulted to `{}`. This causes the oauth gem to form
encode the empty hash data, overriding the Content-Type to application/
x-www-form-urlencoded and the request is rejected by Foreman with a 415
HTTP response.

https://github.com/oauth-xx/oauth-ruby/blob/v0.5.1/lib/oauth/consumer.rb#L362-L364 checks for a Hash overrides the content type.