### PR TITLE
Add Archlinux packages to provider::params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,9 +150,14 @@ class foreman::params {
         }
       }
     }
-    /(ArchLinux|Suse)/: {
+    'Suse': {
       # Only the agent classes (cron / service) are supported for now, which
       # doesn't require any OS-specific params
+    }
+    'Archlinux': {
+      $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/lib/ruby/vendor_ruby/\1/puppet')
+      $puppet_etcdir = '/etc/puppetlabs/puppet'
+      $puppet_home = '/var/lib/puppet'
     }
     /^(FreeBSD|DragonFly)$/: {
       $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/local/lib/ruby/site_ruby/\1/puppet')

--- a/manifests/providers/params.pp
+++ b/manifests/providers/params.pp
@@ -30,6 +30,11 @@ class foreman::providers::params {
       $json_package = 'rubygem-json'
       $apipie_bindings_package = 'rubygem-apipie-bindings'
     }
+    'Archlinux': {
+      $oauth_package = 'ruby-oauth'
+      $json_package = 'ruby-json'
+      $apipie_bindings_package = 'ruby-apipie-bindings'
+    }
     'Linux': {
       case $::operatingsystem {
         'Amazon': {


### PR DESCRIPTION
I'm working on adding Archlinux to puppet-foreman_proxy, and the tests need to load some package names from here. The packages exist (https://aur.archlinux.org/packages/?O=0&SeB=nd&K=apipie+or+ruby-json+or+ruby-oauth&outdated=&SB=n&SO=a&PP=50&do_Search=Go)

 Archlinux isn't currently in the metadata.json, so I've not touched the tests.