### PR TITLE
Remove a possibly undefined requirement in discovery

### DIFF
--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -38,7 +38,6 @@ class foreman::plugin::discovery (
     foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
       remote_location => "${source_url}${image_name}",
       mode            => '0644',
-      require         => File["${tftp_root_clean}/boot"],
     } ~> exec { "untar ${image_name}":
       command => "tar xf ${image_name}",
       path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',

--- a/spec/classes/plugin/discovery_spec.rb
+++ b/spec/classes/plugin/discovery_spec.rb
@@ -16,10 +16,9 @@ describe 'foreman::plugin::discovery' do
           tftproot = '/var/lib/tftpboot'
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_foreman__plugin('discovery') }
-
       describe 'without paramaters' do
+        it { should compile.with_all_deps }
+        it { should contain_foreman__plugin('discovery') }
         it { should_not contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
       end
 
@@ -29,6 +28,9 @@ describe 'foreman::plugin::discovery' do
             :install_images => true
           }
         end
+
+        it { should compile.with_all_deps }
+        it { should contain_foreman__plugin('discovery') }
 
         it 'should download and install tarball' do
           should contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar").


### PR DESCRIPTION
The problem is that puppet-foreman_proxy can define this directory, but that's not guaranteed since the user may not enable that plugin. In that case this dependency can't be satified which results in an error, at least on puppet 4.

The installer will give the following traceback:

```
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/errors.rb:106:in `fail'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1499:in `block in validate_relationship'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1496:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:1496:in `validate_relationship'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:2519:in `block in finish'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:2517:in `collect'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type.rb:2517:in `finish'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:283:in `block in finalize'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:283:in `each'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/resource/catalog.rb:283:in `finalize'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/apply.rb:265:in `block in main'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/context.rb:65:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet.rb:241:in `override'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/apply.rb:225:in `main'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application/apply.rb:170:in `run_command'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:344:in `block in run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util.rb:540:in `exit_on_fail'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/application.rb:344:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:132:in `run'
/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/command_line.rb:72:in `execute'
/opt/puppetlabs/puppet/bin/puppet:5:in `<main>'
```

I considered adding the directory here, but that can give conflicts.