### PR TITLE
Disable docroot management properly.

### DIFF
--- a/manifests/config/passenger.pp
+++ b/manifests/config/passenger.pp
@@ -114,9 +114,6 @@ class foreman::config::passenger(
   include ::apache::mod::passenger
 
   if $use_vhost {
-    # Workaround so apache::vhost doesn't attempt to create a directory
-    file { $docroot: }
-
     # Check the value in case the interface doesn't exist, otherwise listen on all interfaces
     if $listen_on_interface and $listen_on_interface in split($::interfaces, ',') {
       $listen_interface = inline_template("<%= @ipaddress_${listen_on_interface} %>")
@@ -146,6 +143,7 @@ class foreman::config::passenger(
     apache::vhost { 'foreman':
       add_default_charset     => 'UTF-8',
       docroot                 => $docroot,
+      manage_docroot          => false,
       ip                      => $listen_interface,
       options                 => ['SymLinksIfOwnerMatch'],
       passenger_app_root      => $app_root,


### PR DESCRIPTION
The issue that this workaround was designed to mitigate was corrected in
https://github.com/puppetlabs/puppetlabs-apache/commit/dfaae9a00cb70bb536bdd889ac3c4011f36e0c61

Reworked #511. Changing the base pulled in some other commits, it was easier to just reissue a new PR.