### PR TITLE
Add unattended_url parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,8 @@
 #
 # $unattended::                 Should Foreman manage host provisioning as well
 #
+# $unattended_url::             URL hosts will retrieve templates from during build (normally http as many installers don't support https)
+#
 # $authentication::             Enable user authentication. Initial credentials are set using admin_username
 #                               and admin_password.
 #
@@ -205,6 +207,7 @@ class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
   Boolean $puppetrun = $::foreman::params::puppetrun,
   Boolean $unattended = $::foreman::params::unattended,
+  Stdlib::HTTPUrl $unattended_url = $::foreman::params::unattended_url,
   Boolean $authentication = $::foreman::params::authentication,
   Boolean $passenger = $::foreman::params::passenger,
   Optional[String] $passenger_ruby = $::foreman::params::passenger_ruby,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class foreman::params {
   $receive_facts  = true
   # should foreman manage host provisioning as well
   $unattended     = true
+  $unattended_url = "https://${lower_fqdn}"
   # Enable users authentication (default user:admin pw:changeme)
   $authentication = true
   # configure foreman via apache and passenger

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -4,6 +4,7 @@
 <%= @header %>
 
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
+:unattended_url: <%= scope.lookupvar("foreman::unattended_url") %>
 :login: <%= scope.lookupvar("foreman::authentication") %>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
 :locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>


### PR DESCRIPTION
Set `unattended_url` parameter in `foreman/settings.yaml`

Enables setting of unattended_url during install with foreman-installer