### PR TITLE
pin puppetlabs-mysql to 3.9.0 for tests (6.0-stable)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,9 @@ fixtures:
     extlib:
       repo: 'git://github.com/puppet-community/puppet-extlib'
       ref:  'v0.11.3'
-    mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
+    mysql:
+      repo: 'git://github.com/puppetlabs/puppetlabs-mysql'
+      ref:  '3.9.0'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
   # Test operating systems with ruby 1.8.7 explicitly so we can exclude ruby 1.8.7 tests for other OS
-  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
   # Test the rest of the supported platforms
   - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
@@ -25,15 +25,15 @@ matrix:
     - rvm: 1.9.3
       env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
     - rvm: 1.9.3
       env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   include:
     # Only platforms left to support ruby 1.8.7
     - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
     - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
       env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"


### PR DESCRIPTION
newer versions are not compatible with Ruby 1.8.7