### PR TITLE
Change to safe working directory in external_node_v2.rb

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -338,6 +338,10 @@ if __FILE__ == $0 then
     Process::UID.change_privilege(Etc.getpwnam(puppetuser).uid) unless Etc.getpwuid.name == puppetuser
     # Facter (in thread_count) tries to read from $HOME, which is still /root after the UID change
     ENV['HOME'] = Etc.getpwnam(puppetuser).dir
+    # Change CWD to the determined home directory before continuing to make
+    # sure we don't reside in /root or anywhere else we don't have access
+    # permissions
+    Dir.chdir ENV['HOME']
   rescue
     $stderr.puts "cannot switch to user #{puppetuser}, continuing as '#{Etc.getpwuid.name}'"
   end


### PR DESCRIPTION
Change working directory to the determined home directory of
`puppetuser` before continuing to ensure we don't reside in /root or
anywhere else we don't have permissions.

Fixes #611.