### PR TITLE
Added SVG gzip explicit encoding

### DIFF
--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -39,6 +39,11 @@
       Header set Content-Encoding gzip
       SetEnv no-gzip
     </FilesMatch>
+    <FilesMatch \.svg\.gz$>
+      ForceType image/svg+xml
+      Header set Content-Encoding gzip
+      SetEnv no-gzip
+    </FilesMatch>
   </IfModule>
 
 </Directory>


### PR DESCRIPTION
We already precompile SVG files but it's not enabled here.

https://github.com/theforeman/foreman/blob/develop/config/initializers/assets.rb#L64