### PR TITLE
Fix a missing usage of the priority parameter in fragments

### DIFF
--- a/templates/_ssl_virt_host_include.erb
+++ b/templates/_ssl_virt_host_include.erb
@@ -1,6 +1,6 @@
 <IfVersion < 2.4>
-  Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman-ssl.d/*.conf') %>
+  Include <%= File.join(scope.lookupvar('apache::confd_dir'), "/#{scope.lookupvar('priority')}-foreman-ssl.d/*.conf") %>
 </IfVersion>
 <IfVersion >= 2.4>
-  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman-ssl.d/*.conf') %>
+  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), "/#{scope.lookupvar('priority')}-foreman-ssl.d/*.conf") %>
 </IfVersion>

--- a/templates/_virt_host_include.erb
+++ b/templates/_virt_host_include.erb
@@ -1,6 +1,6 @@
 <IfVersion < 2.4>
-  Include <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman.d/*.conf') %>
+  Include <%= File.join(scope.lookupvar('apache::confd_dir'), "/#{scope.lookupvar('priority')}-foreman.d/*.conf") %>
 </IfVersion>
 <IfVersion >= 2.4>
-  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), '/05-foreman.d/*.conf') %>
+  IncludeOptional <%= File.join(scope.lookupvar('apache::confd_dir'), "/#{scope.lookupvar('priority')}-foreman.d/*.conf") %>
 </IfVersion>


### PR DESCRIPTION
The change with GH-418 missed to change 2 vhost fragment templates. The problem only got noticed by apache.

In addition I include spec tests to check for a proper usage of the conf.d directories.

(( We should include this in 5.2-stable branch with the next bugfix release ))