### PR TITLE
Puppetdb4 support

### DIFF
--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -4,19 +4,35 @@
 #
 # === Parameters:
 #
-# $package:: Package name to install, use ruby193-rubygem-puppetdb_foreman on Foreman 1.8/1.9 on EL
-#            type:String
+# $package::           Package name to install, use ruby193-rubygem-puppetdb_foreman on Foreman 1.8/1.9 on EL
+#                      type:String
 #
-# $address:: Address of puppetdb API. Defaults to 'https://localhost:8081/v2/commands'
-#            type:Stdlib::HTTPUrl
-#
-# $dashboard_address:: Address of puppetdb dashboard. Defaults to 'http://localhost:8080/dashboard'
+# $address::           Address of puppetdb API.
+#                      Defaults to 'https://localhost:8081/pdb/cmd/v1'
 #                      type:Stdlib::HTTPUrl
 #
+# $dashboard_address:: Address of puppetdb dashboard.
+#                      Defaults to 'http://localhost:8080/pdb/dashboard'
+#                      type:Stdlib::HTTPUrl
+#
+# $ssl_ca_file::       CA certificate file which will be used to connect to the PuppetDB API.
+#                      Defaults to client_ssl_ca
+#                      type:String
+#
+# $ssl_certificate::   Certificate file which will be used to connect to the PuppetDB API.
+#                      Defaults to client_ssl_cert
+#                      type:String
+#
+# $ssl_private_key::   Private key file which will be used to connect to the PuppetDB API.
+#                      Defaults to client_ssl_key
+#                      type:String
 class foreman::plugin::puppetdb (
   $package           = $foreman::plugin::puppetdb::params::package,
   $address           = $foreman::plugin::puppetdb::params::address,
   $dashboard_address = $foreman::plugin::puppetdb::params::dashboard_address,
+  $ssl_ca_file       = $foreman::plugin::puppetdb::params::ssl_ca_file,
+  $ssl_certificate   = $foreman::plugin::puppetdb::params::ssl_certificate,
+  $ssl_private_key   = $foreman::plugin::puppetdb::params::ssl_private_key,
 ) inherits foreman::plugin::puppetdb::params {
 
   validate_string($package, $address, $dashboard_address)
@@ -35,5 +51,17 @@ class foreman::plugin::puppetdb (
   ->
   foreman_config_entry { 'puppetdb_dashboard_address':
     value => $dashboard_address,
+  }
+  ->
+  foreman_config_entry { 'puppetdb_ssl_ca_file':
+    value => $ssl_ca_file,
+  }
+  ->
+  foreman_config_entry { 'puppetdb_ssl_certificate':
+    value => $ssl_certificate,
+  }
+  ->
+  foreman_config_entry { 'puppetdb_ssl_private_key':
+    value => $ssl_private_key,
   }
 }

--- a/manifests/plugin/puppetdb/params.pp
+++ b/manifests/plugin/puppetdb/params.pp
@@ -1,5 +1,7 @@
 # Data for the puppetdb_foreman plugin
 class foreman::plugin::puppetdb::params {
+  include ::foreman::params
+
   case $::osfamily {
     'RedHat': {
       case $::operatingsystem {
@@ -31,6 +33,9 @@ class foreman::plugin::puppetdb::params {
       fail("${::hostname}: puppetdb_foreman does not support osfamily ${::osfamily}")
     }
   }
-  $address = 'https://localhost:8081/v2/commands'
-  $dashboard_address = 'http://localhost:8080/dashboard'
+  $address           = 'https://localhost:8081/pdb/cmd/v1'
+  $dashboard_address = 'http://localhost:8080/pdb/dashboard'
+  $ssl_ca_file       = $::foreman::params::client_ssl_ca
+  $ssl_certificate   = $::foreman::params::client_ssl_cert
+  $ssl_private_key   = $::foreman::params::client_ssl_key
 }


### PR DESCRIPTION
It is related to this
https://github.com/theforeman/puppetdb_foreman/commit/57f782c5502b4bdc7afcd56436bb303e182ddb45

Recently, I modified codes on the Puppetdb plugin for supporting PuppetDB 4.x.
But the foreman-installer does not reflect these changes.

I added few params on the puppetdb.pp file. these are all related to the client SSL certificate.

Please apply this request.