### PR TITLE
Fixes #18757 - Move foreman-tasks service to Foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ previous stable release.
 
 ### Foreman version compatibility notes
 
+For Foreman 1.16 or older, please set the 'dynflow_in_core' parameter to false.
 For Foreman 1.11 or older, please use the 5.x release series of this module.
 
 ## Types and providers

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,6 +201,9 @@
 #
 # $dynflow_pool_size::          How many workers should Dynflow use
 #
+# $jobs_service::               Name of the service for running the background Dynflow executor
+#
+# $dynflow_in_core::            Whether the Dynflow executor service is provided by Foreman or tasks
 class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
   Boolean $puppetrun = $::foreman::params::puppetrun,
@@ -295,6 +298,8 @@ class foreman (
   Optional[String] $email_smtp_user_name = $::foreman::params::email_smtp_user_name,
   Optional[String] $email_smtp_password = $::foreman::params::email_smtp_password,
   Integer[0, 65535] $dynflow_pool_size = $::foreman::params::dynflow_pool_size,
+  String $jobs_service = $::foreman::params::jobs_service,
+  Boolean $dynflow_in_core = $::foreman::params::dynflow_in_core,
 ) inherits foreman::params {
   if $db_adapter == 'UNSET' {
     $db_adapter_real = $::foreman::db_type ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,6 +94,8 @@ class foreman::params {
 
   # Configure how many workers should Dynflow use
   $dynflow_pool_size = 5
+  # Defines whether Foreman or the tasks plugin provides the Dynflow executor
+  $dynflow_in_core = true
 
   # OS specific paths
   case $::osfamily {
@@ -102,6 +104,8 @@ class foreman::params {
       $init_config_tmpl = 'foreman.sysconfig'
       $puppet_etcdir = '/etc/puppet'
       $puppet_home = '/var/lib/puppet'
+      $jobs_service = $dynflow_in_core ? { true => 'dynflow-executor',
+                                            false => 'foreman-tasks' }
 
       case $::operatingsystem {
         'fedora': {
@@ -134,6 +138,9 @@ class foreman::params {
       $plugin_prefix = 'ruby-foreman-'
       $init_config = '/etc/default/foreman'
       $init_config_tmpl = 'foreman.default'
+      $jobs_service = $dynflow_in_core ? { true => 'ruby-dynflow-executor',
+                                            false => 'ruby-foreman-tasks' }
+
     }
     'Linux': {
       case $::operatingsystem {
@@ -257,4 +264,7 @@ class foreman::params {
   $server_port     = 80
   $server_ssl_port = 443
 
+  # Define job processing service properties
+  $jobs_service_ensure = 'running'
+  $jobs_service_enable = true
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -1,9 +1,8 @@
 # Installs foreman_ansible plugin
 class foreman::plugin::ansible {
-
   include ::foreman::plugin::tasks
 
   foreman::plugin {'ansible':
-    notify => Service['foreman-tasks'],
+    notify => Class['foreman::service::jobs'],
   }
 }

--- a/manifests/plugin/remote_execution.pp
+++ b/manifests/plugin/remote_execution.pp
@@ -1,9 +1,8 @@
 # Installs foreman_remote_execution plugin
 class foreman::plugin::remote_execution {
-
   include ::foreman::plugin::tasks
 
   foreman::plugin {'remote_execution':
-    notify => Service['foreman-tasks'],
+    notify => Class['foreman::service::jobs'],
   }
 }

--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -6,25 +6,20 @@
 #
 # $package:: Package name to install, use ruby193-rubygem-foreman-tasks on Foreman 1.8/1.9 on EL
 #
-# $service:: Service name
-#
 # $automatic_cleanup:: Enable automatic task cleanup using a cron job
 #
 # $cron_line:: Cron line defining when the cleanup cron job should run
 #
 class foreman::plugin::tasks(
   String $package = $::foreman::plugin::tasks::params::package,
-  String $service = $::foreman::plugin::tasks::params::service,
   Boolean $automatic_cleanup = $::foreman::plugin::tasks::params::automatic_cleanup,
   String $cron_line = $::foreman::plugin::tasks::params::cron_line,
 ) inherits foreman::plugin::tasks::params {
+  include ::foreman::service::jobs
+
   foreman::plugin { 'tasks':
     package => $package,
-  }
-  ~> service { 'foreman-tasks':
-    ensure => running,
-    enable => true,
-    name   => $service,
+    notify  => Class['foreman::service::jobs'],
   }
   $cron_state = $automatic_cleanup ? {
     true    => 'present',

--- a/manifests/plugin/tasks/params.pp
+++ b/manifests/plugin/tasks/params.pp
@@ -4,7 +4,6 @@ class foreman::plugin::tasks::params {
   $cron_line = '45 19 * * *'
   case $::osfamily {
     'RedHat': {
-      $service = 'foreman-tasks'
       case $::operatingsystem {
         'fedora': {
           $package = 'rubygem-foreman-tasks'
@@ -16,7 +15,6 @@ class foreman::plugin::tasks::params {
     }
     'Debian': {
       $package = 'ruby-foreman-tasks'
-      $service = 'ruby-foreman-tasks'
     }
     /^(FreeBSD|DragonFly)$/: {
       # do nothing to not break foreman-installer

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ class foreman::service(
   $ssl       = $::foreman::ssl,
 ) {
   anchor { ['foreman::service_begin', 'foreman::service_end']: }
+  contain ::foreman::service::jobs
 
   if $passenger {
     exec {'restart_foreman':

--- a/manifests/service/jobs.pp
+++ b/manifests/service/jobs.pp
@@ -1,0 +1,35 @@
+# = Jobs service
+#
+# Service to start a Dynflow executor for background job
+# processing in Foreman.
+#
+# On foreman 1.16+ this runs the dynflow-executor. This class could be
+# renamed to dynflow-executor when this module has to be compatible with
+# 1.16 and 1.17 only
+#
+# === Parameters:
+#
+# $service:: Service name
+#
+# $dynflow_in_core:: Whether Foreman has a dynflow executor
+#                    without the foreman-tasks plugin
+#
+# $ensure:: State the service should be in
+#
+# $enable:: Whether to enable the service or not
+
+class foreman::service::jobs(
+  String $service = $::foreman::jobs_service,
+  Boolean $dynflow_in_core = $::foreman::dynflow_in_core,
+  Enum['running', 'stopped'] $ensure  = $::foreman::jobs_service_ensure,
+  Boolean $enable = $::foreman::jobs_service_enable,
+) {
+  if $dynflow_in_core and ($service in ['ruby-dynflow-executor', 'dynflow-executor']) or
+    !$dynflow_in_core and ($service in ['ruby-foreman-tasks', 'foreman-tasks']) {
+    service { $service:
+      ensure => $ensure,
+      enable => $enable,
+      name   => $service,
+    }
+  }
+}

--- a/spec/classes/foreman_service_spec.rb
+++ b/spec/classes/foreman_service_spec.rb
@@ -43,7 +43,14 @@ describe 'foreman::service' do
     end
 
     let :pre_condition do
-      'include ::apache'
+      'include ::apache
+      class {
+      "::foreman::service::jobs":
+        service => "dynflow-executor",
+        dynflow_in_core => true,
+        ensure => "running",
+        enable => true,
+      }'
     end
 
     it { is_expected.to compile.with_all_deps }
@@ -80,12 +87,26 @@ describe 'foreman::service' do
   end
 
   context 'without passenger' do
+    let :facts do
+      on_supported_os['redhat-7-x86_64']
+    end
+
     let :params do
       {
         :passenger => false,
         :app_root  => '/usr/share/foreman',
         :ssl => true,
       }
+    end
+
+    let :pre_condition do
+      "class {
+      'foreman::service::jobs':
+        service => 'dynflow-executor',
+        dynflow_in_core => true,
+        ensure => 'running',
+        enable => true,
+      }"
     end
 
     it { is_expected.to compile.with_all_deps }

--- a/spec/classes/plugin/remote_execution_spec.rb
+++ b/spec/classes/plugin/remote_execution_spec.rb
@@ -7,7 +7,12 @@ describe 'foreman::plugin::remote_execution' do
       let(:pre_condition) { 'include foreman' }
 
       it { should compile.with_all_deps }
-      it { should contain_foreman__plugin('remote_execution').that_notifies('Service[foreman-tasks]') }
+      it { should contain_foreman__plugin('remote_execution').that_notifies("Class[foreman::service::jobs]") }
+    end
+
+    context "in 1.16 or lower, tasks is included" do
+      let(:facts) { facts }
+      let(:pre_condition) { 'include foreman' }
       it { should contain_foreman__plugin('tasks') }
     end
   end

--- a/spec/classes/plugin/tasks_spec.rb
+++ b/spec/classes/plugin/tasks_spec.rb
@@ -17,20 +17,16 @@ describe 'foreman::plugin::tasks' do
                        else
                          'tfm-rubygem-foreman-tasks'
                        end
-        service_name = 'foreman-tasks'
       when 'Debian'
         package_name = 'ruby-foreman-tasks'
-        service_name = 'ruby-foreman-tasks'
       else
         package_name = 'foreman-tasks'
-        service_name = 'foreman-tasks'
       end
 
       it { should compile.with_all_deps }
 
       it 'should call the plugin' do
         should contain_foreman__plugin('tasks').with_package(package_name)
-        should contain_service('foreman-tasks').with('ensure' => 'running', 'enable' => 'true', 'name' => service_name)
         should contain_file('/etc/cron.d/foreman-tasks').
           with_path('/etc/cron.d/foreman-tasks').
           with_ensure('absent')

--- a/spec/classes/service/foreman_service_jobs.rb
+++ b/spec/classes/service/foreman_service_jobs.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'foreman::service::jobs' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      let(:pre_condition) { 'include foreman' }
+
+      it { should compile.with_all_deps }
+
+      if os =~ /redhat/i
+        it { should contain_service('dynflow-executor').with({
+          'ensure'    => 'running',
+          'enable'    => true,
+          'name'      => 'dynflow-executor'
+        })}
+      elsif os =~ /debian/i
+        it { should contain_service('ruby-dynflow-executor').with({
+          'ensure'    => 'running',
+          'enable'    => true,
+          'name'      => 'ruby-dynflow-executor'
+        })}
+      end
+    end
+  end
+end


### PR DESCRIPTION
As per #18618, the dynflow executor is moving over to Foreman, in order
to support ActiveJob. Tasks will provide an UI and persistence layer for
Dynflow, but Foreman should be able to run jobs without it too.

Part of this effort includes moving the Dynflow executor over to
Foreman, which at the moment is managed by the foreman-tasks service.

https://github.com/theforeman/foreman/pull/4316 has to be merged before this