### PR TITLE
introduce db_managed_rake flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,9 @@
 # $db_pool::                    Database 'production' size of connection pool
 #                               type:integer
 #
+# $db_manage_rake::             if enabled, will run rake jobs, which depend on the database
+#                               type:boolean
+#
 # $app_root::                   Name of foreman root directory
 #
 # $manage_user::                Controls whether foreman module will manage the user on the system. (default true)
@@ -252,6 +255,7 @@ class foreman (
   $db_password               = $::foreman::params::db_password,
   $db_sslmode                = 'UNSET',
   $db_pool                   = $::foreman::params::db_pool,
+  $db_manage_rake            = $::foreman::params::db_manage_rake,
   $app_root                  = $::foreman::params::app_root,
   $manage_user               = $::foreman::params::manage_user,
   $user                      = $::foreman::params::user,
@@ -363,5 +367,4 @@ class foreman (
   Foreman::Plugin <| |> ~>
   Class['foreman::service']
   # lint:endignore
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,8 @@ class foreman::params {
   $db_password = cache_data('foreman_cache_data', 'db_password', random_password(32))
   # Default database connection pool
   $db_pool = 5
+  # if enabled, will run rake jobs, which depend on the database
+  $db_manage_rake = true
 
   # Configure foreman email settings (email.yaml)
   $email_conf                = 'email.yaml'

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -19,13 +19,50 @@ describe 'foreman::database' do
           "class {'foreman':}"
         end
 
-        it { should contain_class('foreman::database::postgresql') }
+        it {
+          should contain_class('foreman::database::postgresql').
+          with_notify('Foreman_config_entry[db_pending_migration]')
+        }
 
         it { should contain_foreman_config_entry('db_pending_migration') }
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }
         it { should contain_foreman__rake('apipie:cache:index') }
+      end
+
+      describe 'with db_manage set to false' do
+        let :pre_condition do
+          "class {'foreman':
+            db_manage => false,
+          }"
+        end
+
+        it { should_not contain_class('foreman::database::postgresql') }
+
+        it { should contain_foreman_config_entry('db_pending_migration') }
+        it { should contain_foreman__rake('db:migrate') }
+        it { should contain_foreman_config_entry('db_pending_seed') }
+        it { should contain_foreman__rake('db:seed') }
+        it { should contain_foreman__rake('apipie:cache:index') }
+      end
+
+      describe 'with db_manage_rake set to false' do
+        let :pre_condition do
+          "class {'foreman':
+            db_manage_rake => false,
+          }"
+        end
+
+        it {
+          should contain_class('foreman::database::postgresql').
+          with_notify(nil)
+        }
+        it { should_not contain_foreman_config_entry('db_pending_migration') }
+        it { should_not contain_foreman__rake('db:migrate') }
+        it { should_not contain_foreman_config_entry('db_pending_seed') }
+        it { should_not contain_foreman__rake('db:seed') }
+        it { should_not contain_foreman__rake('apipie:cache:index') }
       end
 
       describe 'with seed parameters' do

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -73,6 +73,7 @@ describe 'foreman' do
           :db_password               => 'secret',
           :db_sslmode                => 'UNSET',
           :db_pool                   => 5,
+          :db_manage_rake            => true,
           :app_root                  => '/usr/share/foreman',
           :manage_user               => false,
           :user                      => 'foreman',


### PR DESCRIPTION
This makes it possible to have the databases on an external server,
using db_manage=false, while still populating the database with the
required rake jobs.

closes GH-473