### PR TITLE
external_node_v2.rb: generate_fact_request: don't bail out on nodes for which facts haven'…

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -151,7 +151,7 @@ def generate_fact_request(certname, filename)
   # Temp file keeping the last run time
   stat = stat_file("#{certname}-push-facts")
   last_run = File.exists?(stat) ? File.stat(stat).mtime.utc : Time.now - 365*24*60*60
-  last_fact = File.exists?(filename) ? File.stat(filename).mtime.utc : Time.new(0)
+  last_fact = File.exists?(filename) ? File.stat(filename).mtime.utc : Time.at(0)
   if last_fact > last_run
     begin
       uri = URI.parse("#{url}/api/hosts/facts")

--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -151,7 +151,7 @@ def generate_fact_request(certname, filename)
   # Temp file keeping the last run time
   stat = stat_file("#{certname}-push-facts")
   last_run = File.exists?(stat) ? File.stat(stat).mtime.utc : Time.now - 365*24*60*60
-  last_fact = File.stat(filename).mtime.utc
+  last_fact = File.exists?(filename) ? File.stat(filename).mtime.utc : Time.new(0)
   if last_fact > last_run
     begin
       uri = URI.parse("#{url}/api/hosts/facts")

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -55,7 +55,7 @@ describe 'foreman_external_node' do
   it "should NOT connect to the URL in the manifest" do
 
     enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
-    # first :exists? call is for 'push-facts'; second one for non-existant facts
+    # first :exists? call is for 'push-facts'; second one for non-existent facts
     File.stubs(:exists?).returns(false,false)
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -29,8 +29,11 @@ describe 'foreman_external_node' do
     webstub = stub_request(:post, "http://localhost:3000/api/hosts/facts").with(:body => {"fake"=>"data"})
 
     enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
-    File.stubs(:exists?).with('/tmp/fake.host.fqdn.com-push-facts.yaml').returns(false)
-    File.stubs(:exists?).returns(true)
+    File.stubs(:exists?) do |fname|
+      # the test here pretends that the recorded fake facts are out-of-date
+      return false if (fname =~ /push-facts/)
+      return true
+    end
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})
 

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -29,11 +29,8 @@ describe 'foreman_external_node' do
     webstub = stub_request(:post, "http://localhost:3000/api/hosts/facts").with(:body => {"fake"=>"data"})
 
     enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
-    File.stubs(:exists?) do |fname|
-      # the test here pretends that the recorded fake facts are out-of-date
-      return false if (fname =~ /push-facts/)
-      return true
-    end
+    # first :exists? call is for 'push-facts'; second one for fixture facts
+    File.stubs(:exists?).returns(false,true)
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})
 
@@ -53,6 +50,19 @@ describe 'foreman_external_node' do
     enc.upload_facts_parallel(http_fact_requests)
 
     expect(webstub).to have_been_requested.times(4)
+  end
+
+  it "should NOT connect to the URL in the manifest" do
+
+    enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
+    # first :exists? call is for 'push-facts'; second one for non-existant facts
+    File.stubs(:exists?).returns(false,false)
+    File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
+    enc.stubs(:build_body).returns({'fake' => 'data'})
+
+    req = enc.generate_fact_request('fake.host.fqdn.com',"non-existent-facts.yaml")
+    expect(req).to be_nil
+
   end
 
   it "should have the correct certname and hostname" do

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -60,7 +60,7 @@ describe 'foreman_external_node' do
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})
 
-    req = enc.generate_fact_request('fake.host.fqdn.com',"non-existent-facts.yaml")
+    req = enc.generate_fact_request('fake.host.fqdn.com','non-existent-facts.yaml')
     expect(req).to be_nil
 
   end

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -29,7 +29,8 @@ describe 'foreman_external_node' do
     webstub = stub_request(:post, "http://localhost:3000/api/hosts/facts").with(:body => {"fake"=>"data"})
 
     enc.stubs(:stat_file).with('fake.host.fqdn.com-push-facts').returns("/tmp/fake.host.fqdn.com-push-facts.yaml")
-    File.stubs(:exists?).returns(false)
+    File.stubs(:exists?).with('/tmp/fake.host.fqdn.com-push-facts.yaml').returns(false)
+    File.stubs(:exists?).returns(true)
     File.stubs(:stat).returns(stub(:mtime => Time.now.utc))
     enc.stubs(:build_body).returns({'fake' => 'data'})
 


### PR DESCRIPTION
…t been recorded yet; just ignore the request.

The classifier can encounter this situation when a puppet agent on a node contacts a puppet server instance for the first time. In such cases, the node classifier can get called before the agent has
submitted a set of facts.

See also issue #5925 (maybe this condition happens more frequently on the latest puppet 4 servers?)