### PR TITLE
metadata.json: bump allowed version of puppet-extlib to 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "puppet/extlib",
-      "version_requirement": ">= 0.10.4 < 2.0.0"
+      "version_requirement": ">= 0.10.4 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Recently, version 2.0.0 was released and it does not contain any
breaking changes. See https://forge.puppet.com/puppet/extlib/changelog#v200-2017-10-11
for details.

Currently puppet module list --tree throws following warnings because of
this:

Warning: Module 'puppet-extlib' (v2.0.0) fails to meet some dependencies:
  'theforeman-foreman' (v8.1.0) requires 'puppet-extlib' (>= 0.10.4 < 2.0.0)