### PR TITLE
Skip defined() check for Foreman URL in CLI class on Puppet 3.6/7

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -30,7 +30,10 @@ class foreman::cli (
   $request_timeout    = $::foreman::cli::params::request_timeout,
 ) inherits foreman::cli::params {
   # Inherit URL & auth parameters from foreman class if possible
-  if defined('$foreman::foreman_url') {
+  #
+  # The parameter existence must be checked in case strict variables is enabled, but this will only
+  # work since PUP-4072 (3.7.5+) due to a bug resolving variables outside of this class.
+  if versioncmp($::puppetversion, '3.7.5') < 0 or defined('$foreman::foreman_url') {
     $foreman_url_real = pick($foreman_url, $::foreman::foreman_url)
     $username_real    = pick($username, $::foreman::admin_username)
     $password_real    = pick($password, $::foreman::admin_password)


### PR DESCRIPTION
Puppet 3.7.4 and below are not able to check whether a variable is
defined in another class due to bug PUP-4072, so foreman::foreman_url
isn't used as defined() is returning false on these versions.

This change skips the defined() check for these versions to ensure it
always picks the URL from foreman::foreman_url, at the expense of not
supporting strict variables before Puppet 3.7.5.

---

Should fix issues found in Debian Jessie tests (http://ci.theforeman.org/job/release_nightly_test_deb/796/) where Hammer's foreman.yml had an empty `:host` value. It would also affect EPEL7's 3.6.2.

This can be tested if you like by setting `STRICT_VARIABLES` to yes/no on the various versions and running foreman_cli_spec.rb.