### PR TITLE
Workaround puppet server ruby

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env tfm-ruby
 
 # Script usually acts as an ENC for a single host, with the certname supplied as argument
 #   if 'facts' is true, the YAML facts for the host are uploaded
@@ -115,7 +115,7 @@ def build_body(certname,filename)
   facts        = File.read(filename)
   puppet_facts = YAML::load(facts.gsub(/\!ruby\/object.*$/,''))
   hostname     = puppet_facts['values']['fqdn'] || certname
-  
+
   # if there is no environment in facts
   # get it from node file ({puppetdir}/yaml/node/
   unless puppet_facts['values'].key?('environment')
@@ -128,21 +128,21 @@ def build_body(certname,filename)
       end
     end
   end
-  
+
   begin
     require 'facter'
     puppet_facts['values']['puppetmaster_fqdn'] = Facter.value(:fqdn).to_s
   rescue LoadError => e
     puppet_facts['values']['puppetmaster_fqdn'] = `hostname -f`.strip
   end
-  
+
   # filter any non-printable char from the value, if it is a String
   puppet_facts['values'].each do |key, val|
     if val.is_a? String
       puppet_facts['values'][key] = val.scan(/[[:print:]]/).join
     end
   end
-  
+
   {'facts' => puppet_facts['values'], 'name' => hostname, 'certname' => certname}
 end
 


### PR DESCRIPTION
While originally working around this (https://tickets.puppetlabs.com/browse/MODULES-4256) puppet server issue, it does seem like this foreman installed script should be using the foreman installed ruby instance. Failing build seems to be related to a new parallels requirement for ruby >= 2.

I cleaned up some "hidden" spaces too...