### PR TITLE
refs #15164 - support registering to org/location

### DIFF
--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -57,6 +57,7 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
   def request(method, path, params = {}, data = nil, headers = {})
     base_url = resource[:base_url]
     base_url += '/' unless base_url.end_with?('/')
+    data = data.to_json if data.is_a?(Hash)
 
     uri = URI.join(base_url, path)
     uri.query = params.map { |p,v| "#{URI.escape(p.to_s)}=#{URI.escape(v.to_s)}" }.join('&') unless params.empty?

--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
         :foreman_user => resource[:effective_user],
       },
       :apidoc_cache_base_dir => File.join(Puppet[:vardir], 'apipie_bindings')
-    }).resource(:smart_proxies)
+    })
   end
 
   # proxy hash or nil
@@ -53,7 +53,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
     if @proxy
       @proxy
     else
-      @proxy = api.call(:index, :search => "name=\"#{resource[:name]}\"")['results'][0]
+      @proxy = api.resource(:smart_proxies).call(:index, :search => "name=\"#{resource[:name]}\"")['results'][0]
     end
   rescue Exception => e
     raise_error e
@@ -68,18 +68,18 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
   end
 
   def create
-    api.call(:create, {
+    api.resource(:smart_proxies).call(:create, {
       :smart_proxy => {
         :name => resource[:name],
         :url  => resource[:url]
-      }
+      }.merge(taxonomy_params)
     })
   rescue Exception => e
     raise_error e
   end
 
   def destroy
-    api.call(:destroy, :id => id)
+    api.resource(:smart_proxies).call(:destroy, :id => id)
     @proxy = nil
   rescue Exception => e
     raise_error e
@@ -101,4 +101,34 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
     raise_error e
   end
 
+  def taxonomy_params
+    params = {}
+    params[:organization_ids] = organization_ids if organization_ids
+    params[:location_ids] = location_ids if location_ids
+    params
+  end
+
+  def organization_ids
+    @organization_ids ||= taxonomy_ids(:organization, resource[:organizations])
+  end
+
+  def location_ids
+    @location_ids ||= taxonomy_ids(:location, resource[:locations])
+  end
+
+  def taxonomy_ids(type, names)
+    return unless names && names.any?
+    ids = []
+    names.each do |name|
+      results = api.resource("#{type}s".to_sym).call(:index, :search => %{name="#{name}"})['results']
+      if results.any?
+        ids << results[0]['id']
+      else
+        fail "Could not find #{type} #{name}"
+      end
+    end
+    ids
+  rescue Exception => e
+    raise_error e
+  end
 end

--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -53,7 +53,8 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
     if @proxy
       @proxy
     else
-      @proxy = api.resource(:smart_proxies).call(:index, :search => "name=\"#{resource[:name]}\"")['results'][0]
+      proxy_id = api.resource(:smart_proxies).call(:index, :search => "name=\"#{resource[:name]}\"")['results'][0]['id']
+      @proxy = api.resource(:smart_proxies).call(:show, :id => proxy_id) if proxy_id
     end
   rescue Exception => e
     raise_error e

--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -90,13 +90,33 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
   end
 
   def url=(value)
-    api.call(:update, { :id => id, :smart_proxy => { :url => value } })
+    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :url => value } })
   rescue Exception => e
     raise_error e
   end
 
   def refresh_features!
     api.call(:refresh, :id => id)
+  rescue Exception => e
+    raise_error e
+  end
+
+  def organizations
+    proxy['organizations'] ? proxy['organizations'].map { |org| org['name'] } : nil
+  end
+
+  def organizations=(value)
+    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :organization_ids => taxonomy_ids(:organizations, value) } })
+  rescue Exception => e
+    raise_error e
+  end
+
+  def locations
+    proxy['locations'] ? proxy['locations'].map { |loc| loc['name'] } : nil
+  end
+
+  def locations=(value)
+    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :location_ids => taxonomy_ids(:locations, value) } })
   rescue Exception => e
     raise_error e
   end

--- a/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v2.rb
@@ -102,21 +102,21 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v2) do
   end
 
   def organizations
-    proxy['organizations'] ? proxy['organizations'].map { |org| org['name'] } : nil
+    proxy ? proxy['organizations'].map { |org| org['name'] } : nil
   end
 
   def organizations=(value)
-    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :organization_ids => taxonomy_ids(:organizations, value) } })
+    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :organization_ids => taxonomy_ids(:organization, value) } })
   rescue Exception => e
     raise_error e
   end
 
   def locations
-    proxy['locations'] ? proxy['locations'].map { |loc| loc['name'] } : nil
+    proxy ? proxy['locations'].map { |loc| loc['name'] } : nil
   end
 
   def locations=(value)
-    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :location_ids => taxonomy_ids(:locations, value) } })
+    api.resource(:smart_proxies).call(:update, { :id => id, :smart_proxy => { :location_ids => taxonomy_ids(:location, value) } })
   rescue Exception => e
     raise_error e
   end

--- a/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
   end
 
   def create
-    post_data = {:smart_proxy => {:name => resource[:name], :url => resource[:url]}.merge(taxonomy_params)}.to_json
+    post_data = {:smart_proxy => {:name => resource[:name], :url => resource[:url]}.merge(taxonomy_params)}
     r = request(:post, 'api/v2/smart_proxies', {}, post_data)
     raise Puppet::Error.new("Proxy #{resource[:name]} cannot be registered: #{error_message(r)}") unless success?(r)
   end
@@ -34,7 +34,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
   end
 
   def url=(value)
-    post_data = {:smart_proxy => {:url => value}}.to_json
+    post_data = {:smart_proxy => {:url => value}}
     r = request(:put, "api/v2/smart_proxies/#{id}", {}, post_data)
     raise Puppet::Error.new("Proxy #{resource[:name]} cannot be updated: #{error_message(r)}") unless success?(r)
   end
@@ -49,6 +49,26 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
     params[:organization_ids] = organization_ids if organization_ids
     params[:location_ids] = location_ids if location_ids
     params
+  end
+
+  def organizations
+    proxy ? proxy['organizations'].map { |org| org['name'] } : nil
+  end
+
+  def organizations=(value)
+    data = {:smart_proxy => {:organization_ids => taxonomy_ids(:organization, value)}}
+    r = request(:put, "api/v2/smart_proxies/#{id}", {}, data)
+    raise Puppet::Error.new("Proxy #{resource[:name]} cannot be updated: #{error_message(r)}") unless success?(r)
+  end
+
+  def locations
+    proxy ? proxy['locations'].map { |loc| loc['name'] } : nil
+  end
+
+  def locations=(value)
+    data = {:smart_proxy => {:location_ids => taxonomy_ids(:location, value)}}
+    r = request(:put, "api/v2/smart_proxies/#{id}", {}, data)
+    raise Puppet::Error.new("Proxy #{resource[:name]} cannot be updated: #{error_message(r)}") unless success?(r)
   end
 
   def organization_ids

--- a/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
   end
 
   def create
-    post_data = {:smart_proxy => {:name => resource[:name], :url => resource[:url]}}.to_json
+    post_data = {:smart_proxy => {:name => resource[:name], :url => resource[:url]}.merge(taxonomy_params)}.to_json
     r = request(:post, 'api/v2/smart_proxies', {}, post_data)
     raise Puppet::Error.new("Proxy #{resource[:name]} cannot be registered: #{error_message(r)}") unless success?(r)
   end
@@ -42,5 +42,31 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
   def refresh_features!
     r = request(:put, "api/v2/smart_proxies/#{id}/refresh")
     raise Puppet::Error.new("Proxy #{resource[:name]} cannot be refreshed: #{error_message(r)}") unless success?(r)
+  end
+
+  def taxonomy_params
+    params = {}
+    params[:organization_ids] = organization_ids if organization_ids
+    params[:location_ids] = location_ids if location_ids
+    params
+  end
+
+  def organization_ids
+    @organization_ids ||= taxonomy_ids(:organization, resource[:organizations])
+  end
+
+  def location_ids
+    @location_ids ||= taxonomy_ids(:location, resource[:locations])
+  end
+
+  def taxonomy_ids(type, names)
+    return unless names && names.any?
+    ids = []
+    names.each do |name|
+      r = request(:get, "api/v2/#{type}s", :search => %{name="#{name}"})
+      raise Puppet::Error.new("Could not find #{type} #{name}: #{error_message(r)}") unless success?(r)
+      ids << JSON.load(r.body)['results'][0]['id']
+    end
+    ids
   end
 end

--- a/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
@@ -5,7 +5,12 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
     @proxy ||= begin
       r = request(:get, 'api/v2/smart_proxies', :search => %{name="#{resource[:name]}"})
       raise Puppet::Error.new("Proxy #{resource[:name]} cannot be retrieved: #{error_message(r)}") unless success?(r)
-      JSON.load(r.body)['results'][0]
+      proxy_id = JSON.load(r.body)['results'][0]['id']
+      if proxy_id
+        r = request(:get, "api/v2/smart_proxies/#{proxy_id}")
+        raise Puppet::Error.new("Proxy #{resource[:name]} cannot be retrieved: #{error_message(r)}") unless success?(r)
+        JSON.load(r.body)
+      end
     end
   end
 

--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -1,10 +1,10 @@
 Puppet::Type.newtype(:foreman_smartproxy) do
-  desc 'foreman_smartproxy registers a smartproxy in foreman.'
+  desc 'foreman_smartproxy registers a smart proxy in foreman.'
 
   ensurable
 
   newparam(:name, :namevar => true) do
-    desc 'The name of the smartproxy.'
+    desc 'The name of the smart proxy.'
   end
 
   newparam(:base_url) do
@@ -28,17 +28,17 @@ Puppet::Type.newtype(:foreman_smartproxy) do
   end
 
   newproperty(:url) do
-    desc 'The url of the smartproxy'
+    desc 'The url of the smart proxy'
     isrequired
     newvalues(URI.regexp)
   end
 
   newproperty(:organizations, :array_matching => :all) do
-    desc 'The organizations to add to the smartproxy'
+    desc 'The organizations to add to the smart proxy'
   end
 
   newproperty(:locations, :array_matching => :all) do
-    desc 'The locations to add to the smartproxy'
+    desc 'The locations to add to the smart proxy'
   end
 
   newparam(:timeout) do

--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -34,11 +34,11 @@ Puppet::Type.newtype(:foreman_smartproxy) do
   end
 
   newproperty(:organizations, :array_matching => :all) do
-    desc 'The organizations to add to the smart proxy'
+    desc 'Names of the organizations to add to the smart proxy'
   end
 
   newproperty(:locations, :array_matching => :all) do
-    desc 'The locations to add to the smart proxy'
+    desc 'Names of the locations to add to the smart proxy'
   end
 
   newparam(:timeout) do

--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -33,6 +33,14 @@ Puppet::Type.newtype(:foreman_smartproxy) do
     newvalues(URI.regexp)
   end
 
+  newproperty(:organizations, :array_matching => :all) do
+    desc 'The organizations to add to the smartproxy'
+  end
+
+  newproperty(:locations, :array_matching => :all) do
+    desc 'The locations to add to the smartproxy'
+  end
+
   newparam(:timeout) do
     desc "Timeout for HTTP(s) requests"
 
@@ -56,5 +64,4 @@ Puppet::Type.newtype(:foreman_smartproxy) do
       debug 'Skipping refresh; smart proxy is not registered'
     end
   end
-
 end

--- a/spec/unit/foreman_smartproxy_rest_v3_spec.rb
+++ b/spec/unit/foreman_smartproxy_rest_v3_spec.rb
@@ -9,7 +9,9 @@ describe provider_class do
       :base_url => 'https://foreman.example.com',
       :consumer_key => 'oauth_key',
       :consumer_secret => 'oauth_secret',
-      :effective_user => 'admin'
+      :effective_user => 'admin',
+      :organizations => ['Default Organization', 'ACME Organization'],
+      :locations => ['Default Location']
     )
   end
 
@@ -22,6 +24,9 @@ describe provider_class do
   describe '#create' do
     it 'sends POST request' do
       provider.expects(:request).with(:post, 'api/v2/smart_proxies', {}, is_a(String)).returns(mock(:code => '201'))
+      provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="Default Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 10}]}.to_json))
+      provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="ACME Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 11}]}.to_json))
+      provider.expects(:request).with(:get, 'api/v2/locations', {:search => 'name="Default Location"'}).returns(mock(:code => '201', :body => {:results => [{:id => 12}]}.to_json))
       provider.create
     end
   end

--- a/spec/unit/foreman_smartproxy_rest_v3_spec.rb
+++ b/spec/unit/foreman_smartproxy_rest_v3_spec.rb
@@ -69,6 +69,11 @@ describe provider_class do
       provider.expects(:request).with(:get, 'api/v2/smart_proxies', :search => 'name="proxy.example.com"').returns(
         mock('response', :body => {:results => [{:id => 1, :name => 'proxy.example.com'}]}.to_json, :code => '200')
       )
+
+      provider.expects(:request).with(:get, 'api/v2/smart_proxies/1').returns(
+        mock('response', :body => {:id => 1, :name => 'proxy.example.com'}.to_json, :code => '200')
+      )
+
       expect(provider.proxy['id']).to eq(1)
       expect(provider.proxy['name']).to eq('proxy.example.com')
     end

--- a/spec/unit/foreman_smartproxy_rest_v3_spec.rb
+++ b/spec/unit/foreman_smartproxy_rest_v3_spec.rb
@@ -9,9 +9,7 @@ describe provider_class do
       :base_url => 'https://foreman.example.com',
       :consumer_key => 'oauth_key',
       :consumer_secret => 'oauth_secret',
-      :effective_user => 'admin',
-      :organizations => ['Default Organization', 'ACME Organization'],
-      :locations => ['Default Location']
+      :effective_user => 'admin'
     )
   end
 
@@ -23,10 +21,13 @@ describe provider_class do
 
   describe '#create' do
     it 'sends POST request' do
-      provider.expects(:request).with(:post, 'api/v2/smart_proxies', {}, is_a(String)).returns(mock(:code => '201'))
-      provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="Default Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 10}]}.to_json))
-      provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="ACME Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 11}]}.to_json))
-      provider.expects(:request).with(:get, 'api/v2/locations', {:search => 'name="Default Location"'}).returns(mock(:code => '201', :body => {:results => [{:id => 12}]}.to_json))
+      provider.expects(:request).with do |verb, path, params, data|
+        expect(verb).to eq :post
+        expect(path).to eq 'api/v2/smart_proxies'
+        expect(params).to be_empty
+        expect(data).to include({:smart_proxy => {:name => "proxy.example.com", :url => "https://proxy.example.com:8443"}})
+      end.returns(mock(:code => '201'))
+
       provider.create
     end
   end
@@ -96,8 +97,90 @@ describe provider_class do
   describe '#url=' do
     it 'sends PUT request' do
       provider.expects(:id).returns(1)
-      provider.expects(:request).with(:put, 'api/v2/smart_proxies/1', {}, includes('"url":"https://new.example.com:8443"')).returns(mock(:code => '200'))
+
+      provider.expects(:request).with do |verb, path, params, data|
+        expect(verb).to eq :put
+        expect(path).to eq 'api/v2/smart_proxies/1'
+        expect(params).to be_empty
+        expect(data).to include({:smart_proxy => {:url => 'https://new.example.com:8443'}})
+      end.returns(mock(:code => '200'))
+
       provider.url = 'https://new.example.com:8443'
+    end
+  end
+
+  context 'with organizations and locations' do
+    let(:resource) do
+      Puppet::Type.type(:foreman_smartproxy).new(
+        :name => 'proxy.example.com',
+        :url => 'https://proxy.example.com:8443',
+        :base_url => 'https://foreman.example.com',
+        :consumer_key => 'oauth_key',
+        :consumer_secret => 'oauth_secret',
+        :effective_user => 'admin',
+        :organizations => ['Default Organization', 'ACME Organization'],
+        :locations => ['Default Location']
+      )
+    end
+
+    let(:provider) do
+      provider = provider_class.new
+      provider.resource = resource
+      provider
+    end
+
+    describe '#create' do
+      it 'sends POST request with taxonomy parameters' do
+        expected_post = {:smart_proxy => {:name => 'proxy.example.com', :url => 'https://proxy.example.com:8443', :organization_ids => [10, 11], :location_ids => [12]}}
+
+        provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="Default Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 10}]}.to_json))
+        provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="ACME Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 11}]}.to_json))
+        provider.expects(:request).with(:get, 'api/v2/locations', {:search => 'name="Default Location"'}).returns(mock(:code => '201', :body => {:results => [{:id => 12}]}.to_json))
+        provider.expects(:request).with(:post, 'api/v2/smart_proxies', {}, expected_post).returns(mock(:code => '201'))
+        provider.create
+      end
+    end
+
+    describe '#organizations' do
+      it 'returns organizations from proxy hash' do
+        provider.expects(:proxy).twice.returns({'id' => 1, 'url' => 'https://proxy.example.com:8443', 'organizations' => [{'name' => 'Default Organization'}]})
+        expect(provider.organizations).to eq(['Default Organization'])
+      end
+
+      it 'returns nil when proxy is absent' do
+        provider.expects(:proxy).returns(nil)
+        expect(provider.organizations).to be_nil
+      end
+    end
+
+    describe '#organizations=' do
+      it 'sends PUT request' do
+        provider.expects(:id).returns(1)
+        provider.expects(:request).with(:get, 'api/v2/organizations', {:search => 'name="Default Organization"'}).returns(mock(:code => '201', :body => {:results => [{:id => 10}]}.to_json))
+        provider.expects(:request).with(:put, 'api/v2/smart_proxies/1', {}, {:smart_proxy => {:organization_ids => [10]}}).returns(mock(:code => '200'))
+        provider.organizations = ['Default Organization']
+      end
+    end
+
+    describe '#locations' do
+      it 'returns locations from proxy hash' do
+        provider.expects(:proxy).twice.returns({'id' => 1, 'url' => 'https://proxy.example.com:8443', 'locations' => [{'name' => 'Default Location'}]})
+        expect(provider.locations).to eq(['Default Location'])
+      end
+
+      it 'returns nil when proxy is absent' do
+        provider.expects(:proxy).returns(nil)
+        expect(provider.locations).to be_nil
+      end
+    end
+
+    describe '#locations=' do
+      it 'sends PUT request' do
+        provider.expects(:id).returns(1)
+        provider.expects(:request).with(:get, 'api/v2/locations', {:search => 'name="Default Location"'}).returns(mock(:code => '201', :body => {:results => [{:id => 12}]}.to_json))
+        provider.expects(:request).with(:put, 'api/v2/smart_proxies/1', {}, {:smart_proxy => {:location_ids => [12]}}).returns(mock(:code => '200'))
+        provider.locations = ['Default Location']
+      end
     end
   end
 end


### PR DESCRIPTION
When building a proxy with taxonomies enabled (such as in katello), it's a _very_ frequent complaint that the proxy isn't visible due to having no taxonomies by default.
