### PR TITLE
Add open_timeout to the report script

### DIFF
--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -43,6 +43,7 @@ Puppet::Reports.register_report(:foreman) do
       uri = URI.parse(foreman_url)
       http = Net::HTTP.new(uri.host, uri.port)
       if SETTINGS[:report_timeout]
+        http.open_timeout = SETTINGS[:report_timeout]
         http.read_timeout = SETTINGS[:report_timeout]
       end
       http.use_ssl     = uri.scheme == 'https'


### PR DESCRIPTION
Fixes the issue of a long timeout when the server is unreachable.