### PR TITLE
fixes #16844 - remove discovery image installation

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,8 +10,6 @@ fixtures:
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'
-    tftp:             'git://github.com/theforeman/puppet-tftp'
-
 
   symlinks:
     foreman: "#{source_dir}"

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -1,46 +1,4 @@
-# = Foreman Discovery plugin
-#
-# This class installs discovery plugin and images
-#
-# === Parameters:
-#
-# $install_images::  should the installer download and setup discovery images
-#                    for you? the average size is few hundreds of MB
-#                    type:boolean
-#
-# $tftp_root::       tftp root to install image into
-#
-# $source_url::      source URL to download from
-#
-# $image_name::      tarball with images
-#
-class foreman::plugin::discovery (
-  $install_images = $::foreman::plugin::discovery::params::install_images,
-  $tftp_root      = $::foreman::plugin::discovery::params::tftp_root,
-  $source_url     = $::foreman::plugin::discovery::params::source_url,
-  $image_name     = $::foreman::plugin::discovery::params::image_name,
-) inherits foreman::plugin::discovery::params {
-
-  validate_bool($install_images)
-
-  foreman::plugin {'discovery':
-  }
-
-  if $install_images {
-    $tftp_root_clean = regsubst($tftp_root, '/$', '')
-    validate_absolute_path($tftp_root_clean)
-    validate_string($source_url)
-    validate_string($image_name)
-
-    foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
-      remote_location => "${source_url}${image_name}",
-      mode            => '0644',
-      require         => File["${tftp_root_clean}/boot"],
-    } ~> exec { "untar ${image_name}":
-      command => "tar xf ${image_name}",
-      path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      cwd     => "${tftp_root_clean}/boot",
-      creates => "${tftp_root_clean}/boot/fdi-image/initrd0.img",
-    }
-  }
+# Foreman Discovery plugin
+class foreman::plugin::discovery {
+  foreman::plugin {'discovery': }
 }

--- a/manifests/plugin/discovery/params.pp
+++ b/manifests/plugin/discovery/params.pp
@@ -1,9 +1,0 @@
-# Default parameters for foreman::plugin::discovery
-class foreman::plugin::discovery::params {
-  include ::tftp::params
-
-  $install_images = false
-  $tftp_root      = $::tftp::params::root
-  $source_url     = 'http://downloads.theforeman.org/discovery/releases/latest/'
-  $image_name     = 'fdi-image-latest.tar'
-}

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
   ],
   "dependencies": [
     {
-      "name": "theforeman/tftp",
-      "version_requirement": ">= 1.4.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs/apache",
       "version_requirement": ">= 1.10.0 < 2.0.0"
     },

--- a/spec/classes/foreman_plugin_discovery_spec.rb
+++ b/spec/classes/foreman_plugin_discovery_spec.rb
@@ -10,42 +10,7 @@ describe 'foreman::plugin::discovery' do
 
       let(:pre_condition) { 'include foreman' }
 
-      case facts[:operatingsystem]
-        when 'Debian'
-          tftproot = '/srv/tftp'
-        when 'FreeBSD'
-          tftproot = '/tftpboot'
-        else
-          tftproot = '/var/lib/tftpboot'
-      end
-
       it { should contain_foreman__plugin('discovery') }
-
-      describe 'without paramaters' do
-        it { should_not contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
-      end
-
-      describe 'with install_images => true' do
-        let :params do
-          {
-            :install_images => true
-          }
-        end
-
-        it 'should download and install tarball' do
-          should contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar").
-            with_remote_location('http://downloads.theforeman.org/discovery/releases/latest/fdi-image-latest.tar')
-        end
-
-        it 'should extract the tarball' do
-          should contain_exec('untar fdi-image-latest.tar').with({
-            'command' => 'tar xf fdi-image-latest.tar',
-            'path' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            'cwd' => "#{tftproot}/boot",
-            'creates' => "#{tftproot}/boot/fdi-image/initrd0.img",
-          })
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This should (and is) handled in puppet-foreman_proxy. If needed, there could be even a migration to  transfer the values to foreman_proxy parameters, when it was enabled for foreman.
