### PR TITLE
Disable the docroot management

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,12 @@ fixtures:
     apache:           'git://github.com/puppetlabs/puppetlabs-apache'
     apt:              'git://github.com/puppetlabs/puppetlabs-apt'
     concat:           'git://github.com/puppetlabs/puppetlabs-concat'
-    extlib:           'git://github.com/voxpupuli/puppet-extlib'
-    mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
+    extlib:
+      repo: 'git://github.com/puppet-community/puppet-extlib'
+      ref:  'v0.11.3'
+    mysql:
+      repo: 'git://github.com/puppetlabs/puppetlabs-mysql'
+      ref:  '3.9.0'
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'

--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -114,9 +114,6 @@ class foreman::config::passenger(
   include ::apache::mod::passenger
 
   if $use_vhost {
-    # Workaround so apache::vhost doesn't attempt to create a directory
-    file { $docroot: }
-
     # Check the value in case the interface doesn't exist, otherwise listen on all interfaces
     if $listen_on_interface and $listen_on_interface in split($::interfaces, ',') {
       $listen_interface = inline_template("<%= @ipaddress_${listen_on_interface} %>")
@@ -146,6 +143,7 @@ class foreman::config::passenger(
     apache::vhost { 'foreman':
       add_default_charset     => 'UTF-8',
       docroot                 => $docroot,
+      manage_docroot          => false,
       ip                      => $listen_interface,
       options                 => ['SymLinksIfOwnerMatch'],
       passenger_app_root      => $app_root,


### PR DESCRIPTION
Rather than a weird and troublesome workaround, just tell `apache::vhost` not to manage the `docroot`.