### PR TITLE
Allow undef for foreman::compute::*::version parameters

### DIFF
--- a/manifests/compute/ec2.pp
+++ b/manifests/compute/ec2.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::ec2($version = 'installed') {
   package { 'foreman-ec2':

--- a/manifests/compute/foreman_compute.pp
+++ b/manifests/compute/foreman_compute.pp
@@ -4,7 +4,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::foreman_compute ( $version = 'installed' ) {
   package { 'foreman-compute':

--- a/manifests/compute/gce.pp
+++ b/manifests/compute/gce.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::gce ( $version = 'installed' ) {
   package { 'foreman-gce':

--- a/manifests/compute/libvirt.pp
+++ b/manifests/compute/libvirt.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::libvirt ( $version = 'installed' ) {
   package { 'foreman-libvirt':

--- a/manifests/compute/openstack.pp
+++ b/manifests/compute/openstack.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::openstack($version = 'installed') {
   package { 'foreman-openstack':

--- a/manifests/compute/ovirt.pp
+++ b/manifests/compute/ovirt.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::ovirt ( $version = 'installed' ) {
   package { 'foreman-ovirt':

--- a/manifests/compute/rackspace.pp
+++ b/manifests/compute/rackspace.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::rackspace ( $version = 'installed' ) {
   package { 'foreman-rackspace':

--- a/manifests/compute/vmware.pp
+++ b/manifests/compute/vmware.pp
@@ -5,7 +5,7 @@
 # === Parameters:
 #
 # $version::  Package version to install, defaults to installed
-#             type:String
+#             type:Optional[String]
 #
 class foreman::compute::vmware ( $version = 'installed' ) {
   package { 'foreman-vmware':


### PR DESCRIPTION
When set to undef, the default "installed" value will be used anyway.
This works around Kafo issue [#6158](http://projects.theforeman.org/issues/6158) where string defaults on parameters
are ignored and stored as undef/nil.

---

Should fix failures seen in nightly tests using these compute classes, where Kafo's validation of `nil` against `String` raises errors:

<pre>
# [ INFO 2016-11-28 08:00:22 verbose] Running validation checks
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-ec2-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-gce-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-libvirt-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-openstack-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-ovirt-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-rackspace-version invalid: nil is not a valid string
# [ERROR 2016-11-28 08:00:22 verbose] Parameter foreman-compute-vmware-version invalid: nil is not a valid string
</pre>