### PR TITLE
Allow configuration of non-default ports for Apache

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -16,6 +16,12 @@
 # $serveraliases::            Serveraliases for the vhost.
 #                             type:array
 #
+# $server_port::              Port for Apache to listen on HTTP requests
+#                             type:integer
+#
+# $server_ssl_port::          Port for Apache to listen on HTTPS requests
+#                             type:integer
+#
 # $ssl::                      Whether to enable SSL.
 #
 # $ssl_cert::                 Location of the SSL certificate file.
@@ -60,6 +66,8 @@ class foreman::config::passenger(
   $priority               = $::foreman::vhost_priority,
   $servername             = $::foreman::servername,
   $serveraliases          = $::foreman::serveraliases,
+  $server_port            = $::foreman::server_port,
+  $server_ssl_port        = $::foreman::server_ssl_port,
   $ssl                    = $::foreman::ssl,
   $ssl_ca                 = $::foreman::server_ssl_ca,
   $ssl_chain              = $::foreman::server_ssl_chain,
@@ -88,6 +96,8 @@ class foreman::config::passenger(
   validate_integer($max_keepalive_requests)
   validate_integer($keepalive_timeout)
   validate_string($priority)
+  validate_integer($server_port)
+  validate_integer($server_ssl_port)
 
   $docroot = "${app_root}/public"
   $suburi_parts = split($foreman_url, '/')
@@ -116,7 +126,7 @@ class foreman::config::passenger(
     }
 
     $http_prestart = $prestart ? {
-      true  => "http://${servername}",
+      true  => "http://${servername}:${server_port}",
       false => undef,
     }
 
@@ -144,7 +154,7 @@ class foreman::config::passenger(
       passenger_pre_start     => $http_prestart,
       passenger_start_timeout => $start_timeout,
       passenger_ruby          => $ruby,
-      port                    => 80,
+      port                    => $server_port,
       priority                => $priority,
       servername              => $servername,
       serveraliases           => $serveraliases,
@@ -157,7 +167,7 @@ class foreman::config::passenger(
 
     if $ssl {
       $https_prestart = $prestart ? {
-        true  => "https://${servername}",
+        true  => "https://${servername}:${server_ssl_port}",
         false => undef,
       }
       if $ssl_crl and $ssl_crl != '' {
@@ -187,7 +197,7 @@ class foreman::config::passenger(
         passenger_pre_start     => $https_prestart,
         passenger_start_timeout => $start_timeout,
         passenger_ruby          => $ruby,
-        port                    => 443,
+        port                    => $server_ssl_port,
         priority                => $priority,
         servername              => $servername,
         serveraliases           => $serveraliases,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,12 @@
 #
 # $vhost_priority::             Defines Apache vhost priority for the Foreman vhost conf file.
 #
+# $server_port::                Defines Apache port for HTTP requests
+#                               type:integer
+#
+# $server_ssl_port::            Defines Apache port for HTTPS reqquests
+#                               type:integer
+#
 # $server_ssl_ca::              Defines Apache mod_ssl SSLCACertificateFile setting in Foreman vhost conf file.
 #
 # $server_ssl_chain::           Defines Apache mod_ssl SSLCertificateChainFile setting in Foreman vhost conf file.
@@ -258,6 +264,8 @@ class foreman (
   $organizations_enabled     = $::foreman::params::organizations_enabled,
   $passenger_interface       = $::foreman::params::passenger_interface,
   $vhost_priority            = $::foreman::params::vhost_priority,
+  $server_port               = $::foreman::params::server_port,
+  $server_ssl_port           = $::foreman::params::server_ssl_port,
   $server_ssl_ca             = $::foreman::params::server_ssl_ca,
   $server_ssl_chain          = $::foreman::params::server_ssl_chain,
   $server_ssl_cert           = $::foreman::params::server_ssl_cert,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -240,4 +240,9 @@ class foreman::params {
   $keepalive              = true
   $max_keepalive_requests = 100
   $keepalive_timeout      = 5
+
+  # Default ports for Apache to listen on
+  $server_port     = 80
+  $server_ssl_port = 443
+
 }

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -37,7 +37,8 @@ describe 'foreman::config::passenger' do
           :keepalive              => true,
           :max_keepalive_requests => 100,
           :keepalive_timeout      => 5,
-
+          :server_port            => 80,
+          :server_ssl_port        => 443,
         } end
 
         it 'should include apache with modules' do
@@ -76,6 +77,8 @@ describe 'foreman::config::passenger' do
           :keepalive              => true,
           :max_keepalive_requests => 100,
           :keepalive_timeout      => 5,
+          :server_port            => 80,
+          :server_ssl_port        => 443,
         } end
 
         case facts[:osfamily]
@@ -108,7 +111,7 @@ describe 'foreman::config::passenger' do
             :options                 => ['SymLinksIfOwnerMatch'],
             :port                    => 80,
             :passenger_min_instances => 1,
-            :passenger_pre_start     => "http://#{facts[:fqdn]}",
+            :passenger_pre_start     => "http://#{facts[:fqdn]}:80",
             :passenger_start_timeout => 600,
             :passenger_ruby          => '/usr/bin/tfm-ruby',
             :keepalive               => 'on',
@@ -129,7 +132,7 @@ describe 'foreman::config::passenger' do
             :options                 => ['SymLinksIfOwnerMatch'],
             :port                    => 443,
             :passenger_min_instances => 1,
-            :passenger_pre_start     => "https://#{facts[:fqdn]}",
+            :passenger_pre_start     => "https://#{facts[:fqdn]}:443",
             :passenger_start_timeout => 600,
             :passenger_ruby          => '/usr/bin/tfm-ruby',
             :ssl                     => true,
@@ -175,6 +178,8 @@ describe 'foreman::config::passenger' do
           :keepalive              => true,
           :max_keepalive_requests => 100,
           :keepalive_timeout      => 5,
+          :server_port            => 80,
+          :server_ssl_port        => 443,
         } end
 
         it do
@@ -206,7 +211,9 @@ describe 'foreman::config::passenger' do
             :foreman_url            => "https://#{facts[:fqdn]}",
             :keepalive              => false,
             :max_keepalive_requests => 10,
-            :keepalive_timeout      => 15
+            :keepalive_timeout      => 15,
+            :server_port            => 80,
+            :server_ssl_port        => 443,
         } end
 
         it 'should set the respective parameters' do
@@ -243,6 +250,8 @@ describe 'foreman::config::passenger' do
           :keepalive              => true,
           :max_keepalive_requests => 100,
           :keepalive_timeout      => 5,
+          :server_port            => 80,
+          :server_ssl_port        => 443,
         } end
 
         case facts[:osfamily]
@@ -283,6 +292,43 @@ describe 'foreman::config::passenger' do
             without({
               :custom_fragment => /05-foreman-ssl\.d/,
             })
+        end
+      end
+
+
+      describe 'with different ports set' do
+        let :params do {
+          :app_root               => '/usr/share/foreman',
+          :listen_on_interface    => '192.168.0.1',
+          :use_vhost              => true,
+          :priority               => '20',
+          :servername             => facts[:fqdn],
+          :serveraliases          => ['foreman', 'also.foreman'],
+          :ssl                    => true,
+          :ssl_cert               => 'cert.pem',
+          :ssl_certs_dir          => '',
+          :ssl_key                => 'key.pem',
+          :ssl_ca                 => 'ca.pem',
+          :ssl_crl                => 'crl.pem',
+          :ssl_chain              => 'ca.pem',
+          :prestart               => true,
+          :user                   => 'foreman',
+          :min_instances          => 1,
+          :start_timeout          => 600,
+          :ruby                   => '/usr/bin/tfm-ruby',
+          :foreman_url            => "https://#{facts[:fqdn]}",
+          :keepalive              => true,
+          :max_keepalive_requests => 100,
+          :keepalive_timeout      => 5,
+          :server_port            => 8080,
+          :server_ssl_port        => 8443,
+        } end
+
+        it 'should set the respective parameters' do
+          should contain_apache__vhost('foreman').with_port(8080)
+          should contain_apache__vhost('foreman').with_passenger_pre_start("http://#{facts[:fqdn]}:8080")
+          should contain_apache__vhost('foreman-ssl').with_port(8443)
+          should contain_apache__vhost('foreman-ssl').with_passenger_pre_start("https://#{facts[:fqdn]}:8443")
         end
       end
     end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -85,6 +85,8 @@ describe 'foreman' do
           :organizations_enabled     => true,
           :passenger_interface       => 'lo0',
           :vhost_priority            => '5',
+          :server_port               => 80,
+          :server_ssl_port           => 443,
           :server_ssl_ca             => '/etc/ssl/certs/ca.pem',
           :server_ssl_chain          => '/etc/ssl/certs/ca.pem',
           :server_ssl_cert           => '/etc/ssl/certs/snakeoil.pem',

--- a/spec/defines/foreman_config_passenger_fragment_spec.rb
+++ b/spec/defines/foreman_config_passenger_fragment_spec.rb
@@ -44,6 +44,8 @@ describe 'foreman::config::passenger::fragment' do
               keepalive               => true,
               max_keepalive_requests  => 100,
               keepalive_timeout       => 5,
+              server_port             => 80,
+              server_ssl_port         => 443,
           }"
         end
 
@@ -96,6 +98,8 @@ describe 'foreman::config::passenger::fragment' do
               keepalive               => true,
               max_keepalive_requests  => 100,
               keepalive_timeout       => 5,
+              server_port             => 80,
+              server_ssl_port         => 443,
           }"
         end
 


### PR DESCRIPTION
Both ports for Apache are currently hard-coded in the module and set to 80 for HTTP and 443 for HTTPS.
This change allows to configure non-default ports for Apache through 2 new parameters.
Running Foreman on non-default ports is e.g. usable for running multiple instances behind a loadbalancer. Usually those instances are not running on the default ports.