### PR TITLE
Fixes #21072 - build apipie cache after plugins

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -44,8 +44,6 @@ class foreman::database {
     ~> foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
     }
-    ~> foreman::rake { 'apipie:cache:index':
-      timeout => 0,
-    }
+    ~> Foreman::Rake['apipie:cache:index']
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -311,6 +311,9 @@ class foreman (
   }
 
   include ::foreman::repo
+  foreman::rake { 'apipie:cache:index':
+    timeout => 0,
+  }
 
   Class['foreman::repo']
   ~> class { '::foreman::install': }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -17,6 +17,7 @@ define foreman::plugin(
   package { $real_package:
     ensure => $version,
   }
+  ~> Foreman::Rake['apipie:cache:index']
 
   if $config {
     file { $config_file:

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -58,7 +58,6 @@ describe 'foreman::database' do
         it { should_not contain_foreman__rake('db:migrate') }
         it { should_not contain_foreman_config_entry('db_pending_seed') }
         it { should_not contain_foreman__rake('db:seed') }
-        it { should_not contain_foreman__rake('apipie:cache:index') }
       end
 
       describe 'with seed parameters' do


### PR DESCRIPTION
Installation of the plugins can influence the API
and the apipie cache needs to be refreshed after that.