### PR TITLE
Support timeout configuration in foreman report processor

### DIFF
--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -42,6 +42,9 @@ Puppet::Reports.register_report(:foreman) do
 
       uri = URI.parse(foreman_url)
       http = Net::HTTP.new(uri.host, uri.port)
+      if SETTINGS[:report_timeout]
+        http.read_timeout = SETTINGS[:report_timeout]
+      end
       http.use_ssl     = uri.scheme == 'https'
       if http.use_ssl?
         if SETTINGS[:ssl_ca] && !SETTINGS[:ssl_ca].empty?

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,7 @@ class foreman::params {
   $plugin_version    = 'present'
 
   $puppetmaster_timeout = 60
+  $puppetmaster_report_timeout = 60
 
   # when undef, foreman-selinux will be installed if SELinux is enabled
   # setting to false/true will override this check (e.g. set to false on 1.1)

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -13,6 +13,7 @@ class foreman::puppetmaster (
   $puppet_basedir   = $::foreman::params::puppet_basedir,
   $puppet_etcdir    = $::foreman::params::puppet_etcdir,
   $timeout          = $::foreman::params::puppetmaster_timeout,
+  $report_timeout   = $::foreman::params::puppetmaster_report_timeout,
   $ssl_ca           = $::foreman::params::client_ssl_ca,
   $ssl_cert         = $::foreman::params::client_ssl_cert,
   $ssl_key          = $::foreman::params::client_ssl_key,

--- a/spec/classes/foreman_puppetmaster_spec.rb
+++ b/spec/classes/foreman_puppetmaster_spec.rb
@@ -81,6 +81,7 @@ describe 'foreman::puppetmaster' do
             with_content(%r{^:puppetdir: "#{puppet_vardir}"$}).
             with_content(/^:facts: true$/).
             with_content(/^:timeout: 60$/).
+            with_content(/^:report_timeout: 60$/).
             with({
               :mode  => '0640',
               :owner => 'root',

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -9,4 +9,5 @@
 :puppetuser: "<%= @puppet_user %>"
 :facts: <%= @receive_facts %>
 :timeout: <%= @timeout %>
+:report_timeout: <%= @report_timeout %>
 :threads: null


### PR DESCRIPTION
I have run into cases where a catalog and subsequent reports are so large that the default 60 second timeout in Net::HTTP is too short.  The reports are still uploaded but errors are thrown in puppetserver.