### PR TITLE
Use puppet4 functions-api

### DIFF
--- a/lib/puppet/functions/foreman/ensure_value_in_string.rb
+++ b/lib/puppet/functions/foreman/ensure_value_in_string.rb
@@ -1,0 +1,28 @@
+# Returns an string with appended values to the end if they were not present in original string.
+#     Prototype:
+#       ensure_value_in_string(string, array, separator = ',')
+# Where string is the original string, array is array of additional values to append,
+# separator is optional specifying delimiter and defaults to a comma.
+#     For example:
+# Given the following statements:
+#       ensure_value_in_string('one,two', ['two', 'three'])
+# The result will be as follows:
+#       'one,two,three'
+# You can specify you own separator as a third argument
+#       ensure_value_in_string('one,two', ['two', 'three'], ', ')
+# results in
+#       'one,two, three'
+Puppet::Functions.create_function(:'foreman::ensure_value_in_string') do
+  dispatch :ensure_value_in_string do
+    required_param 'String', :string
+    required_param 'Array', :adding
+    optional_param 'String', :separator
+  end
+
+  def ensure_value_in_string(string, adding, separator = ',')
+    existing = string.split(separator.strip).map(&:strip)
+    to_add = adding - existing
+
+    ([ string.empty? ? nil : string ] + to_add).compact.join(separator)
+  end
+end

--- a/lib/puppet/functions/foreman/ensure_value_in_string.rb
+++ b/lib/puppet/functions/foreman/ensure_value_in_string.rb
@@ -15,7 +15,7 @@
 Puppet::Functions.create_function(:'foreman::ensure_value_in_string') do
   dispatch :ensure_value_in_string do
     required_param 'String', :string
-    required_param 'Array', :adding
+    required_param 'Array[String]', :adding
     optional_param 'String', :separator
   end
 

--- a/lib/puppet/functions/foreman/foreman.rb
+++ b/lib/puppet/functions/foreman/foreman.rb
@@ -1,0 +1,144 @@
+# Query Foreman
+#
+# The foreman() parser takes a hash value with parameters to execute the query.
+#
+# To use foreman(), first create a hash. This sample hash will contain
+# parameters to let us get a list of 'hosts' that match our search parameters.
+#
+# $f = { item         => 'hosts',
+#        search       => 'hostgroup=Grid',
+#        per_page     => '20',
+#        foreman_url  => 'https://foreman',
+#        foreman_user => 'my_api_foreman_user',
+#        foreman_pass => 'my_api_foreman_pass' }
+#
+# 'item' may be: environments, fact_values, hosts, hostgroups, puppetclasses, smart_proxies, subnets
+# 'search' is your actual search query.
+# 'per_page' specifies the maximum number of results you'd like to receive.
+#            This defaults to '20' which is consistent with what you'd get from
+#            Foreman if you didn't specify anything.
+# 'foreman_url' is your actual foreman server address
+# 'foreman_user' is the username of an account with API access
+# 'foreman_pass' is the password of an account with API access
+# 'filter_result' string or array with attribites to return
+#                 if a string is given foreman() returns an array only with given attributes
+#                 in case of an array is given foreman() returns an array of hashes selecting only
+#                 attributes given in array
+#                 in case of an given hash foreman() returns an array of hashes selecting only
+#                 attribute keys given in hash renamed to values of given keys. This can be used
+#                 to rename keys in result
+# 'timeout' is the Foreman request timeout in seconds as an integer.
+#           This defaults to five seconds.
+#
+# Then, use a variable to capture its output:
+# $hosts = foreman($f)
+#
+# Note: If you're using this in a template, you may be receiving an array of
+# hashes. So you might need to use two loops to get the values you need.
+#
+# Happy Foreman API-ing!
+
+require "yaml"
+require "net/http"
+require "net/https"
+require "uri"
+require "timeout"
+
+Puppet::Functions.create_function(:'foreman::foreman') do
+  dispatch :foreman do
+    required_param 'Hash', :args_hash
+  end
+
+  def foreman(args_hash)
+    # parse an args hash
+    item          = args_hash["item"]
+    search        = args_hash["search"]
+    per_page      = args_hash["per_page"]     || "20"
+    use_tfmproxy  = args_hash["use_tfmproxy"] || false
+    foreman_url   = args_hash["foreman_url"]  || "https://localhost" # defaults: all-in-one
+    foreman_user  = args_hash["foreman_user"] || "admin"             # has foreman/puppet
+    foreman_pass  = args_hash["foreman_pass"] || "changeme"          # on the same box
+    filter_result = args_hash['filter_result'] || false
+    timeout       = (args_hash['timeout']      || 5).to_i
+
+    # extend this as required
+    searchable_items = %w{ environments fact_values hosts hostgroups puppetclasses smart_proxies subnets }
+    raise Puppet::ParseError, "Foreman: Invalid item to search on: #{item}, must be one of #{searchable_items.join(", ")}." unless searchable_items.include?(item)
+    raise Puppet::ParseError, "Foreman: Invalid filter_result: #{filter_result}, must be a String or an Array" unless filter_result.is_a? String or filter_result.is_a? Array or filter_result.is_a? Hash or filter_result == false
+
+    begin
+      path = URI.escape("/api/#{item}?search=#{search}&per_page=#{per_page}")
+
+      req = Net::HTTP::Get.new(path)
+      req['Content-Type'] = 'application/json'
+      req['Accept'] = 'application/json'
+
+      if use_tfmproxy
+        configfile = '/etc/foreman-proxy/settings.yml'
+        configfile = use_tfmproxy if use_tfmproxy.is_a? String
+        raise Puppet::ParseError, "File #{configfile} not found while use_tfmproxy is enabled" unless File.exists?(configfile)
+        tfmproxy = YAML.load(File.read(configfile))
+        uri = URI.parse(tfmproxy[:foreman_url])
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.ca_file = tfmproxy[:foreman_ssl_ca]
+        http.cert = OpenSSL::X509::Certificate.new(File.read(tfmproxy[:foreman_ssl_cert]))
+        http.key = OpenSSL::PKey::RSA.new(File.read(tfmproxy[:foreman_ssl_key]), nil)
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      else
+        uri = URI.parse(foreman_url)
+        http = Net::HTTP.new(uri.host, uri.port)
+        req.basic_auth(foreman_user, foreman_pass)
+        http.use_ssl = true if uri.scheme == 'https'
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
+      end
+      results = Timeout::timeout(timeout) { PSON.parse http.request(req).body }
+    rescue Exception => e
+      raise Puppet::ParseError, "Failed to contact Foreman at #{foreman_url}: #{e}"
+    end
+
+    # Filter results
+    if filter_result != false and results.has_key?('results')
+      filtered_results = Array.new
+
+      if filter_result.is_a? String
+        # filter into an array
+        results['results'].each do |result|
+          if result.has_key?(filter_result)
+            filtered_results << result[filter_result]
+          end
+        end
+      elsif filter_result.is_a? Array
+        # filter into an array of hashes by given key
+        results['results'].each do |result|
+          resulthash = Hash.new
+          result.each do |key,value|
+            if filter_result.include? key
+              resulthash[key] = result[key]
+            end
+          end
+          if resulthash != {}
+            filtered_results << resulthash
+          end
+        end
+      else
+        # filter into an array of hashes while rename keys
+        results['results'].each do |result|
+          resulthash = Hash.new
+          result.each do |key,value|
+            if filter_result.include? key
+              resulthash[filter_result[key]] = result[key]
+            end
+          end
+          if resulthash != {}
+            filtered_results << resulthash
+          end
+        end
+      end
+     return filtered_results
+    end
+
+    # return unfiltered
+    return results
+  end
+end

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -10,7 +10,7 @@ require "timeout"
 Puppet::Functions.create_function(:'foreman::smartvar') do
   dispatch :smartvar do
     required_param 'String[1]', :var
-    optional_param 'String', :foreman_url
+    optional_param 'Stdlib::Httpurl', :foreman_url
     optional_param 'String', :foreman_user
     optional_param 'String', :foreman_pass
   end

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -8,14 +8,14 @@ require "uri"
 require "timeout"
 
 Puppet::Functions.create_function(:'foreman::smartvar') do
-  def smartvar(var)
-    #URL to query
-    foreman_url  = "http://foreman"
-    foreman_user = "admin"
-    foreman_pass = "changeme"
+  dispatch :smartvar do
+    required_param 'String[1]', :var
+    optional_param 'String', :foreman_url
+    optional_param 'String', :foreman_user
+    optional_param 'String', :foreman_pass
+  end
 
-    raise Puppet::ParseError, "Must provide a variable name to search for" if var.nil?
-
+   def smartvar(var, foreman_url = "http://foreman", foreman_user = "admin", foreman_pass = "changeme")
     scope = closure_scope
     fqdn = scope['facts']['fqdn']
 

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -1,0 +1,38 @@
+# Query Foreman in order to resolv a smart variable
+# Foreman holds all the value names and their possible values,
+# this function simply ask foreman for the right value for this host.
+
+require "net/http"
+require "net/https"
+require "uri"
+require "timeout"
+
+Puppet::Functions.create_function(:'foreman::smartvar') do
+  def smartvar(var)
+    #URL to query
+    foreman_url  = "http://foreman"
+    foreman_user = "admin"
+    foreman_pass = "changeme"
+
+    raise Puppet::ParseError, "Must provide a variable name to search for" if var.nil?
+
+    scope = closure_scope
+    fqdn = scope['facts']['fqdn']
+
+    uri = URI.parse(foreman_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.scheme == 'https'
+
+    path = URI.escape("/hosts/#{fqdn}/lookup_keys/#{var}")
+    req = Net::HTTP::Get.new(path)
+    req.basic_auth(foreman_user, foreman_pass)
+    req['Content-Type'] = 'application/json'
+    req['Accept'] = 'application/json'
+
+    begin
+      Timeout::timeout(5) { PSON.parse(http.request(req).body)["value"] }
+    rescue Exception => e
+      raise Puppet::ParseError, "Failed to contact Foreman #{e}"
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -132,13 +132,13 @@ class foreman::config {
 
 
       if $::foreman::ipa_manage_sssd {
-        $sssd_services = ensure_value_in_string($::sssd_services, ['ifp'], ', ')
+        $sssd_services = foreman::ensure_value_in_string($::sssd_services, ['ifp'], ', ')
 
-        $sssd_ldap_user_extra_attrs = ensure_value_in_string($::sssd_ldap_user_extra_attrs, ['email:mail', 'lastname:sn', 'firstname:givenname'], ', ')
+        $sssd_ldap_user_extra_attrs = foreman::ensure_value_in_string($::sssd_ldap_user_extra_attrs, ['email:mail', 'lastname:sn', 'firstname:givenname'], ', ')
 
-        $sssd_allowed_uids = ensure_value_in_string($::sssd_allowed_uids, ['apache', 'root'], ', ')
+        $sssd_allowed_uids = foreman::ensure_value_in_string($::sssd_allowed_uids, ['apache', 'root'], ', ')
 
-        $sssd_user_attributes = ensure_value_in_string($::sssd_user_attributes, ['+email', '+firstname', '+lastname'], ', ')
+        $sssd_user_attributes = foreman::ensure_value_in_string($::sssd_user_attributes, ['+email', '+firstname', '+lastname'], ', ')
 
         augeas { 'sssd-ifp-extra-attributes':
           context => '/files/etc/sssd/sssd.conf',

--- a/spec/functions/foreman_ensure_value_in_string_spec.rb
+++ b/spec/functions/foreman_ensure_value_in_string_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'foreman::ensure_value_in_string' do
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should throw an error with bad number of arguments' do
+    is_expected.to run.with_params().and_raise_error(ArgumentError)
+    is_expected.to run.with_params('string').and_raise_error(ArgumentError)
+    is_expected.to run.with_params('string', [], ', ', 'additional').and_raise_error(ArgumentError)
+  end
+
+  it 'should append values to the end' do
+    is_expected.to run.with_params('one,two', ['three']).and_return('one,two,three')
+  end
+
+  it 'should append values to the end in same order' do
+    is_expected.to run.with_params('one,two', ['three', 'four']).and_return('one,two,three,four')
+  end
+
+  it 'should not append values existing in original string' do
+    is_expected.to run.with_params('one,two', ['two', 'three']).and_return('one,two,three')
+    is_expected.to run.with_params('one,two', ['one', 'three']).and_return('one,two,three')
+    is_expected.to run.with_params('one,two', ['one', 'two']).and_return('one,two')
+  end
+
+  it 'should append even to empty strings' do
+    is_expected.to run.with_params('', ['two', 'three']).and_return('two,three')
+  end
+
+  it 'should append even empty array' do
+    is_expected.to run.with_params('one,two', []).and_return('one,two')
+  end
+
+  it 'should not allow using wrong types and undefined values' do
+    is_expected.to run.with_params(nil, ['two', 'three']).and_raise_error(ArgumentError)
+    is_expected.to run.with_params(:undef, ['two', 'three']).and_raise_error(ArgumentError)
+    is_expected.to run.with_params('one', 'two').and_raise_error(ArgumentError)
+  end
+
+  it 'should ignore whitespaces but preserve it' do
+    is_expected.to run.with_params('one, two,   three    ,    four', ['five']).and_return('one, two,   three    ,    four,five')
+  end
+
+  it 'should accept third argument as a custom separator' do
+    is_expected.to run.with_params('one,two', ['two', 'three'], ', ').and_return('one,two, three')
+  end
+end

--- a/spec/functions/foreman_foreman_spec.rb
+++ b/spec/functions/foreman_foreman_spec.rb
@@ -15,14 +15,7 @@ describe 'foreman::foreman' do
       with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
       to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
 
-    is_expected.to run.with_params(
-      'item'         => 'hosts',
-      'search'       => 'hostgroup=Grid',
-      'per_page'     => '20',
-      'foreman_url'  => 'https://foreman.example.com',
-      'foreman_user' => 'my_api_foreman_user',
-      'foreman_pass' => 'my_api_foreman_pass'
-    )
+    is_expected.to run.with_params('hosts', 'hostgroup=Grid', '20', 'https://foreman.example.com', 'my_api_foreman_user', 'my_api_foreman_pass')
   end
 
   it 'should succeed with a non-default timeout specified' do
@@ -30,15 +23,7 @@ describe 'foreman::foreman' do
       with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
       to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
 
-    is_expected.to run.with_params(
-      'item'         => 'hosts',
-      'search'       => 'hostgroup=Grid',
-      'per_page'     => '20',
-      'foreman_url'  => 'https://foreman.example.com',
-      'foreman_user' => 'my_api_foreman_user',
-      'foreman_pass' => 'my_api_foreman_pass',
-      'timeout'      => '15'
-    )
+    is_expected.to run.with_params('hosts', 'hostgroup=Grid', '20', 'https://foreman.example.com', 'my_api_foreman_user', 'my_api_foreman_pass', 15)
   end
 
   it 'should throw an "execution expired" error when the timeout is exceeded' do
@@ -46,15 +31,7 @@ describe 'foreman::foreman' do
       with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
       to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
 
-    is_expected.to run.with_params(
-      'item'         => 'hosts',
-      'search'       => 'hostgroup=Grid',
-      'per_page'     => '20',
-      'foreman_url'  => 'https://foreman.example.com',
-      'foreman_user' => 'my_api_foreman_user',
-      'foreman_pass' => 'my_api_foreman_pass',
-      'timeout'      => '1'
-    ).and_raise_error(/execution expired/)
+    is_expected.to run.with_params('hosts', 'hostgroup=Grid', '20', 'https://foreman.example.com', 'my_api_foreman_user', 'my_api_foreman_pass',  1).and_raise_error(/execution expired/)
   end
 
   it 'should not throw an "execution expired" error with the default timeout' do
@@ -62,14 +39,7 @@ describe 'foreman::foreman' do
       with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
       to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
 
-    is_expected.to run.with_params(
-      'item'         => 'hosts',
-      'search'       => 'hostgroup=Grid',
-      'per_page'     => '20',
-      'foreman_url'  => 'https://foreman.example.com',
-      'foreman_user' => 'my_api_foreman_user',
-      'foreman_pass' => 'my_api_foreman_pass'
-    )
+    is_expected.to run.with_params('hosts', 'hostgroup=Grid', '20', 'https://foreman.example.com', 'my_api_foreman_user', 'my_api_foreman_pass')
   end
 
   # TODO: Test functionality of the actual function.

--- a/spec/functions/foreman_foreman_spec.rb
+++ b/spec/functions/foreman_foreman_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'webmock'
+
+describe 'foreman::foreman' do
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should throw an error with no arguments' do
+    is_expected.to run.with_params().and_raise_error(ArgumentError)
+  end
+
+  it 'should succeed with no timeout specified' do
+    stub_request(:get, "https://foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
+      to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass'
+    )
+  end
+
+  it 'should succeed with a non-default timeout specified' do
+    stub_request(:get, "https://foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
+      to_return(:status => 200, :body => '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}', :headers => {})
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass',
+      'timeout'      => '15'
+    )
+  end
+
+  it 'should throw an "execution expired" error when the timeout is exceeded' do
+    stub_request(:get, "https://foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
+      to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass',
+      'timeout'      => '1'
+    ).and_raise_error(/execution expired/)
+  end
+
+  it 'should not throw an "execution expired" error with the default timeout' do
+    stub_request(:get, "https://foreman.example.com/api/hosts?per_page=20&search=hostgroup=Grid").
+      with(basic_auth: ['my_api_foreman_user', 'my_api_foreman_pass']).
+      to_return(body: lambda { |request| sleep(2) ; '{"total":0,"subtotal":0,"page":1,"per_page":20,"search":"hostgroup=Grid","sort":{"by":null,"order":null},"results":[]}' })
+
+    is_expected.to run.with_params(
+      'item'         => 'hosts',
+      'search'       => 'hostgroup=Grid',
+      'per_page'     => '20',
+      'foreman_url'  => 'https://foreman.example.com',
+      'foreman_user' => 'my_api_foreman_user',
+      'foreman_pass' => 'my_api_foreman_pass'
+    )
+  end
+
+  # TODO: Test functionality of the actual function.
+
+end

--- a/spec/functions/foreman_smartvar_spec.rb
+++ b/spec/functions/foreman_smartvar_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'foreman::smartvar' do
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should throw an error with no arguments' do
+    is_expected.to run.with_params().and_raise_error(ArgumentError)
+  end
+
+  # TODO: Test functionality of the actual function.
+
+end


### PR DESCRIPTION
The legacy puppet3 functions-api should be avoided.
This migrates the existing functions to the new api and uses it in the module. It also adds the tests for the new functions based on those for the olds.
We should keep the legacy functions for now to allow compatibility for those using the functions outside out this module.