### PR TITLE
fixes #17133 - add puppet::server::config (CA) dep to foreman::service

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -112,7 +112,6 @@ class foreman::config::passenger(
   include ::apache
   include ::apache::mod::headers
   include ::apache::mod::passenger
-  Class['::apache'] -> anchor { 'foreman::config::passenger_end': }
 
   if $use_vhost {
     # Workaround so apache::vhost doesn't attempt to create a directory

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,8 @@ class foreman::service(
   $passenger = $::foreman::passenger,
   $app_root  = $::foreman::app_root,
 ) {
+  anchor { ['foreman::service_begin', 'foreman::service_end']: }
+
   if $passenger {
     exec {'restart_foreman':
       command     => "/bin/touch ${app_root}/tmp/restart.txt",
@@ -10,6 +12,11 @@ class foreman::service(
       cwd         => $app_root,
       path        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
+
+    # Anchor httpd service within this service class, but allow other
+    # configuration within the apache module to occur before
+    Anchor['foreman::service_begin'] -> Service['httpd']
+    Class['::apache'] -> Anchor['foreman::service_end']
 
     $service_ensure = 'stopped'
     $service_enabled = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,6 +2,7 @@
 class foreman::service(
   $passenger = $::foreman::passenger,
   $app_root  = $::foreman::app_root,
+  $ssl       = $::foreman::ssl,
 ) {
   anchor { ['foreman::service_begin', 'foreman::service_end']: }
 
@@ -17,6 +18,12 @@ class foreman::service(
     # configuration within the apache module to occur before
     Anchor['foreman::service_begin'] -> Service['httpd']
     Class['::apache'] -> Anchor['foreman::service_end']
+
+    # Ensure SSL certs from the puppetmaster are available
+    # Relationship is duplicated there as defined() is parse-order dependent
+    if $ssl and defined(Class['puppet::server::config']) {
+      Class['puppet::server::config'] -> Class['foreman::service']
+    }
 
     $service_ensure = 'stopped'
     $service_enabled = false

--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -35,7 +35,7 @@ describe 'foreman::config::passenger' do
         } end
 
         it 'should include apache with modules' do
-          should contain_class('apache').that_comes_before('Anchor[foreman::config::passenger_end]')
+          should contain_class('apache')
           should contain_class('apache::mod::headers')
           should contain_class('apache::mod::passenger')
         end

--- a/spec/classes/foreman_service_spec.rb
+++ b/spec/classes/foreman_service_spec.rb
@@ -38,6 +38,7 @@ describe 'foreman::service' do
       {
         :passenger => true,
         :app_root  => '/usr/share/foreman',
+        :ssl => true,
       }
     end
 
@@ -64,6 +65,18 @@ describe 'foreman::service' do
       'enable'    => false,
       'hasstatus' => true,
     })}
+
+    context 'without ssl' do
+      let :params do
+        {
+          :passenger => true,
+          :app_root  => '/usr/share/foreman',
+          :ssl => false,
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+    end
   end
 
   context 'without passenger' do
@@ -71,6 +84,7 @@ describe 'foreman::service' do
       {
         :passenger => false,
         :app_root  => '/usr/share/foreman',
+        :ssl => true,
       }
     end
 

--- a/spec/classes/foreman_service_spec.rb
+++ b/spec/classes/foreman_service_spec.rb
@@ -11,6 +11,8 @@ describe 'foreman::service' do
       'include ::foreman'
     end
 
+    it { is_expected.to compile.with_all_deps }
+
     it 'should restart passenger' do
       should contain_exec('restart_foreman').with({
         :command     => '/bin/touch /usr/share/foreman/tmp/restart.txt',
@@ -28,12 +30,22 @@ describe 'foreman::service' do
   end
 
   context 'with passenger' do
+    let :facts do
+      on_supported_os['redhat-7-x86_64']
+    end
+
     let :params do
       {
         :passenger => true,
         :app_root  => '/usr/share/foreman',
       }
     end
+
+    let :pre_condition do
+      'include ::apache'
+    end
+
+    it { is_expected.to compile.with_all_deps }
 
     it 'should restart passenger' do
       should contain_exec('restart_foreman').with({
@@ -43,6 +55,9 @@ describe 'foreman::service' do
         :path        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       })
     end
+
+    it { should contain_service('httpd').that_requires('Anchor[foreman::service_begin]') }
+    it { should contain_class('apache').that_comes_before('Anchor[foreman::service_end]') }
 
     it { should contain_service('foreman').with({
       'ensure'    => 'stopped',
@@ -58,6 +73,8 @@ describe 'foreman::service' do
         :app_root  => '/usr/share/foreman',
       }
     end
+
+    it { is_expected.to compile.with_all_deps }
 
     it 'should not restart passenger' do
       should_not contain_exec('restart_foreman')

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -5,6 +5,7 @@ describe 'foreman' do
     context "on #{os}" do
       let :facts do facts end
 
+      it { is_expected.to compile.with_all_deps }
       it { should contain_class('foreman::repo').that_notifies('Class[foreman::install]') }
       it { should contain_class('foreman::install') }
       it { should contain_class('foreman::config') }


### PR DESCRIPTION
Two parts:

1. Move containment of Class['apache'] and Service['httpd'] so the service is contained within foreman::service, and the entire apache class is run at any time before the end of foreman::service (some of the config will be part of foreman::config::passenger etc).
1. Add dep to foreman::service on puppet::server::config ([mirror](https://github.com/theforeman/puppet-puppet/issues/453)).