### PR TITLE
Remove redundant directory definition

### DIFF
--- a/spec/classes/foreman_config_passenger_spec.rb
+++ b/spec/classes/foreman_config_passenger_spec.rb
@@ -110,7 +110,7 @@ describe 'foreman::config::passenger' do
             :keepalive               => 'on',
             :max_keepalive_requests  => 100,
             :keepalive_timeout       => 5,
-            :custom_fragment         => %r{^<Directory #{params[:app_root]}/public>$},
+            :custom_fragment         => %r{^<Directory ~ #{params[:app_root]}/public/\(assets\|webpack\)>$},
           })
         end
 
@@ -142,7 +142,7 @@ describe 'foreman::config::passenger' do
             :keepalive               => 'on',
             :max_keepalive_requests  => 100,
             :keepalive_timeout       => 5,
-            :custom_fragment         => %r{^<Directory #{params[:app_root]}/public>$},
+            :custom_fragment         => %r{^<Directory ~ #{params[:app_root]}/public/\(assets\|webpack\)>$},
           })
         end
       end

--- a/templates/_assets.conf.erb
+++ b/templates/_assets.conf.erb
@@ -1,16 +1,5 @@
 # Static public dir serving
 <% unless @suburi %>
-<Directory <%= @docroot %>>
-
-  <IfVersion < 2.4>
-    Allow from all
-  </IfVersion>
-  <IfVersion >= 2.4>
-    Require all granted
-  </IfVersion>
-
-</Directory>
-
 <Directory ~ <%= @docroot %>/(assets|webpack)>
 
   # Use standard http expire header for assets instead of ETag


### PR DESCRIPTION
The standard puppetlabs-vhost already generates a directory location for the docroot with a Require all granted. It also does the version logic in puppet code resulting in a shorter config file.

For reference the generated config file from a katello host without this change:

```

<VirtualHost *:443>
  ServerName pipeline-katello-nightly-centos7.example.com

  ## Vhost docroot
  DocumentRoot "/usr/share/foreman/public"

  ## Directories, there should at least be a declaration for /usr/share/foreman/public

  <Directory "/usr/share/foreman/public">
    Options SymLinksIfOwnerMatch
    AllowOverride None
    Require all granted
  </Directory>

  ## Load additional static includes
  IncludeOptional "/etc/httpd/conf.d/05-foreman-ssl.d/*.conf"

  ## Logging
  ErrorLog "/var/log/httpd/foreman-ssl_error_ssl.log"
  ServerSignature Off
  CustomLog "/var/log/httpd/foreman-ssl_access_ssl.log" combined

  ## Server aliases
  ServerAlias foreman

  ## SSL directives
  SSLEngine on
  SSLCertificateFile      "/etc/pki/katello/certs/katello-apache.crt"
  SSLCertificateKeyFile   "/etc/pki/katello/private/katello-apache.key"
  SSLCertificateChainFile "/etc/pki/katello/certs/katello-server-ca.crt"
  SSLCACertificateFile    "/etc/pki/katello/certs/katello-default-ca.crt"
  SSLVerifyClient         optional
  SSLVerifyDepth          3
  SSLOptions +StdEnvVars +ExportCertData

  ## Custom fragment
  # Static public dir serving

<Directory /usr/share/foreman/public>

  <IfVersion < 2.4>
    Allow from all
  </IfVersion>
  <IfVersion >= 2.4>
    Require all granted
  </IfVersion>

</Directory>

<Directory ~ /usr/share/foreman/public/(assets|webpack)>

  # Use standard http expire header for assets instead of ETag
  <IfModule mod_expires.c>
    Header unset ETag
    FileETag None
    ExpiresActive On
    ExpiresDefault "access plus 1 year"
  </IfModule>

  # Return compressed assets if they are precompiled
  <IfModule mod_rewrite.c>
    RewriteEngine on
    # Make sure the browser supports gzip encoding and file with .gz added
    # does exist on disc before we rewrite with the extension
    RewriteCond %{HTTP:Accept-Encoding} \b(x-)?gzip\b
    RewriteCond %{REQUEST_FILENAME} \.(css|js|svg)$
    RewriteCond %{REQUEST_FILENAME}.gz -s
    RewriteRule ^(.+) $1.gz [L]
    # Set headers for all possible assets which are compressed
    <FilesMatch \.css\.gz$>
      ForceType text/css
      Header set Content-Encoding gzip
      SetEnv no-gzip
    </FilesMatch>
    <FilesMatch \.js\.gz$>
      ForceType text/javascript
      Header set Content-Encoding gzip
      SetEnv no-gzip
    </FilesMatch>
    <FilesMatch \.svg\.gz$>
      ForceType image/svg+xml
      Header set Content-Encoding gzip
      SetEnv no-gzip
    </FilesMatch>
  </IfModule>

</Directory>



  PassengerAppRoot /usr/share/foreman
  PassengerRuby /usr/bin/tfm-ruby
  PassengerMinInstances 1
  PassengerStartTimeout 600
  PassengerPreStart https://pipeline-katello-nightly-centos7.example.com:443

  AddDefaultCharset UTF-8
  KeepAlive on
  KeepAliveTimeout 5
  MaxKeepAliveRequests 10000
</VirtualHost>
```