### PR TITLE
Added pgsql cluster option

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -10,18 +10,27 @@ class foreman::database::postgresql {
     default => postgresql_password($::foreman::db_username, $::foreman::db_password),
   }
 
+  $replication_password = postgresql_password($::foreman::db_replication_username, $::foreman::db_replication_password)
+
+  $port = $::foreman::db_port ? {
+    'UNSET' => 5432,
+    default => $::foreman::db_port,
+  }
+
   # Prevents errors if run from /root etc.
   Postgresql_psql {
     cwd => '/',
   }
 
-  include ::postgresql::client, ::postgresql::server
+  class { "foreman::database::postgresql::${::foreman::db_node_type}": }
 
-  postgresql::server::db { $dbname:
-    user     => $::foreman::db_username,
-    password => $password,
-    owner    => $::foreman::db_username,
-    encoding => 'utf8',
-    locale   => 'en_US.utf8',
+  unless $::foreman::db_host == 'UNSET' {
+    postgresql::validate_db_connection { 'validate postgres connection':
+      database_host     => $::foreman::db_host,
+      database_username => $::foreman::db_username,
+      database_password => $::foreman::db_password,
+      database_name     => $dbname,
+      database_port     => $port,
+    }
   }
 }

--- a/manifests/database/postgresql/db_access.pp
+++ b/manifests/database/postgresql/db_access.pp
@@ -1,0 +1,27 @@
+# provides pg_hba rules for the Foreman app
+#
+#  === Parameters:
+#
+#  $address::  Address to allow access from
+#
+define foreman::database::postgresql::db_access(
+  $address=$name,
+) {
+  postgresql::server::pg_hba_rule { "allow ${address} access to ${::foreman::database::postgresql::dbname} database":
+    description => "Open up PostgreSQL for access from ${address}",
+    type        => 'host',
+    database    => $::foreman::database::postgresql::dbname,
+    user        => $::foreman::db_username,
+    address     => $address,
+    auth_method => 'md5',
+  }
+
+  postgresql::server::pg_hba_rule { "allow replication from ${address}":
+    description => "Open replication access from ${address}",
+    type        => 'host',
+    database    => 'replication',
+    user        => $::foreman::db_replication_username,
+    address     => $address,
+    auth_method => 'md5',
+  }
+}

--- a/manifests/database/postgresql/master.pp
+++ b/manifests/database/postgresql/master.pp
@@ -1,0 +1,48 @@
+# Set up the foreman master database using postgresql
+class foreman::database::postgresql::master(
+  $wal_keep_segments = 256
+) {
+  $db_all_cluster_hostnames = unique(concat($::foreman::db_cluster_hostnames, $::fqdn))
+
+  class {'::postgresql::server':
+    listen_addresses => '*',
+  }
+
+  if $::foreman::db_synchronous_names {
+    postgresql::server::config_entry { 'synchronous_standby_names':
+      value => join($::foreman::db_synchronous_names, ','),
+    }
+  }
+
+  postgresql::server::db { $::foreman::database::postgresql::dbname:
+    user     => $::foreman::db_username,
+    password => $::foreman::database::postgresql::password,
+    owner    => $::foreman::db_username,
+    encoding => 'utf8',
+    locale   => 'en_US.utf8',
+  }
+
+  foreman::database::postgresql::db_access { $db_all_cluster_hostnames: }
+
+  postgresql::server::role { $::foreman::db_replication_username:
+    password_hash => $::foreman::database::postgresql::replication_password,
+    replication   => true,
+  }
+
+  postgresql::server::config_entry { 'wal_level':
+    value => 'hot_standby',
+  }
+
+  postgresql::server::config_entry { 'max_wal_senders':
+    value => count($db_all_cluster_hostnames),
+  }
+
+  postgresql::server::config_entry { 'wal_keep_segments':
+    value => $wal_keep_segments,
+  }
+
+  postgresql::server::config_entry { 'hot_standby':
+    value => 'on',
+  }
+
+}

--- a/manifests/database/postgresql/slave.pp
+++ b/manifests/database/postgresql/slave.pp
@@ -1,0 +1,60 @@
+# Set up the foreman slave database using postgresql
+class foreman::database::postgresql::slave(
+  $wal_keep_segments = 256
+) {
+  require ::postgresql::params
+
+  $db_all_cluster_hostnames = unique(concat($::foreman::db_cluster_hostnames, $::fqdn))
+
+  file { 'Write .pgpass':
+    content => "*:*:*:${::foreman::db_replication_username}:${::foreman::db_replication_password}\n",
+    path    => "${::foreman::params::postgres_home}/.pgpass",
+    owner   => $::postgresql::params::user,
+    group   => $::postgresql::params::group,
+    mode    => '0600',
+  }
+  -> exec { 'Initialize new postgresql cluster':
+    command => "${::postgresql::params::bindir}/pg_basebackup -w -c fast -X stream -h ${::foreman::db_host} -p ${::foreman::database::postgresql::port} -U ${::foreman::db_replication_username} -D ${::postgresql::params::datadir}",
+    creates => "${::postgresql::params::datadir}/base",
+    user    => $::postgresql::params::user,
+  }
+  -> class {'::postgresql::server':
+    listen_addresses     => '*',
+    manage_recovery_conf => true,
+    needs_initdb         => false,
+  }
+
+  postgresql::server::recovery { 'Configure recovery.conf':
+    standby_mode     => 'on',
+    primary_conninfo => "host=${::foreman::db_host} port=${::foreman::database::postgresql::port} user=${::foreman::db_replication_username} password=${::foreman::db_replication_password}",
+    trigger_file     => "${::postgresql::params::datadir}/failover",
+  }
+
+  postgresql::server::role { $::foreman::db_username:
+    password_hash => $::foreman::database::postgresql::password,
+  }
+
+  foreman::database::postgresql::db_access { $db_all_cluster_hostnames: }
+
+  postgresql::server::role { $::foreman::db_replication_username:
+    password_hash => $::foreman::database::postgresql::replication_password,
+    replication   => true,
+  }
+
+  postgresql::server::config_entry { 'wal_level':
+    value => 'hot_standby',
+  }
+
+  postgresql::server::config_entry { 'max_wal_senders':
+    value => count($db_all_cluster_hostnames),
+  }
+
+  postgresql::server::config_entry { 'wal_keep_segments':
+    value => $wal_keep_segments,
+  }
+
+  postgresql::server::config_entry { 'hot_standby':
+    value => 'on',
+  }
+
+}

--- a/manifests/database/postgresql/standalone.pp
+++ b/manifests/database/postgresql/standalone.pp
@@ -1,0 +1,13 @@
+# Set up the foreman standalone database using postgresql
+class foreman::database::postgresql::standalone {
+  include ::postgresql::client, ::postgresql::server
+
+  postgresql::server::db { $::foreman::database::postgresql::dbname:
+    user     => $::foreman::db_username,
+    password => $::foreman::database::postgresql::password,
+    owner    => $::foreman::db_username,
+    encoding => 'utf8',
+    locale   => 'en_US.utf8',
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,16 @@
 #
 # $db_manage_rake::             if enabled, will run rake jobs, which depend on the database
 #
+# $db_node_type::               Cluster node type, can be 'standalone', 'master' or 'slave'.
+#
+# $db_cluster_hostnames::       List of hostnames in the cluster. Excluding this one.
+#
+# $db_synchronous_names::       List of hostnames in the cluster using synchronous replication.
+#
+# $db_replication_username::    Database username for replication.
+#
+# $db_replication_password::    Database password for replication.
+#
 # $app_root::                   Name of foreman root directory
 #
 # $manage_user::                Controls whether foreman module will manage the user on the system.
@@ -227,6 +237,11 @@ class foreman (
   Optional[String] $db_sslmode = 'UNSET',
   Integer[0] $db_pool = $::foreman::params::db_pool,
   Boolean $db_manage_rake = $::foreman::params::db_manage_rake,
+  Optional[Enum['master', 'slave', 'standalone']] $db_node_type = $::foreman::params::db_node_type,
+  Optional[Array[String]] $db_cluster_hostnames = $::foreman::params::db_cluster_hostnames,
+  Optional[Array[String]] $db_synchronous_names = $::foreman::params::db_synchronous_names,
+  Optional[String] $db_replication_username = $::foreman::params::db_replication_username,
+  Optional[String] $db_replication_password = $::foreman::params::db_replication_password,
   Stdlib::Absolutepath $app_root = $::foreman::params::app_root,
   Boolean $manage_user = $::foreman::params::manage_user,
   String $user = $::foreman::params::user,

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -95,6 +95,38 @@ describe 'foreman::database' do
           })
         }
       end
+
+       describe 'with master db_node_type ' do
+        let :pre_condition do
+          "class { 'foreman':
+            db_node_type         => 'master',
+            db_cluster_hostnames => ['slave.example.com'],
+            db_host              => 'vip.example.com',
+          }"
+        end
+
+        it { should_not contain_class('foreman::database::mysql') }
+        it { should_not contain_class('foreman::database::postgresql::slave') }
+        it { should contain_class('foreman::database::postgresql') }
+        it { should contain_class('postgresql::server') }
+        it { should contain_class('foreman::database::postgresql::master') }
+      end
+
+      describe 'with slave db_node_type ' do
+        let :pre_condition do
+          "class { 'foreman':
+            db_node_type         => 'slave',
+            db_cluster_hostnames => ['slave.example.com'],
+            db_host              => 'vip.example.com',
+          }"
+        end
+
+        it { should_not contain_class('foreman::database::mysql') }
+        it { should_not contain_class('foreman::database::postgresql::master') }
+        it { should contain_class('foreman::database::postgresql') }
+        it { should contain_class('postgresql::server') }
+        it { should contain_class('foreman::database::postgresql::slave') }
+      end
     end
   end
 end

--- a/spec/classes/foreman_puppetmaster_spec.rb
+++ b/spec/classes/foreman_puppetmaster_spec.rb
@@ -111,11 +111,12 @@ describe 'foreman::puppetmaster' do
   context 'Amazon' do
     let :facts do
       {
-        :operatingsystem => 'Amazon',
-        :rubyversion     => '1.8.7',
-        :osfamily        => 'Linux',
-        :puppetversion   => Puppet.version,
-        :rubysitedir     => '/usr/lib/ruby/site_ruby',
+        :operatingsystemrelease => '7.0',
+        :operatingsystem        => 'Amazon',
+        :rubyversion            => '1.8.7',
+        :osfamily               => 'Linux',
+        :puppetversion          => Puppet.version,
+        :rubysitedir            => '/usr/lib/ruby/site_ruby',
       }
     end
 

--- a/spec/defines/foreman_database_postgresql_db_access_spec.rb
+++ b/spec/defines/foreman_database_postgresql_db_access_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe 'foreman::database::postgresql::db_access' do
+  let(:title) { 'foreman' }
+
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'as master' do
+        let :pre_condition do
+          "class { '::foreman':
+              db_database          => 'foreman',
+              db_username          => 'foreman',
+              db_cluster_hostnames => ['vip.example.com'],
+              db_host              => 'vip.example.com',
+              db_node_type         => 'master',
+          }"
+        end
+
+        it { is_expected.to contain_class('foreman::database::postgresql::master') }
+
+        it { should contain_postgresql__server__pg_hba_rule("allow vip.example.com access to foreman database").with({
+          :type        => 'host',
+          :database    => 'foreman',
+          :user        => 'foreman',
+          :address     => 'vip.example.com',
+          :auth_method => 'md5',
+        }) }
+
+        it { should contain_postgresql__server__pg_hba_rule("allow replication from vip.example.com").with({
+         :type        => 'host',
+         :database    => 'replication',
+         :user        => 'foreman-replicator',
+         :address     => 'vip.example.com',
+         :auth_method => 'md5',
+        }) }
+      end
+
+      context 'as slave' do
+        let :pre_condition do
+          "class { '::foreman':
+              db_database          => 'foreman',
+              db_username          => 'foreman',
+              db_cluster_hostnames => ['vip.example.com'],
+              db_host              => 'vip.example.com',
+              db_node_type         => 'slave',
+          }"
+        end
+
+        it { is_expected.to contain_class('foreman::database::postgresql::slave') }
+
+        it { should contain_postgresql__server__pg_hba_rule("allow vip.example.com access to foreman database").with({
+          :type        => 'host',
+          :database    => 'foreman',
+          :user        => 'foreman',
+          :address     => 'vip.example.com',
+          :auth_method => 'md5',
+        }) }
+
+        it { should contain_postgresql__server__pg_hba_rule("allow replication from vip.example.com").with({
+         :type        => 'host',
+         :database    => 'replication',
+         :user        => 'foreman-replicator',
+         :address     => 'vip.example.com',
+         :auth_method => 'md5',
+        }) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to setup a HA pgSQL cluster using Streaming Replication.

On a master, you can do:
`--foreman-db-node-type master --foreman-db-cluster-hostnames node2.example.com --foreman-db-host foreman-vip.example.com`

One a slave, you can do:
`--foreman-db-node-type slave --foreman-db-cluster-hostnames node1.example.com --foreman-db-host foreman-vip.example.com --foreman-db-username <SAME AS MASTER> --foreman-db-replication-password <SAME AS MASTER>`

Failover should be just as simple as touching the trigger file. e.g `touch /var/lib/pgsql/data/failover`. You can then set `--foreman-db-node-type master` for consistency.
If the master then recovers you can do `rm -rf /var/lib/pgsql/data/` and then set the machine up as a slave.

By default slaves are asynchronous, slaves can be set to synchronous using the `--foreman-db-synchronous-names` option, though don't do this during initial setup as if the slaves aren't running yet it will result in a error.