### PR TITLE
add plugin foreman_column_view

### DIFF
--- a/manifests/plugin/column_view.pp
+++ b/manifests/plugin/column_view.pp
@@ -1,0 +1,15 @@
+# @summary Install the column view plugin and optionally manage the configuration file
+#
+# @param columns
+#   an hash of columns to add to the configuration
+#
+class foreman::plugin::column_view (
+  Hash[String, Hash] $columns = {},
+){
+  # https://projects.theforeman.org/issues/21398
+  assert_type(Hash[String, Foreman::Column_view_column], $columns)
+
+  foreman::plugin { 'column_view':
+    config => template('foreman/foreman_column_view.yaml.erb'),
+  }
+}

--- a/spec/classes/plugin/column_view_spec.rb
+++ b/spec/classes/plugin/column_view_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::column_view' do
+  include_examples 'basic foreman plugin tests', 'column_view'
+
+  context 'with columns hash architecture' do
+    let(:params) do
+      {
+        'columns' => {
+          'architecture' => {
+            'title' => 'Architecture',
+            'after' => 'last_report',
+            'content' => 'facts_hash["architecture"]',
+          }
+        }
+      }
+    end
+
+    it { is_expected.to contain_file('/etc/foreman/plugins/foreman_column_view.yaml').with_content(/.*:title: Architecture.*/) }
+
+    it { is_expected.to compile.with_all_deps }
+  end
+
+  context 'with columns hash architecture and console' do
+    let(:params) do
+      {
+        'columns' => {
+          'architecture' => {
+            'title' => 'Architecture',
+            'after' => 'last_report',
+            'content' => 'facts_hash["architecture"]',
+          },
+          'console' => {
+            'title' => 'Console',
+            'after' => '0',
+            'content' => 'link_to(_("Console"), "https://#{host.interfaces.first.name}.domainname", { :class => "btn btn-info" } )',
+	    'conditional' => ':bmc_available?',
+	    'eval_content' => 'true',
+	    'view' => ':hosts_properties',
+          }
+        }
+      }
+    end
+
+    it { is_expected.to contain_file('/etc/foreman/plugins/foreman_column_view.yaml').with_content(/.*:title: Console.*/) }
+
+    it { is_expected.to compile.with_all_deps }
+  end
+
+  context 'with columns hash broken' do
+    let(:params) do
+      {
+        'columns' => {
+          'broken' => {
+            'title' => 'Broken',
+          }
+        }
+      }
+    end
+
+    it { is_expected.to compile.and_raise_error(%r{broken}) }
+  end
+end

--- a/templates/foreman_column_view.yaml.erb
+++ b/templates/foreman_column_view.yaml.erb
@@ -1,0 +1,12 @@
+<%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
+#
+# See tfm-rubygem-foreman_column_view-doc and /opt/theforeman/tfm/root/usr/share/gems/gems/foreman_column_view-0.3.0/README.md for more information
+:column_view:
+<% if @columns -%>
+<%   @columns.each do |column, hash| -%>
+  :<%= column %>:
+<%     hash.each do |key,value| -%>
+    :<%= key %>: <%= value %>
+<%     end -%>
+<%   end -%>
+<% end -%>

--- a/types/column_view_column.pp
+++ b/types/column_view_column.pp
@@ -1,0 +1,12 @@
+type Foreman::Column_view_column = Struct[
+  {
+    title => String[1],
+    after => String[1],
+    content => String[1],
+    Optional['conditional'] => String[1],
+    Optional['eval_content'] => String[1],
+    Optional['view'] => String[1],
+    Optional['width'] => String[1],
+    Optional['custom_method'] => String[1],
+  }
+]


### PR DESCRIPTION
This PR adds support for the plugin foreman_column_view.

In my tests it worked fine, but there are some points I am not sure about:
* I used Puppet 4+ Datatypes in an excessive way for validation as some other code is already doing this but only in a much more simple way
* I fear using a hash of hashes will not work with kafo, only with Puppet
* I only added the default tests and one positive test for the configuration file, no negative one to fail if configuration is wrong
* Changes of the plugin's configuration require a restart of Foreman which I did not address

Please let me know if something requires a change in the PR.