### PR TITLE
Improve formatting of foreman_smartproxy feature lists

### DIFF
--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -35,6 +35,11 @@ Puppet::Type.newtype(:foreman_smartproxy) do
     def insync?(current)
       (@should.sort - current.sort).empty?
     end
+
+    def is_to_s(value)
+      "[#{value.sort.map(&:inspect).join(', ')}]"
+    end
+    alias should_to_s is_to_s
   end
 
   newparam(:ssl_ca) do

--- a/spec/unit/foreman_smartproxy_spec.rb
+++ b/spec/unit/foreman_smartproxy_spec.rb
@@ -8,5 +8,7 @@ describe Puppet::Type.type(:foreman_smartproxy) do
     it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?(['Logs', 'TFTP'])).to eq(true) }
     it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?(['Logs'])).to eq(false) }
     it { expect(described_class.new(name: 's', features: ['TFTP', 'Logs']).property(:features).insync?([])).to eq(false) }
+    it { expect(described_class.new(name: 's').property(:features).is_to_s(['Foo', 'Bar'])).to eq('["Bar", "Foo"]') }
+    it { expect(described_class.new(name: 's').property(:features).should_to_s(['Foo', 'Bar'])).to eq('["Bar", "Foo"]') }
   end
 end


### PR DESCRIPTION
Originally:

    change from ["Logs", "Puppet CA", "TFTP"] to Puppet Puppet CA TFTP Logs failed

Now:

    change from [Logs, Puppet CA, TFTP] to [Logs, Puppet, Puppet CA, TFTP] failed