### PR TITLE
Fixes #20079 - SSL secured and verified Pg connection

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -10,6 +10,22 @@ class foreman::database::postgresql {
     default => postgresql_password($::foreman::db_username, $::foreman::db_password),
   }
 
+  if $::foreman::db_root_cert {
+    $pg_cert_dir = "${::foreman::app_root}/.postgresql/"
+
+    file { $pg_cert_dir:
+      ensure => 'directory',
+    }
+
+    file { "${pg_cert_dir}/root.crt":
+      ensure => file,
+      source => $::foreman::db_root_cert,
+      owner  => 'root',
+      group  => $::foreman::group,
+      mode   => '0640',
+    }
+  }
+
   # Prevents errors if run from /root etc.
   Postgresql_psql {
     cwd => '/',

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -15,6 +15,9 @@ class foreman::database::postgresql {
 
     file { $pg_cert_dir:
       ensure => 'directory',
+      owner  => 'root',
+      group  => $::foreman::group,
+      mode   => '0640',
     }
 
     file { "${pg_cert_dir}/root.crt":

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -11,7 +11,7 @@ class foreman::database::postgresql {
   }
 
   if $::foreman::db_root_cert {
-    $pg_cert_dir = "${::foreman::app_root}/.postgresql/"
+    $pg_cert_dir = "${::foreman::app_root}/.postgresql"
 
     file { $pg_cert_dir:
       ensure => 'directory',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -227,7 +227,7 @@ class foreman (
   Optional[String] $db_username = $::foreman::params::db_username,
   Optional[String] $db_password = $::foreman::params::db_password,
   Optional[String] $db_sslmode = 'UNSET',
-  Optional[String] $db_root_cert = 'UNSET',
+  Optional[String] $db_root_cert = undef,
   Integer[0] $db_pool = $::foreman::params::db_pool,
   Boolean $db_manage_rake = $::foreman::params::db_manage_rake,
   Stdlib::Absolutepath $app_root = $::foreman::params::app_root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -299,6 +299,13 @@ class foreman (
   } else {
     $db_adapter_real = $db_adapter
   }
+
+  if $db_sslmode == 'UNSET' and $db_root_cert and $db_type == 'postgresql' {
+    $db_sslmode_real = 'verify-full'
+  } else {
+    $db_sslmode_real = $db_sslmode
+  }
+
   if $passenger == false and $ipa_authentication {
     fail("${::hostname}: External authentication via IPA can only be enabled when passenger is used.")
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,8 @@
 #
 # $db_sslmode::                 Database 'production' ssl mode
 #
+# $db_root_cert::               Root cert used to verify SSL connection to postgres
+#
 # $db_pool::                    Database 'production' size of connection pool
 #
 # $db_manage_rake::             if enabled, will run rake jobs, which depend on the database
@@ -225,6 +227,7 @@ class foreman (
   Optional[String] $db_username = $::foreman::params::db_username,
   Optional[String] $db_password = $::foreman::params::db_password,
   Optional[String] $db_sslmode = 'UNSET',
+  Optional[String] $db_root_cert = 'UNSET',
   Integer[0] $db_pool = $::foreman::params::db_pool,
   Boolean $db_manage_rake = $::foreman::params::db_manage_rake,
   Stdlib::Absolutepath $app_root = $::foreman::params::app_root,

--- a/templates/database.yml.erb
+++ b/templates/database.yml.erb
@@ -35,7 +35,7 @@ production:
 <% unless (port = scope.lookupvar("::foreman::db_port")) == 'UNSET' -%>
   port: <%= port %>
 <% end -%>
-<% unless (sslmode = scope.lookupvar("::foreman::db_sslmode")) == 'UNSET' -%>
+<% unless (sslmode = scope.lookupvar("::foreman::db_sslmode_real")) == 'UNSET' -%>
   sslmode: <%= sslmode %>
 <% end -%>
   database: <%= database %>


### PR DESCRIPTION
To setup DB with SSL and verification use params:

  db_sslmode => 'verify-full',
  db_root_cert => 'ca_bundle.pem'

Default DB sslmode is 'prefer' - non-verified SSL with fallback to
non-SSL. To use SSL secured connection with CA verification sslmode
needs to be set to either 'verify-ca' or 'verify-full'. Underlying libpg
uses DB root cert stored at '~/.postgresql/root.crt' which is in case of
Foreman at '/usr/share/foreman/.postgresql/root.crt'. There is no way to
setup different path (besides using env vars). System CA trust is not
supported. The cert needs to be real file as links are not allowed too.

For more details see SSL support in libpg:
  https://www.postgresql.org/docs/9.2/static/libpq-ssl.html