### PR TITLE
Add param for timeout to foreman() parser function

### DIFF
--- a/lib/puppet/parser/functions/foreman.rb
+++ b/lib/puppet/parser/functions/foreman.rb
@@ -27,6 +27,8 @@
 #                 in case of an given hash foreman() returns an array of hashes selecting only
 #                 attribute keys given in hash renamed to values of given keys. This can be used
 #                 to rename keys in result
+# 'timeout' is the Foreman request timeout in seconds as an integer.  
+#           This defaults to five seconds.
 #
 # Then, use a variable to capture its output:
 # $hosts = foreman($f)
@@ -53,6 +55,7 @@ module Puppet::Parser::Functions
     foreman_user  = args_hash["foreman_user"] || "admin"             # has foreman/puppet
     foreman_pass  = args_hash["foreman_pass"] || "changeme"          # on the same box
     filter_result = args_hash['filter_result'] || false
+    timeout       = args_hash['timeout']       || 5
 
     # extend this as required
     searchable_items = %w{ environments fact_values hosts hostgroups puppetclasses smart_proxies subnets }
@@ -71,7 +74,7 @@ module Puppet::Parser::Functions
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.scheme == 'https'
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
-      results = Timeout::timeout(5) { PSON.parse http.request(req).body }
+      results = Timeout::timeout(timeout) { PSON.parse http.request(req).body }
     rescue Exception => e
       raise Puppet::ParseError, "Failed to contact Foreman at #{foreman_url}: #{e}"
     end

--- a/lib/puppet/parser/functions/foreman.rb
+++ b/lib/puppet/parser/functions/foreman.rb
@@ -27,7 +27,7 @@
 #                 in case of an given hash foreman() returns an array of hashes selecting only
 #                 attribute keys given in hash renamed to values of given keys. This can be used
 #                 to rename keys in result
-# 'timeout' is the Foreman request timeout in seconds as an integer.  
+# 'timeout' is the Foreman request timeout in seconds as an integer.
 #           This defaults to five seconds.
 #
 # Then, use a variable to capture its output:
@@ -55,7 +55,7 @@ module Puppet::Parser::Functions
     foreman_user  = args_hash["foreman_user"] || "admin"             # has foreman/puppet
     foreman_pass  = args_hash["foreman_pass"] || "changeme"          # on the same box
     filter_result = args_hash['filter_result'] || false
-    timeout       = args_hash['timeout']       || 5
+    timeout       = (args_hash['timeout']      || 5).to_i
 
     # extend this as required
     searchable_items = %w{ environments fact_values hosts hostgroups puppetclasses smart_proxies subnets }

--- a/spec/functions/foreman_spec.rb
+++ b/spec/functions/foreman_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'webmock'
 
 describe 'foreman' do
   it 'should exist' do
@@ -7,6 +8,64 @@ describe 'foreman' do
 
   it 'should throw an error with no arguments' do
     is_expected.to run.with_params().and_raise_error(Puppet::ParseError)
+  end
+  
+  it 'should succeed with no timeout specified' do
+    stub_request(:get, "https://my_api_foreman_user:my_api_foreman_pass@foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass'
+    )
+  end
+
+  it 'should succeed with a non-default timeout specified' do
+    stub_request(:get, "https://my_api_foreman_user:my_api_foreman_pass@foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass',
+      'timeout'      => '15'
+    )
+  end
+
+  it 'should throw an "execution expired" error when the timeout is exceeded' do
+    stub_request(:get, "https://my_api_foreman_user:my_api_foreman_pass@foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass',
+      'timeout'      => '1'
+    ).and_raise_error(/execution expired/)
+  end
+  
+  it 'should not throw an "execution expired" error with the default timeout' do
+    stub_request(:get, "https://my_api_foreman_user:my_api_foreman_pass@foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass'
+    )
   end
 
   # TODO: Test functionality of the actual function.


### PR DESCRIPTION
Add parameter for timeout to foreman() parser function.  If unspecified, keep the default at 5sec.

This is useful if you are using the foreman() parser function to automatically populate templates, and you are using queries that occasionally take more than five seconds to complete.