### PR TITLE
Support configuring email settings via foreman_config_entry

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,12 +26,18 @@ class foreman::config {
   }
 
   if $::foreman::email_delivery_method and !empty($::foreman::email_delivery_method) {
-    file { "/etc/foreman/${foreman::email_conf}":
-      ensure  => file,
-      owner   => 'root',
-      group   => $::foreman::group,
-      mode    => '0640',
-      content => template("foreman/${foreman::email_source}"),
+    if $::foreman::email_config_method == 'file' {
+      file { "/etc/foreman/${foreman::email_conf}":
+        ensure  => file,
+        owner   => 'root',
+        group   => $::foreman::group,
+        mode    => '0640',
+        content => template("foreman/${foreman::email_source}"),
+      }
+    } else {
+      file { "/etc/foreman/${foreman::email_conf}":
+        ensure => absent,
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,9 @@
 # $loggers::                    Enable or disable specific loggers, e.g. {"sql" => true}
 #                               type:Hash[String, Boolean]
 #
+# $email_config_method::        Configure email settings in database (1.14+) or configuration file (deprecated)
+#                               type:Enum['database', 'file']
+#
 # $email_conf::                 Email configuration file under /etc/foreman, defaults to email.yaml
 #                               type:String
 #
@@ -363,6 +366,7 @@ class foreman (
   $websockets_ssl_cert       = $::foreman::params::websockets_ssl_cert,
   $logging_level             = $::foreman::params::logging_level,
   $loggers                   = $::foreman::params::loggers,
+  $email_config_method       = $::foreman::params::email_config_method,
   $email_conf                = $::foreman::params::email_conf,
   $email_source              = $::foreman::params::email_source,
   $email_delivery_method     = $::foreman::params::email_delivery_method,
@@ -391,6 +395,7 @@ class foreman (
   validate_re($plugin_version, '^(installed|present|latest)$')
   validate_hash($loggers)
   validate_array($serveraliases)
+  validate_re($email_config_method, '^(database|file)$')
   if $email_delivery_method {
     validate_re($email_delivery_method, ['^sendmail$', '^smtp$'], "email_delivery_method can be either sendmail or smtp, not ${email_delivery_method}")
   }
@@ -428,4 +433,7 @@ class foreman (
   Foreman::Plugin <| |> ~>
   Class['foreman::service']
   # lint:endignore
+
+  contain 'foreman::settings' # lint:ignore:relative_classname_inclusion (PUP-1597)
+  Class['foreman::database'] -> Class['foreman::settings']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,8 @@ class foreman::params {
   # if enabled, will run rake jobs, which depend on the database
   $db_manage_rake = true
 
-  # Configure foreman email settings (email.yaml)
+  # Configure foreman email settings (database or email.yaml)
+  $email_config_method       = 'file'
   $email_conf                = 'email.yaml'
   $email_source              = 'email.yaml.erb'
   $email_delivery_method     = undef

--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -1,0 +1,45 @@
+# Configure settings in Foreman's database
+class foreman::settings(
+  $email_config_method       = $::foreman::email_config_method,
+  $email_delivery_method     = $::foreman::email_delivery_method,
+  $email_smtp_address        = $::foreman::email_smtp_address,
+  $email_smtp_port           = $::foreman::email_smtp_port,
+  $email_smtp_domain         = $::foreman::email_smtp_domain,
+  $email_smtp_authentication = $::foreman::email_smtp_authentication,
+  $email_smtp_user_name      = $::foreman::email_smtp_user_name,
+  $email_smtp_password       = $::foreman::email_smtp_password,
+) {
+  if $email_config_method == 'database' and !empty($email_delivery_method) {
+    foreman_config_entry { 'delivery_method':
+      value => $email_delivery_method,
+    }
+
+    foreman_config_entry { 'smtp_address':
+      value => $email_smtp_address,
+    }
+
+    foreman_config_entry { 'smtp_port':
+      value => $email_smtp_port,
+    }
+
+    foreman_config_entry { 'smtp_domain':
+      value => $email_smtp_domain,
+    }
+
+    $real_email_smtp_authentication = $email_smtp_authentication ? {
+      'none'  => '',
+      default => $email_smtp_authentication,
+    }
+    foreman_config_entry { 'smtp_authentication':
+      value => $real_email_smtp_authentication,
+    }
+
+    foreman_config_entry { 'smtp_user_name':
+      value => $email_smtp_user_name,
+    }
+
+    foreman_config_entry { 'smtp_password':
+      value => $email_smtp_password,
+    }
+  }
+}

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -47,6 +47,8 @@ describe 'foreman::config' do
           })
         end
 
+        it { should_not contain_file('/etc/foreman/email.yaml') }
+
         case facts[:osfamily]
         when 'RedHat'
           it 'should set the defaults file' do
@@ -264,6 +266,17 @@ describe 'foreman::config' do
             with_content(/delivery_method: :sendmail/).
             with_ensure('file')
         end
+      end
+
+      describe 'with email configured in the database' do
+        let :pre_condition do
+          "class {'foreman':
+            email_config_method   => 'database',
+            email_delivery_method => 'sendmail',
+          }"
+        end
+
+        it { should contain_file('/etc/foreman/email.yaml').with_ensure('absent') }
       end
 
       if Puppet.version >= '4.0'

--- a/spec/classes/foreman_settings_spec.rb
+++ b/spec/classes/foreman_settings_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'foreman::settings' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:sample_params) do {
+        email_config_method: 'database',
+        email_delivery_method: 'sendmail',
+        email_smtp_address: 'smtp.example.com',
+        email_smtp_port: 25,
+        email_smtp_domain: 'example.com',
+        email_smtp_authentication: 'none',
+        email_smtp_user_name: 'smtp-username',
+        email_smtp_password: 'smtp-password',
+      } end
+
+      describe 'with sample parameters' do
+        let(:params) { sample_params }
+        it { should contain_foreman_config_entry('delivery_method').with_value('sendmail') }
+        it { should contain_foreman_config_entry('smtp_address').with_value('smtp.example.com') }
+        it { should contain_foreman_config_entry('smtp_port').with_value('25') }
+        it { should contain_foreman_config_entry('smtp_domain').with_value('example.com') }
+        it { should contain_foreman_config_entry('smtp_authentication').with_value('') }
+        it { should contain_foreman_config_entry('smtp_user_name').with_value('smtp-username') }
+        it { should contain_foreman_config_entry('smtp_password').with_value('smtp-password') }
+      end
+
+      context 'with email_config_method=file' do
+        let(:params) { sample_params.merge(email_config_method: 'file') }
+        it { should_not contain_foreman_config_entry('delivery_method') }
+      end
+
+      context 'with email_smtp_authentication=cram-md5' do
+        let(:params) { sample_params.merge(email_smtp_authentication: 'cram-md5') }
+        it { should contain_foreman_config_entry('smtp_authentication').with_value('cram-md5') }
+      end
+    end
+  end
+end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -15,6 +15,7 @@ describe 'foreman' do
       end
       it { should contain_class('foreman::database') }
       it { should contain_class('foreman::service') }
+      it { should contain_class('foreman::settings').that_requires('Class[foreman::database]') }
 
       describe 'with foreman::cli' do
         let :pre_condition do


### PR DESCRIPTION
Foreman 1.14+ stores email settings in its database when email.yaml
is absent. This can be configured by setting `email_config_method`
to 'database', defaulting to the file method for 1.13 compatibility.

---

Support in Foreman not quite merged, but likely to be shortly (http://projects.theforeman.org/issues/12156).

I'll also change the default value to `database` in foreman-installer's develop branch.