### PR TITLE
Remove test and development database declarations

### DIFF
--- a/templates/database.yml.erb
+++ b/templates/database.yml.erb
@@ -1,21 +1,5 @@
 <%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
 
-# SQLite version 3.x
-development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  adapter: sqlite3
-  database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
-
 <%
   type     = scope.lookupvar("::foreman::db_type")
   adapter  = scope.lookupvar("::foreman::db_adapter_real")
@@ -23,11 +7,12 @@ test:
   host     = scope.lookupvar("::fqdn") if type == 'mysql' && adapter == 'UNSET'
   database = scope.lookupvar("::foreman::db_database")
   database = (type == 'sqlite') ? 'db/production.sqlite3' : 'foreman' if database == 'UNSET'
+  rails_env = scope.lookupvar("::foreman::rails_env")
 -%>
 <% unless scope.lookupvar("::foreman::db_manage") == 'UNSET' -%>
 # Database is managed by foreman::database::<%= type %>
 <% end -%>
-production:
+<%= rails_env %>:
   adapter: <%= adapter %>
 <% unless host == 'UNSET' -%>
   host: <%= host %>


### PR DESCRIPTION
These database declarations don't make sense in a production
environment which the module is focused on. If these environment
databases are desired then they can be added back properly. This
also serves to fix an odd issue in production with Dynflow.