### PR TITLE
Extend gzip file serving to /public/webpack

### DIFF
--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -11,7 +11,7 @@
 
 </Directory>
 
-<Directory <%= @docroot %>/assets>
+<Directory ~ <%= @docroot %>/(assets|webpack)>
 
   # Use standard http expire header for assets instead of ETag
   <IfModule mod_expires.c>


### PR DESCRIPTION
With compression-webpack-plugin, precompressed files are also available
in `~foreman/public/webpack/` and may be served if available.