### PR TITLE
Set ssl_ca_file in Hammer system-wide config file

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -24,6 +24,9 @@
 # $request_timeout::      API request timeout, set -1 for infinity
 #                         type:Integer[-1]
 #
+# $ssl_ca_file::          Path to SSL certificate authority
+#                         type:Optional[Stdlib::Absolutepath]
+#
 # $hammer_plugin_prefix:: Hammer plugin package prefix based normally on platform
 #                         type:String
 #
@@ -39,6 +42,7 @@ class foreman::cli (
   $password             = $::foreman::cli::params::password,
   $refresh_cache        = $::foreman::cli::params::refresh_cache,
   $request_timeout      = $::foreman::cli::params::request_timeout,
+  $ssl_ca_file          = $::foreman::cli::params::ssl_ca_file,
   $hammer_plugin_prefix = $::foreman::cli::params::hammer_plugin_prefix,
 ) inherits foreman::cli::params {
   # Inherit URL & auth parameters from foreman class if possible
@@ -49,13 +53,18 @@ class foreman::cli (
     $foreman_url_real = pick($foreman_url, $::foreman::foreman_url)
     $username_real    = pick($username, $::foreman::admin_username)
     $password_real    = pick($password, $::foreman::admin_password)
+    $ssl_ca_file_real = pick($ssl_ca_file, $::foreman::server_ssl_ca)
   } else {
     $foreman_url_real = $foreman_url
     $username_real    = $username
     $password_real    = $password
+    $ssl_ca_file_real = $ssl_ca_file
   }
   validate_string($foreman_url_real, $username_real, $password_real)
   validate_bool($manage_root_config, $refresh_cache)
+  if $ssl_ca_file_real {
+    validate_absolute_path($ssl_ca_file_real)
+  }
 
   package { 'foreman-cli':
     ensure => $version,

--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -7,6 +7,7 @@ class foreman::cli::params {
   $password = undef
   $refresh_cache = false
   $request_timeout = 120
+  $ssl_ca_file = undef
 
   # OS specific paths
   case $::osfamily {

--- a/spec/classes/foreman_cli_spec.rb
+++ b/spec/classes/foreman_cli_spec.rb
@@ -50,6 +50,27 @@ describe 'foreman::cli' do
           it { should_not contain_file('/root/.hammer') }
           it { should_not contain_file('/root/.hammer/cli.modules.d/foreman.yml') }
         end
+
+        context 'with ssl_ca_file' do
+          let(:params) do {
+            'foreman_url' => 'http://example.com',
+            'username'    => 'joe',
+            'password'    => 'secret',
+            'ssl_ca_file' => '/etc/ca.pub',
+          } end
+
+          describe '/etc/hammer/cli.modules.d/foreman.yml' do
+            it 'should contain settings' do
+              verify_exact_contents(catalogue, '/etc/hammer/cli.modules.d/foreman.yml', [
+                ":foreman:",
+                "  :enable_module: true",
+                "  :host: 'http://example.com'",
+                ":ssl:",
+                "  :ssl_ca_file: '/etc/ca.pub'",
+              ])
+            end
+          end
+        end
       end
 
       context 'with foreman' do
@@ -58,6 +79,7 @@ describe 'foreman::cli' do
           "class { 'foreman':
              admin_username => 'joe',
              admin_password => 'secret',
+             server_ssl_ca  => '/etc/puppetlabs/puppet/ssl/certs/ca.pub',
            }"
         end
 
@@ -69,6 +91,8 @@ describe 'foreman::cli' do
               ":foreman:",
               "  :enable_module: true",
               "  :host: 'https://#{facts[:fqdn]}'",
+              ":ssl:",
+              "  :ssl_ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pub'",
             ])
           end
         end

--- a/templates/hammer_etc.yml.erb
+++ b/templates/hammer_etc.yml.erb
@@ -4,3 +4,8 @@
 
   # Your foreman server address
   :host: '<%= @foreman_url_real %>'
+<% if @ssl_ca_file_real -%>
+
+:ssl:
+  :ssl_ca_file: '<%= @ssl_ca_file_real %>'
+<% end -%>


### PR DESCRIPTION
Defaults when used with main 'foreman' class to the server's CA file,
automatically ensuring Hammer CLI will trust the CA used.