### PR TITLE
Restrict gzip asset serving to known extensions

### DIFF
--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -27,6 +27,7 @@
     # Make sure the browser supports gzip encoding and file with .gz added
     # does exist on disc before we rewrite with the extension
     RewriteCond %{HTTP:Accept-Encoding} \b(x-)?gzip\b
+    RewriteCond %{REQUEST_FILENAME} \.(css|js|svg)$
     RewriteCond %{REQUEST_FILENAME}.gz -s
     RewriteRule ^(.+) $1.gz [L]
     # Set headers for all possible assets which are compressed


### PR DESCRIPTION
Prevents responses with incorrect content types being served if
different, unknown types of assets are later added to the directory
(similar to #18371 where SVG was added, if 568f278 was not applied).