### PR TITLE
Add unattended_url parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,8 @@
 #
 # $unattended::                 Should Foreman manage host provisioning as well
 #
+# $unattended_url::             URL hosts will retrieve templates from during build (normally http as many installers don't support https)
+#
 # $authentication::             Enable user authentication. Initial credentials are set using admin_username
 #                               and admin_password.
 #
@@ -205,6 +207,7 @@ class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
   Boolean $puppetrun = $::foreman::params::puppetrun,
   Boolean $unattended = $::foreman::params::unattended,
+  Optional[Stdlib::HTTPUrl] $unattended_url = $::foreman::params::unattended_url,
   Boolean $authentication = $::foreman::params::authentication,
   Boolean $passenger = $::foreman::params::passenger,
   Optional[String] $passenger_ruby = $::foreman::params::passenger_ruby,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class foreman::params {
   $receive_facts  = true
   # should foreman manage host provisioning as well
   $unattended     = true
+  $unattended_url = undef
   # Enable users authentication (default user:admin pw:changeme)
   $authentication = true
   # configure foreman via apache and passenger

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -14,6 +14,7 @@ describe 'foreman::config' do
         it 'should set up the config' do
           should contain_concat__fragment('foreman_settings+01-header.yaml').
             with_content(/^:unattended:\s*true$/).
+            without_content(/^:unattended_url:/).
             with_content(/^:login:\s*true$/).
             with_content(/^:require_ssl:\s*true$/).
             with_content(/^:locations_enabled:\s*false$/).
@@ -159,6 +160,17 @@ describe 'foreman::config' do
             with_content(/^:oauth_consumer_secret:\s*def$/).
             with({})
         end
+      end
+
+      describe 'with unattended_url' do
+        let :pre_condition do
+          "class {'foreman':
+            unattended_url => 'http://example.com',
+          }"
+        end
+
+        it { should contain_concat__fragment('foreman_settings+01-header.yaml').
+            with_content(%r{^:unattended_url:\s*http://example.com$}) }
       end
 
       describe 'with url ending with trailing slash' do

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -4,6 +4,9 @@
 <%= @header %>
 
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
+<% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::unattended_url")) -%>
+:unattended_url: <%= scope.lookupvar("foreman::unattended_url") %>
+<% end -%>
 :login: <%= scope.lookupvar("foreman::authentication") %>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
 :locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>


### PR DESCRIPTION
Set `unattended_url` parameter in `foreman/settings.yaml`

Enables setting of unattended_url during install with foreman-installer