### PR TITLE
Fix changes to config not restarting service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -350,6 +350,9 @@ class foreman (
   Class['foreman'] ->
   Foreman_smartproxy <| base_url == $foreman_url |>
 
+  # When db_manage and db_manage_rake are false, this extra relationship is required.
+  Class['foreman::config'] ~> Class['foreman::service']
+
   # Anchor these separately so as not to break
   # the notify between main classes
   Class['foreman::install'] ~>

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -8,7 +8,11 @@ describe 'foreman' do
       it { is_expected.to compile.with_all_deps }
       it { should contain_class('foreman::repo').that_notifies('Class[foreman::install]') }
       it { should contain_class('foreman::install') }
-      it { should contain_class('foreman::config') }
+      it do
+        is_expected.to contain_class('foreman::config').that_notifies(
+          ['Class[foreman::database]', 'Class[foreman::service]']
+        )
+      end
       it { should contain_class('foreman::database') }
       it { should contain_class('foreman::service') }
 


### PR DESCRIPTION
When `db_manage` and `db_manage_rake` are both set to `false`,
there are no resources in `Class['foreman::database']` that get
refreshed when configuration changes. As a result,
`Class['foreman::service']` doesn't get notified and foreman isn't
restarted.

This commit adds an explicit relationship between
`Class['foreman::config']` and `Class['foreman::service']`.

Fixes #GH-502