### PR TITLE
Limit number of parallel_test processes

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,9 @@
   beaker_sets:
     - docker/centos-7
     - docker/debian-8
+  env:
+    global:
+      - PARALLEL_TEST_PROCESSORS=16
 Gemfile:
   extra:
     - gem: webmock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@
 rvm:
   - 2.1.5
 env:
-  # First test the major distros
-  - PUPPET_VERSION=4.6 ONLY_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
-  # Test the rest of the supported platforms
-  - PUPPET_VERSION=4.6 EXCLUDE_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,scientific-7-x86_64
+  global:
+    - PARALLEL_TEST_PROCESSORS=16
+  matrix:
+    # First test the major distros
+    - PUPPET_VERSION=4.6 ONLY_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
+    # Test the rest of the supported platforms
+    - PUPPET_VERSION=4.6 EXCLUDE_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,scientific-7-x86_64
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Prevent test jobs being killed for excessive resource consumption on
Travis CI.

---

Example failure: https://api.travis-ci.org/jobs/219217285/log.txt?deansi=true (see "Killed" part way down, running 32 processes).

Corresponding modulesync change made in https://github.com/theforeman/foreman-installer-modulesync/pull/59.