### PR TITLE
Remove YAML.load_file stubbing, preset $settings_file

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -11,9 +11,9 @@ require 'rbconfig'
 require 'yaml'
 
 if RbConfig::CONFIG['host_os'] =~ /freebsd|dragonfly/i
-  $settings_file = '/usr/local/etc/puppet/foreman.yaml'
+  $settings_file ||= '/usr/local/etc/puppet/foreman.yaml'
 else
-  $settings_file = File.exist?('/etc/puppetlabs/puppet/foreman.yaml') ? '/etc/puppetlabs/puppet/foreman.yaml' : '/etc/puppet/foreman.yaml'
+  $settings_file ||= File.exist?('/etc/puppetlabs/puppet/foreman.yaml') ? '/etc/puppetlabs/puppet/foreman.yaml' : '/etc/puppet/foreman.yaml'
 end
 
 SETTINGS = YAML.load_file($settings_file)

--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -25,9 +25,9 @@ rescue LoadError
 end
 
 if RbConfig::CONFIG['host_os'] =~ /freebsd|dragonfly/i
-  $settings_file = '/usr/local/etc/puppet/foreman.yaml'
+  $settings_file ||= '/usr/local/etc/puppet/foreman.yaml'
 else
-  $settings_file = File.exist?('/etc/puppetlabs/puppet/foreman.yaml') ? '/etc/puppetlabs/puppet/foreman.yaml' : '/etc/puppet/foreman.yaml'
+  $settings_file ||= File.exist?('/etc/puppetlabs/puppet/foreman.yaml') ? '/etc/puppetlabs/puppet/foreman.yaml' : '/etc/puppet/foreman.yaml'
 end
 
 SETTINGS = YAML.load_file($settings_file)

--- a/spec/unit/foreman_external_node_spec.rb
+++ b/spec/unit/foreman_external_node_spec.rb
@@ -1,23 +1,18 @@
 require 'rbconfig'
 require 'spec_helper'
 require 'yaml'
-
-if RbConfig::CONFIG['host_os'] =~ /freebsd|dragonfly/i
-  $settings_file = "/usr/local/etc/puppet/foreman.yaml"
-else
-  $settings_file = "/etc/puppet/foreman.yaml"
-end
+require 'tempfile'
 
 class Enc
-  yaml_text = <<-EOF
+  settings = Tempfile.new('foreman.yaml')
+  settings.write(<<-EOF)
 ---
 :url: "http://localhost:3000"
 :facts: true
 :puppet_home: "/var/lib/puppet"
   EOF
-  yaml = YAML.load(yaml_text)
-  YAML.stubs(:load_file).with($settings_file).returns(yaml)
-  YAML.stubs(:load_file).with("/dev/null").returns({})
+  settings.close
+  $settings_file = settings.path
   eval File.read(File.join(File.dirname(__FILE__), '../..', 'files', 'external_node_v2.rb'))
 end
 

--- a/spec/unit/foreman_report_processor_spec.rb
+++ b/spec/unit/foreman_report_processor_spec.rb
@@ -1,22 +1,18 @@
 require 'rbconfig'
 require 'spec_helper'
 require 'yaml'
-
-if RbConfig::CONFIG['host_os'] =~ /freebsd|dragonfly/i
-  $settings_file = "/usr/local/etc/puppet/foreman.yaml"
-else
-  $settings_file = "/etc/puppet/foreman.yaml"
-end
+require 'tempfile'
 
 describe 'foreman_report_processor' do
-  yaml_text = <<-EOF
+  settings = Tempfile.new('foreman.yaml')
+  settings.write(<<-EOF)
 ---
 :url: "http://localhost:3000"
 :facts: true
 :puppet_home: "/var/lib/puppet"
   EOF
-  yaml = YAML.load(yaml_text)
-  YAML.stubs(:load_file).with($settings_file).returns(yaml)
+  settings.close
+  $settings_file = settings.path
   eval File.read(File.join(File.dirname(__FILE__), '../..', 'files', 'foreman-report_v2.rb'))
   let(:processor) { Puppet::Reports.report(:foreman) }
 


### PR DESCRIPTION
Internally Puppet uses YAML.load_file to load the Hiera config (set to
/dev/null under rspec-puppet), but 4.9.0 uses Pathnames instead of
Strings causing the existing stub for "/dev/null" to fail.

Setting the value of $settings_file prior to evaluating the ENC/report
scripts is more reliable than stubbing the YAML constant.