### PR TITLE
Fixes #18757 - Handle dynflow service in foreman core

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ previous stable release.
 
 ### Foreman version compatibility notes
 
+For Foreman 1.16 or older, please set the `dynflow_in_core` parameter to false.
 For Foreman 1.11 or older, please use the 5.x release series of this module.
 
 ## Types and providers

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -203,6 +203,9 @@
 #
 # $dynflow_pool_size::          How many workers should Dynflow use
 #
+# $jobs_service::               Name of the service for running the background Dynflow executor
+#
+# $dynflow_in_core::            Whether the Dynflow executor service is provided by Foreman or tasks
 class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
   Boolean $puppetrun = $::foreman::params::puppetrun,
@@ -298,6 +301,8 @@ class foreman (
   Optional[String] $email_smtp_user_name = $::foreman::params::email_smtp_user_name,
   Optional[String] $email_smtp_password = $::foreman::params::email_smtp_password,
   Integer[0, 65535] $dynflow_pool_size = $::foreman::params::dynflow_pool_size,
+  Optional[String] $jobs_service = $::foreman::params::jobs_service,
+  Boolean $dynflow_in_core = $::foreman::params::dynflow_in_core,
 ) inherits foreman::params {
   if $db_adapter == 'UNSET' {
     $db_adapter_real = $::foreman::db_type ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,6 +95,13 @@ class foreman::params {
 
   # Configure how many workers should Dynflow use
   $dynflow_pool_size = 5
+  # Defines whether Foreman or the tasks plugin provides the Dynflow executor
+  $dynflow_in_core = true
+
+  # Define job processing service properties
+  $jobs_service = undef
+  $jobs_service_ensure = 'running'
+  $jobs_service_enable = true
 
   # OS specific paths
   case $::osfamily {

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -1,9 +1,8 @@
 # Installs foreman_ansible plugin
 class foreman::plugin::ansible {
-
   include ::foreman::plugin::tasks
 
   foreman::plugin {'ansible':
-    notify => Service['foreman-tasks'],
+    notify => Class['foreman::service::jobs'],
   }
 }

--- a/manifests/plugin/remote_execution.pp
+++ b/manifests/plugin/remote_execution.pp
@@ -1,9 +1,8 @@
 # Installs foreman_remote_execution plugin
 class foreman::plugin::remote_execution {
-
   include ::foreman::plugin::tasks
 
   foreman::plugin {'remote_execution':
-    notify => Service['foreman-tasks'],
+    notify => Class['foreman::service::jobs'],
   }
 }

--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -6,25 +6,20 @@
 #
 # $package:: Package name to install, use ruby193-rubygem-foreman-tasks on Foreman 1.8/1.9 on EL
 #
-# $service:: Service name
-#
 # $automatic_cleanup:: Enable automatic task cleanup using a cron job
 #
 # $cron_line:: Cron line defining when the cleanup cron job should run
 #
 class foreman::plugin::tasks(
   String $package = $::foreman::plugin::tasks::params::package,
-  String $service = $::foreman::plugin::tasks::params::service,
   Boolean $automatic_cleanup = $::foreman::plugin::tasks::params::automatic_cleanup,
   String $cron_line = $::foreman::plugin::tasks::params::cron_line,
 ) inherits foreman::plugin::tasks::params {
+  include ::foreman::service::jobs
+
   foreman::plugin { 'tasks':
     package => $package,
-  }
-  ~> service { 'foreman-tasks':
-    ensure => running,
-    enable => true,
-    name   => $service,
+    notify  => Class['foreman::service::jobs'],
   }
   $cron_state = $automatic_cleanup ? {
     true    => 'present',

--- a/manifests/plugin/tasks/params.pp
+++ b/manifests/plugin/tasks/params.pp
@@ -4,7 +4,6 @@ class foreman::plugin::tasks::params {
   $cron_line = '45 19 * * *'
   case $::osfamily {
     'RedHat': {
-      $service = 'foreman-tasks'
       case $::operatingsystem {
         'fedora': {
           $package = 'rubygem-foreman-tasks'
@@ -16,7 +15,6 @@ class foreman::plugin::tasks::params {
     }
     'Debian': {
       $package = 'ruby-foreman-tasks'
-      $service = 'ruby-foreman-tasks'
     }
     /^(FreeBSD|DragonFly)$/: {
       # do nothing to not break foreman-installer

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,15 @@
 # Configure the foreman service
 class foreman::service(
-  $passenger = $::foreman::passenger,
-  $app_root  = $::foreman::app_root,
-  $ssl       = $::foreman::ssl,
+  $passenger       = $::foreman::passenger,
+  $app_root        = $::foreman::app_root,
+  $ssl             = $::foreman::ssl,
+  $dynflow_in_core = $::foreman::dynflow_in_core,
 ) {
   anchor { ['foreman::service_begin', 'foreman::service_end']: }
+
+  if $dynflow_in_core {
+    contain ::foreman::service::jobs
+  }
 
   if $passenger {
     exec {'restart_foreman':

--- a/manifests/service/jobs.pp
+++ b/manifests/service/jobs.pp
@@ -1,0 +1,31 @@
+# = Jobs service
+#
+# Service to start a Dynflow daemon for background job processing in Foreman.
+#
+# === Parameters:
+#
+# $service:: The name of the service
+#
+# $ensure:: State the service should be in
+#
+# $enable:: Whether to enable the service or not
+
+class foreman::service::jobs(
+  Optional[String] $service = undef,
+  Enum['running', 'stopped'] $ensure = 'running',
+  Boolean $enable = true,
+) {
+  if $service {
+    $_service = $service
+  } else {
+    $_service = $::osfamily ? {
+      'Debian' => 'ruby-foreman-tasks',
+      default  => 'foreman-tasks',
+    }
+  }
+
+  service { $_service:
+    ensure => $ensure,
+    enable => $enable,
+  }
+}

--- a/manifests/service/jobs.pp
+++ b/manifests/service/jobs.pp
@@ -6,21 +6,29 @@
 #
 # $service:: The name of the service
 #
+# $dynflow_in_core:: Whether the dynflow is integrated into core. This affects
+#                    the autodetection of the service name.
+#
 # $ensure:: State the service should be in
 #
 # $enable:: Whether to enable the service or not
 
 class foreman::service::jobs(
-  Optional[String] $service = undef,
-  Enum['running', 'stopped'] $ensure = 'running',
-  Boolean $enable = true,
+  Optional[String] $service = $::foreman::jobs_service,
+  Boolean $dynflow_in_core = $::foreman::dynflow_in_core,
+  Enum['running', 'stopped'] $ensure = $::foreman::jobs_service_ensure,
+  Boolean $enable = $::foreman::jobs_service_enable,
 ) {
   if $service {
     $_service = $service
   } else {
-    $_service = $::osfamily ? {
-      'Debian' => 'ruby-foreman-tasks',
-      default  => 'foreman-tasks',
+    if $dynflow_in_core {
+      $_service = 'dynflowd'
+    } else{
+      $_service = $::osfamily ? {
+        'Debian' => 'ruby-foreman-tasks',
+        default  => 'foreman-tasks',
+      }
     }
   }
 

--- a/spec/classes/foreman_service_jobs.rb
+++ b/spec/classes/foreman_service_jobs.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'foreman::service::jobs' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      let(:service_name) do
+        facts[:osfamily] == 'Debian' ? 'ruby-foreman-tasks' : 'foreman-tasks'
+      end
+
+      it { should compile.with_all_deps }
+      it { should contain_service(service_name).with_ensure('running').with_enable(true) }
+    end
+  end
+end

--- a/spec/classes/foreman_service_jobs.rb
+++ b/spec/classes/foreman_service_jobs.rb
@@ -5,12 +5,47 @@ describe 'foreman::service::jobs' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      let(:service_name) do
-        facts[:osfamily] == 'Debian' ? 'ruby-foreman-tasks' : 'foreman-tasks'
+      context 'with inherited parameters' do
+        context 'dynflow_in_core => true' do
+          let(:pre_condition) do
+            'include ::foreman'
+          end
+
+          it { should compile.with_all_deps }
+          it { should contain_service('dynflowd').with_ensure('running').with_enable(true) }
+        end
+
+        context 'dynflow_in_core => false' do
+          let(:pre_condition) do
+            <<-EOS
+            class { '::foreman':
+              dynflow_in_core => false,
+            }
+            EOS
+          end
+
+          let(:service_name) do
+            facts[:osfamily] == 'Debian' ? 'ruby-foreman-tasks' : 'foreman-tasks'
+          end
+
+          it { should compile.with_all_deps }
+          it { should contain_service(service_name).with_ensure('running').with_enable(true) }
+        end
       end
 
-      it { should compile.with_all_deps }
-      it { should contain_service(service_name).with_ensure('running').with_enable(true) }
+      context 'with explicit parameters' do
+        let(:params) do
+          {
+            :service         => 'dynflower',
+            :dynflow_in_core => true,
+            :ensure          => 'running',
+            :enable          => true,
+          }
+        end
+
+        it { should compile.with_all_deps }
+        it { should contain_service('dynflower').with_ensure('running').with_enable(true) }
+      end
     end
   end
 end

--- a/spec/classes/foreman_service_spec.rb
+++ b/spec/classes/foreman_service_spec.rb
@@ -12,6 +12,7 @@ describe 'foreman::service' do
     end
 
     it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('foreman::service::jobs') }
 
     it 'should restart passenger' do
       should contain_exec('restart_foreman').with({
@@ -39,6 +40,7 @@ describe 'foreman::service' do
         :passenger => true,
         :app_root  => '/usr/share/foreman',
         :ssl => true,
+        :dynflow_in_core => false,
       }
     end
 
@@ -47,6 +49,7 @@ describe 'foreman::service' do
     end
 
     it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_class('foreman::service::jobs') }
 
     it 'should restart passenger' do
       should contain_exec('restart_foreman').with({
@@ -72,10 +75,12 @@ describe 'foreman::service' do
           :passenger => true,
           :app_root  => '/usr/share/foreman',
           :ssl => false,
+          :dynflow_in_core => false,
         }
       end
 
       it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_class('foreman::service::jobs') }
     end
   end
 
@@ -85,10 +90,12 @@ describe 'foreman::service' do
         :passenger => false,
         :app_root  => '/usr/share/foreman',
         :ssl => true,
+        :dynflow_in_core => false,
       }
     end
 
     it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_class('foreman::service::jobs') }
 
     it 'should not restart passenger' do
       should_not contain_exec('restart_foreman')

--- a/spec/classes/plugin/remote_execution_spec.rb
+++ b/spec/classes/plugin/remote_execution_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman::plugin::remote_execution' do
       let(:pre_condition) { 'include foreman' }
 
       it { should compile.with_all_deps }
-      it { should contain_foreman__plugin('remote_execution').that_notifies('Service[foreman-tasks]') }
+      it { should contain_foreman__plugin('remote_execution').that_notifies("Class[foreman::service::jobs]") }
       it { should contain_foreman__plugin('tasks') }
     end
   end

--- a/spec/classes/plugin/tasks_spec.rb
+++ b/spec/classes/plugin/tasks_spec.rb
@@ -17,20 +17,18 @@ describe 'foreman::plugin::tasks' do
                        else
                          'tfm-rubygem-foreman-tasks'
                        end
-        service_name = 'foreman-tasks'
       when 'Debian'
         package_name = 'ruby-foreman-tasks'
-        service_name = 'ruby-foreman-tasks'
       else
         package_name = 'foreman-tasks'
-        service_name = 'foreman-tasks'
       end
 
       it { should compile.with_all_deps }
 
+      it { should contain_class('foreman::service::jobs') }
+
       it 'should call the plugin' do
         should contain_foreman__plugin('tasks').with_package(package_name)
-        should contain_service('foreman-tasks').with('ensure' => 'running', 'enable' => 'true', 'name' => service_name)
         should contain_file('/etc/cron.d/foreman-tasks').
           with_path('/etc/cron.d/foreman-tasks').
           with_ensure('absent')


### PR DESCRIPTION
The dynflow service was moved into core with 1.16. That renamed it to dynflowd and means the service should be started by default.

For compatibility parameters are provided. This means we must move the service name detection to the jobs.pp file because that's the only place we know the actual value.

This replaces https://github.com/theforeman/puppet-foreman/pull/530. It's mostly the same, but split into two commits to make reviews easier. The first is a compatible refactor where the second is just the introduction of dynflow in core.