### PR TITLE
Add open_timeout to the report and external node script

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -222,6 +222,7 @@ def upload_facts(certname, req)
   uri = URI.parse("#{url}/api/hosts/facts")
   begin
     res = initialize_http(uri)
+    res.open_timeout = SETTINGS[:timeout]
     res.read_timeout = SETTINGS[:timeout]
     res.start do |http|
       response = http.request(req)

--- a/files/foreman-report_v2.rb
+++ b/files/foreman-report_v2.rb
@@ -43,6 +43,7 @@ Puppet::Reports.register_report(:foreman) do
       uri = URI.parse(foreman_url)
       http = Net::HTTP.new(uri.host, uri.port)
       if SETTINGS[:report_timeout]
+        http.open_timeout = SETTINGS[:report_timeout]
         http.read_timeout = SETTINGS[:report_timeout]
       end
       http.use_ssl     = uri.scheme == 'https'


### PR DESCRIPTION
Fixes the issue of a long timeout when the server is unreachable.