### PR TITLE
Add features property to foreman_smartproxy to check enabled features

### DIFF
--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -1,6 +1,8 @@
 Puppet::Type.newtype(:foreman_smartproxy) do
   desc 'foreman_smartproxy registers a smartproxy in foreman.'
 
+  feature :feature_validation, "Enabled features can be validated", methods: [:features, :features=]
+
   ensurable
 
   newparam(:name, :namevar => true) do
@@ -21,6 +23,18 @@ Puppet::Type.newtype(:foreman_smartproxy) do
 
   newparam(:consumer_secret) do
     desc 'Foreman oauth consumer_secret'
+  end
+
+  newproperty(:features, required_features: :feature_validation, array_matching: :all) do
+    desc 'Features expected to be enabled on the smart proxy. Setting this
+      validates that all of the listed features are functional, according to
+      the list of enabled features returned when registering or refreshing the
+      smart proxy.'
+    defaultto []
+
+    def insync?(current)
+      (@should.sort - current.sort).empty?
+    end
   end
 
   newparam(:ssl_ca) do

--- a/spec/unit/foreman_smartproxy_spec.rb
+++ b/spec/unit/foreman_smartproxy_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:foreman_smartproxy) do
+  describe 'features' do
+    it { expect(described_class.new(name: 's').property(:features).insync?([])).to eq(true) }
+    it { expect(described_class.new(name: 's', features: ['Logs']).property(:features).insync?(['Logs'])).to eq(true) }
+    it { expect(described_class.new(name: 's', features: ['Logs']).property(:features).insync?(['Logs', 'Other'])).to eq(true) }
+    it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?(['Logs', 'TFTP'])).to eq(true) }
+    it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?(['Logs'])).to eq(false) }
+    it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?([])).to eq(false) }
+  end
+end


### PR DESCRIPTION
Implemented on the rest_v3 provider to validate that the enabled
features found by Foreman include all of the features listed in the
'features' property on the resource.

This should detect configuration errors on the smart proxy, or missing
Foreman plugins for the registered smart proxy.