### PR TITLE
Change existing Kafo type definitions to Puppet 4 types

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -5,26 +5,31 @@
 # === Parameters:
 #
 # $foreman_url::        URL on which Foreman runs
+#                       type:Optional[Stdlib::HTTPUrl]
 #
 # $username::           Username for authentication
+#                       type:Optional[String]
 #
 # $password::           Password for authentication
+#                       type:Optional[String]
 #
 # === Advanced parameters:
 #
 # $manage_root_config::   Whether to manage /root/.hammer configuration.
-#                         type:boolean
+#                         type:Boolean
 #
 # $refresh_cache::        Check API documentation cache status on each request
-#                         type:boolean
+#                         type:Boolean
 #
 # $request_timeout::      API request timeout, set -1 for infinity
-#                         type:integer
+#                         type:Integer[-1]
 #
 # $hammer_plugin_prefix:: Hammer plugin package prefix based normally on platform
+#                         type:String
 #
 # $version::              foreman-cli package version, it's passed to ensure parameter of package resource
 #                         can be set to specific version number, 'latest', 'present' etc.
+#                         type:String
 #
 class foreman::cli (
   $foreman_url          = $::foreman::cli::params::foreman_url,

--- a/manifests/compute/ec2.pp
+++ b/manifests/compute/ec2.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::ec2($version = 'installed') {
   package { 'foreman-ec2':

--- a/manifests/compute/foreman_compute.pp
+++ b/manifests/compute/foreman_compute.pp
@@ -4,6 +4,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::foreman_compute ( $version = 'installed' ) {
   package { 'foreman-compute':

--- a/manifests/compute/gce.pp
+++ b/manifests/compute/gce.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::gce ( $version = 'installed' ) {
   package { 'foreman-gce':

--- a/manifests/compute/libvirt.pp
+++ b/manifests/compute/libvirt.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::libvirt ( $version = 'installed' ) {
   package { 'foreman-libvirt':

--- a/manifests/compute/openstack.pp
+++ b/manifests/compute/openstack.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::openstack($version = 'installed') {
   package { 'foreman-openstack':

--- a/manifests/compute/ovirt.pp
+++ b/manifests/compute/ovirt.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::ovirt ( $version = 'installed' ) {
   package { 'foreman-ovirt':

--- a/manifests/compute/rackspace.pp
+++ b/manifests/compute/rackspace.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::rackspace ( $version = 'installed' ) {
   package { 'foreman-rackspace':

--- a/manifests/compute/vmware.pp
+++ b/manifests/compute/vmware.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
+#             type:String
 #
 class foreman::compute::vmware ( $version = 'installed' ) {
   package { 'foreman-vmware':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,228 +3,284 @@
 # === Parameters:
 #
 # $admin_username::             Username for the initial admin user
+#                               type:String
 #
 # $admin_password::             Password of the initial admin user, default is randomly generated
+#                               type:String
 #
 # $admin_first_name::           First name of the initial admin user
+#                               type:Optional[String]
 #
 # $admin_last_name::            Last name of the initial admin user
+#                               type:Optional[String]
 #
 # $admin_email::                E-mail address of the initial admin user
+#                               type:Optional[String]
 #
 # $db_manage::                  if enabled, will install and configure the database server on this host
-#                               type:boolean
+#                               type:Boolean
 #
-# $db_type::                    Database 'production' type (valid types: mysql/postgresql/sqlite)
+# $db_type::                    Database 'production' type
+#                               type:Enum['mysql', 'postgresql', 'sqlite']
 #
-# $email_delivery_method::      can be sendmail or smtp
+# $email_delivery_method::      Email delivery method
+#                               type:Optional[Enum['sendmail', 'smtp']]
 #
-# $email_smtp_address::         if delivery_method is smtp, this should contain an valid smtp host
+# $email_smtp_address::         SMTP server hostname, when delivery method is SMTP
+#                               type:Optional[String]
 #
-# $email_smtp_port::            smtp port, defaults to 25
-#                               type:integer
+# $email_smtp_port::            SMTP port, defaults to 25
+#                               type:Integer[0, 65535]
 #
-# $email_smtp_domain::          email domain
+# $email_smtp_domain::          SMTP HELO domain
+#                               type:Optional[String]
 #
-# $email_smtp_authentication::  authentication settings, can be none or login, defaults to none
+# $email_smtp_authentication::  SMTP authentication method
+#                               type:Enum['none', 'plain', 'login', 'cram-md5']
 #
-# $email_smtp_user_name::       user_name for mail server auth, if authentication login
+# $email_smtp_user_name::       Username for SMTP server auth, if authentication is enabled
+#                               type:Optional[String]
 #
-# $email_smtp_password::        password for mail server auth, if authentication login
+# $email_smtp_password::        Password for SMTP server auth, if authentication is enabled
+#                               type:Optional[String]
 #
 # $locations_enabled::          Enable locations?
-#                               type:boolean
+#                               type:Boolean
 #
 # $organizations_enabled::      Enable organizations?
-#                               type:boolean
+#                               type:Boolean
 #
 # $initial_organization::       Name of an initial organization
+#                               type:Optional[String]
 #
 # $initial_location::           Name of an initial location
+#                               type:Optional[String]
 #
 # $ipa_authentication::         Enable configuration for external authentication via IPA
-#                               type:boolean
+#                               type:Boolean
 #
-# $puppetrun::                  Should foreman be able to start puppetruns on nodes
-#                               type: boolean
+# $puppetrun::                  Should Foreman be able to start Puppet runs on nodes
+#                               type:Boolean
 #
 # === Advanced parameters:
 #
-# $email_source::               template to use for email configuration file
+# $email_source::               Template to use for email configuration file
+#                               type:String
 #
 # $foreman_url::                URL on which foreman is going to run
+#                               type:Stdlib::HTTPUrl
 #
-# $unattended::                 Should foreman manage host provisioning as well
-#                               type:boolean
+# $unattended::                 Should Foreman manage host provisioning as well
+#                               type:Boolean
 #
 # $authentication::             Enable user authentication. Initial credentials are set using admin_username
 #                               and admin_password.
-#                               type:boolean
+#                               type:Boolean
 #
 # $passenger::                  Configure foreman via apache and passenger
-#                               type:boolean
+#                               type:Boolean
 #
 # $passenger_ruby::             Ruby interpreter used to run Foreman under Passenger
+#                               type:Optional[String]
 #
 # $passenger_ruby_package::     Package to install to provide Passenger libraries for the active Ruby
 #                               interpreter
+#                               type:Optional[String]
 #
 # $plugin_prefix::              String which is prepended to the plugin package names
+#                               type:String
 #
 # $use_vhost::                  Enclose apache configuration in VirtualHost tags
-#                               type:boolean
+#                               type:Boolean
 #
 # $servername::                 Server name of the VirtualHost in the webserver
+#                               type:String
 #
 # $serveraliases::              Server aliases of the VirtualHost in the webserver
-#                               type:array
+#                               type:Array[String]
 #
 # $ssl::                        Enable and set require_ssl in Foreman settings (note: requires passenger, SSL does not apply to kickstarts)
-#                               type:boolean
+#                               type:Boolean
 #
 # $custom_repo::                No need to change anything here by default
 #                               if set to true, no repo will be added by this module, letting you to
 #                               set it to some custom location.
-#                               type:boolean
+#                               type:Boolean
 #
 # $repo::                       This can be stable, nightly or a specific version i.e. 1.7
+#                               type:String
 #
 # $configure_epel_repo::        If disabled the EPEL repo will not be configured on Red Hat family systems.
-#                               type:boolean
+#                               type:Boolean
 #
 # $configure_scl_repo::         If disabled the SCL repo will not be configured on Red Hat clone systems.
 #                               (Currently only installs repos for CentOS and Scientific)
-#                               type:boolean
+#                               type:Boolean
 #
-# $selinux::                    when undef, foreman-selinux will be installed if SELinux is enabled
+# $selinux::                    When undef, foreman-selinux will be installed if SELinux is enabled
 #                               setting to false/true will override this check (e.g. set to false on 1.1)
-#                               type:boolean
+#                               type:Optional[Boolean]
 #
-# $gpgcheck::                   turn on/off gpg check in repo files (effective only on RedHat family systems)
-#                               type:boolean
+# $gpgcheck::                   Turn on/off gpg check in repo files (effective only on RedHat family systems)
+#                               type:Boolean
 #
-# $version::                    foreman package version, it's passed to ensure parameter of package resource
+# $version::                    Foreman package version, it's passed to ensure parameter of package resource
 #                               can be set to specific version number, 'latest', 'present' etc.
+#                               type:String
 #
-# $plugin_version::             foreman plugins package version, it's passed to ensure parameter of package resource
+# $plugin_version::             Foreman plugins package version, it's passed to ensure parameter of package resource
 #                               can be set to 'installed', 'latest', 'present' only
+#                               type:String
 #
 # $db_adapter::                 Database 'production' adapter
+#                               type:Optional[Enum['mysql2', 'postgresql', 'sqlite3']]
 #
 # $db_host::                    Database 'production' host
+#                               type:Optional[String]
 #
 # $db_port::                    Database 'production' port
-#                               type:integer
+#                               type:Optional[Integer[0, 65635]]
 #
 # $db_database::                Database 'production' database (e.g. foreman)
+#                               type:Optional[String]
 #
 # $db_username::                Database 'production' user (e.g. foreman)
+#                               type:Optional[String]
 #
 # $db_password::                Database 'production' password (default is random)
+#                               type:Optional[String]
 #
 # $db_sslmode::                 Database 'production' ssl mode
+#                               type:Optional[String]
 #
 # $db_pool::                    Database 'production' size of connection pool
-#                               type:integer
+#                               type:Integer[0]
 #
 # $db_manage_rake::             if enabled, will run rake jobs, which depend on the database
-#                               type:boolean
+#                               type:Boolean
 #
 # $app_root::                   Name of foreman root directory
+#                               type:Stdlib::Absolutepath
 #
 # $manage_user::                Controls whether foreman module will manage the user on the system. (default true)
-#                               type:boolean
+#                               type:Boolean
 #
 # $user::                       User under which foreman will run
+#                               type:String
 #
 # $group::                      Primary group for the Foreman user
+#                               type:String
 #
 # $rails_env::                  Rails environment of foreman
+#                               type:String
 #
 # $user_groups::                Additional groups for the Foreman user
-#                               type:array
+#                               type:Array[String]
 #
 # $puppet_home::                Puppet home directory
+#                               type:Stdlib::Absolutepath
 #
 # $puppet_ssldir::              Puppet SSL directory
+#                               type:Stdlib::Absolutepath
 #
 # $passenger_interface::        Defines which network interface passenger should listen on, undef means all interfaces
+#                               type:Optional[String]
 #
 # $passenger_prestart::         Pre-start the first passenger worker instance process during httpd start.
-#                               type:boolean
+#                               type:Boolean
 #
 # $passenger_min_instances::    Minimum passenger worker instances to keep when application is idle.
+#                               type:Integer[0]
 #
 # $passenger_start_timeout::    Amount of seconds to wait for Ruby application boot.
+#                               type:Integer[0]
 #
 # $vhost_priority::             Defines Apache vhost priority for the Foreman vhost conf file.
+#                               type:String
 #
 # $server_port::                Defines Apache port for HTTP requests
-#                               type:integer
+#                               type:Integer[0, 65535]
 #
 # $server_ssl_port::            Defines Apache port for HTTPS reqquests
-#                               type:integer
+#                               type:Integer[0, 65535]
 #
 # $server_ssl_ca::              Defines Apache mod_ssl SSLCACertificateFile setting in Foreman vhost conf file.
+#                               type:Stdlib::Absolutepath
 #
 # $server_ssl_chain::           Defines Apache mod_ssl SSLCertificateChainFile setting in Foreman vhost conf file.
+#                               type:Stdlib::Absolutepath
 #
 # $server_ssl_cert::            Defines Apache mod_ssl SSLCertificateFile setting in Foreman vhost conf file.
+#                               type:Stdlib::Absolutepath
 #
 # $server_ssl_certs_dir::       Defines Apache mod_ssl SSLCACertificatePath setting in Foreman vhost conf file.
+#                               type:Variant[String[0], Stdlib::Absolutepath]
 #
 # $server_ssl_key::             Defines Apache mod_ssl SSLCertificateKeyFile setting in Foreman vhost conf file.
+#                               type:Stdlib::Absolutepath
 #
 # $server_ssl_crl::             Defines the Apache mod_ssl SSLCARevocationFile setting in Foreman vhost conf file.
+#                               type:Stdlib::Absolutepath
 #
 # $client_ssl_ca::              Defines the SSL CA used to communicate with Foreman Proxies
+#                               type:Stdlib::Absolutepath
 #
 # $client_ssl_cert::            Defines the SSL certificate used to communicate with Foreman Proxies
+#                               type:Stdlib::Absolutepath
 #
 # $client_ssl_key::             Defines the SSL private key used to communicate with Foreman Proxies
+#                               type:Stdlib::Absolutepath
 #
 # $keepalive::                  Enable KeepAlive setting of Apache?
-#                               type:boolean
+#                               type:Boolean
 #
 # $max_keepalive_requests::     MaxKeepAliveRequests setting of Apache
 #                               (Number of requests allowed on a persistent connection)
-#                               type:integer
+#                               type:Integer[0]
 #
 # $keepalive_timeout::          KeepAliveTimeout setting of Apache
 #                               (Seconds the server will wait for subsequent requests on a persistent connection)
-#                               type:integer
+#                               type:Integer[0]
 #
 # $oauth_active::               Enable OAuth authentication for REST API
-#                               type:boolean
+#                               type:Boolean
 #
-# $oauth_map_users::            Should foreman use the foreman_user header to identify API user?
-#                               type:boolean
+# $oauth_map_users::            Should Foreman use the foreman_user header to identify API user?
+#                               type:Boolean
 #
 # $oauth_consumer_key::         OAuth consumer key
+#                               type:String
 #
 # $oauth_consumer_secret::      OAuth consumer secret
+#                               type:String
 #
 # $http_keytab::                Path to keytab to be used for Kerberos authentication on the WebUI
+#                               type:Stdlib::Absolutepath
 #
 # $pam_service::                PAM service used for host-based access control in IPA
+#                               type:String
 #
 # $ipa_manage_sssd::            If ipa_authentication is true, should the installer manage SSSD? You can disable it
 #                               if you use another module for SSSD configuration
-#                               type:boolean
+#                               type:Boolean
 #
 # $websockets_encrypt::         Whether to encrypt websocket connections
-#                               type:boolean
+#                               type:Boolean
 #
 # $websockets_ssl_key::         SSL key file to use when encrypting websocket connections
+#                               type:Stdlib::Absolutepath
 #
 # $websockets_ssl_cert::        SSL certificate file to use when encrypting websocket connections
+#                               type:Stdlib::Absolutepath
 #
-# $logging_level::              Logging level of the Foreman application (valid values: debug, info, warn, error, fatal)
+# $logging_level::              Logging level of the Foreman application
+#                               type:Enum['debug', 'info', 'warn', 'error', 'fatal']
 #
 # $loggers::                    Enable or disable specific loggers, e.g. {"sql" => true}
-#                               type:hash
+#                               type:Hash[String, Boolean]
 #
-# $email_conf::                 email configuration file, defaults to /etc/foreman/email.yaml
+# $email_conf::                 Email configuration file under /etc/foreman, defaults to email.yaml
+#                               type:String
 #
 class foreman (
   $foreman_url               = $::foreman::params::foreman_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,7 +85,7 @@ class foreman::params {
   $email_source              = 'email.yaml.erb'
   $email_delivery_method     = undef
   $email_smtp_address        = undef
-  $email_smtp_port           = '25'
+  $email_smtp_port           = 25
   $email_smtp_domain         = undef
   $email_smtp_authentication = 'none'
   $email_smtp_user_name      = undef

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -6,13 +6,16 @@
 #
 # $install_images::  should the installer download and setup discovery images
 #                    for you? the average size is few hundreds of MB
-#                    type:boolean
+#                    type:Boolean
 #
-# $tftp_root::       tftp root to install image into
+# $tftp_root::       TFTP root to install image into
+#                    type:Stdlib::Absolutepath
 #
 # $source_url::      source URL to download from
+#                    type:Stdlib::HTTPUrl
 #
 # $image_name::      tarball with images
+#                    type:String
 #
 class foreman::plugin::discovery (
   $install_images = $::foreman::plugin::discovery::params::install_images,

--- a/manifests/plugin/memcache.pp
+++ b/manifests/plugin/memcache.pp
@@ -5,16 +5,16 @@
 # === Parameters:
 #
 # $hosts::      an array of hosts running memcache
-#               type:array
+#               type:Array[String]
 #
 # $expires_in:: global default for key TTL in seconds
-#               type:integer
+#               type:Integer[0]
 #
 # $namespace::  prepends each key with this value to provide simple namespacing
-#               type:string
+#               type:String
 #
 # $compress::   will gzip-compress values larger than 1K
-#               type:boolean
+#               type:Boolean
 #
 class foreman::plugin::memcache (
   $hosts      = $::foreman::plugin::memcache::params::hosts,

--- a/manifests/plugin/ovirt_provision.pp
+++ b/manifests/plugin/ovirt_provision.pp
@@ -5,6 +5,7 @@
 # === Parameters:
 #
 # $package:: Package name to install, use ruby193-rubygem-ovirt_provision_plugin on Foreman 1.8/1.9 on EL
+#            type:String
 #
 class foreman::plugin::ovirt_provision (
   $package = $foreman::plugin::ovirt_provision::params::package,

--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -5,10 +5,13 @@
 # === Parameters:
 #
 # $package:: Package name to install, use ruby193-rubygem-puppetdb_foreman on Foreman 1.8/1.9 on EL
+#            type:String
 #
 # $address:: Address of puppetdb API. Defaults to 'https://localhost:8081/v2/commands'
+#            type:Stdlib::HTTPUrl
 #
 # $dashboard_address:: Address of puppetdb dashboard. Defaults to 'http://localhost:8080/dashboard'
+#                      type:Stdlib::HTTPUrl
 #
 class foreman::plugin::puppetdb (
   $package           = $foreman::plugin::puppetdb::params::package,

--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -5,8 +5,10 @@
 # === Parameters:
 #
 # $package:: Package name to install, use ruby193-rubygem-foreman-tasks on Foreman 1.8/1.9 on EL
+#            type:String
 #
 # $service:: Service name
+#            type:String
 #
 class foreman::plugin::tasks(
   $package = $foreman::plugin::tasks::params::package,


### PR DESCRIPTION
Supported since Kafo 1.0.0, it performs more precise validation of
parameter values and can later be moved to the parameter definitions
when the module is made Puppet 4-only.