### PR TITLE
Reduce PARALLEL_TEST_PROCESSORS to 8

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,7 +5,7 @@
     - docker/debian-8
   env:
     global:
-      - PARALLEL_TEST_PROCESSORS=16
+      - PARALLEL_TEST_PROCESSORS=8
 Gemfile:
   extra:
     - gem: webmock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - PUPPET_VERSION=4.9
   global:
-    - PARALLEL_TEST_PROCESSORS=16
+    - PARALLEL_TEST_PROCESSORS=8
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Tests are starting to fail in Travis without a clear error. We've seen
this before and reducing the concurrency has helped.