### PR TITLE
Remove discovery image downloading

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,6 @@ fixtures:
     postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
     puppet:           'git://github.com/theforeman/puppet-puppet'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'
-    tftp:             'git://github.com/theforeman/puppet-tftp'
 
 
   symlinks:

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -2,37 +2,7 @@
 #
 # This class installs discovery plugin and images
 #
-# === Parameters:
-#
-# $install_images::  should the installer download and setup discovery images
-#                    for you? the average size is few hundreds of MB
-#
-# $tftp_root::       TFTP root to install image into
-#
-# $source_url::      source URL to download from
-#
-# $image_name::      tarball with images
-#
-class foreman::plugin::discovery (
-  Boolean $install_images = $::foreman::plugin::discovery::params::install_images,
-  Stdlib::Absolutepath $tftp_root = $::foreman::plugin::discovery::params::tftp_root,
-  Stdlib::HTTPUrl $source_url = $::foreman::plugin::discovery::params::source_url,
-  String $image_name = $::foreman::plugin::discovery::params::image_name,
-) inherits foreman::plugin::discovery::params {
+class foreman::plugin::discovery {
   foreman::plugin {'discovery':
-  }
-
-  if $install_images {
-    $tftp_root_clean = regsubst($tftp_root, '/$', '')
-
-    foreman::remote_file {"${tftp_root_clean}/boot/${image_name}":
-      remote_location => "${source_url}${image_name}",
-      mode            => '0644',
-    } ~> exec { "untar ${image_name}":
-      command => "tar xf ${image_name}",
-      path    => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      cwd     => "${tftp_root_clean}/boot",
-      creates => "${tftp_root_clean}/boot/fdi-image/initrd0.img",
-    }
   }
 }

--- a/manifests/plugin/discovery/params.pp
+++ b/manifests/plugin/discovery/params.pp
@@ -1,7 +1,0 @@
-# Default parameters for foreman::plugin::discovery
-class foreman::plugin::discovery::params {
-  $install_images = false
-  $tftp_root      = lookup('tftp::root')
-  $source_url     = 'http://downloads.theforeman.org/discovery/releases/latest/'
-  $image_name     = 'fdi-image-latest.tar'
-}

--- a/metadata.json
+++ b/metadata.json
@@ -13,10 +13,6 @@
   ],
   "dependencies": [
     {
-      "name": "theforeman/tftp",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
-    },
-    {
       "name": "puppetlabs/apache",
       "version_requirement": ">= 2.0.0 < 3.0.0"
     },

--- a/spec/classes/plugin/discovery_spec.rb
+++ b/spec/classes/plugin/discovery_spec.rb
@@ -1,51 +1,5 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::discovery' do
-  on_os_under_test.each do |os, facts|
-    context "on #{os}" do
-      let(:facts) { facts }
-
-      let(:pre_condition) { 'include foreman' }
-
-      case facts[:operatingsystem]
-        when 'Debian'
-          tftproot = '/srv/tftp'
-        when 'FreeBSD'
-          tftproot = '/tftpboot'
-        else
-          tftproot = '/var/lib/tftpboot'
-      end
-
-      describe 'without paramaters' do
-        it { should compile.with_all_deps }
-        it { should contain_foreman__plugin('discovery') }
-        it { should_not contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar") }
-      end
-
-      describe 'with install_images => true' do
-        let :params do
-          {
-            :install_images => true
-          }
-        end
-
-        it { should compile.with_all_deps }
-        it { should contain_foreman__plugin('discovery') }
-
-        it 'should download and install tarball' do
-          should contain_foreman__remote_file("#{tftproot}/boot/fdi-image-latest.tar").
-            with_remote_location('http://downloads.theforeman.org/discovery/releases/latest/fdi-image-latest.tar')
-        end
-
-        it 'should extract the tarball' do
-          should contain_exec('untar fdi-image-latest.tar').with({
-            'command' => 'tar xf fdi-image-latest.tar',
-            'path' => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            'cwd' => "#{tftproot}/boot",
-            'creates' => "#{tftproot}/boot/fdi-image/initrd0.img",
-          })
-        end
-      end
-    end
-  end
+  include_examples 'basic foreman plugin tests', 'discovery'
 end


### PR DESCRIPTION
The image downloading is tied to tftp and handled by the proxy. Since puppet-foreman_proxy is already able to download images there's no sense in duplicating the code here.

Based on https://github.com/theforeman/puppet-foreman/pull/486

I think this also needs installer migrations to remove the answers.

Closes GH-580
Closes GH-581