### PR TITLE
Refs #15963 - katello-installer --help typos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@
 # $ssl::                          Enable and set require_ssl in Foreman settings (note: requires passenger, SSL does not apply to kickstarts)
 #
 # $custom_repo::                  No need to change anything here by default
-#                                 if set to true, no repo will be added by this module, letting you to
+#                                 if set to true, no repo will be added by this module, letting you 
 #                                 set it to some custom location.
 #
 # $repo::                         This can be stable, nightly or a specific version i.e. 1.7
@@ -136,7 +136,7 @@
 #
 # $passenger_min_instances::      Minimum passenger worker instances to keep when application is idle.
 #
-# $passenger_start_timeout::      Amount of seconds to wait for Ruby application boot.
+# $passenger_start_timeout::      Number of seconds to wait for Ruby application boot.
 #
 # $vhost_priority::               Defines Apache vhost priority for the Foreman vhost conf file.
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class foreman::params {
   $configure_scl_repo       = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')
 
 # Advanced configuration - no need to change anything here by default
-  # if set to true, no repo will be added by this module, letting you to
+  # if set to true, no repo will be added by this module, letting you 
   # set it to some custom location.
   $custom_repo       = false
   # this can be stable, or nightly


### PR DESCRIPTION
Hi,

This is one of a series of patches to address typos in `katello-installer --help` [#15963](http://projects.theforeman.org/issues/15963)

This diff addresses the `--foreman-custom-repo` and `--foreman-passenger-start-timeout` parameters' descriptions, changing them from:

~~~
   --foreman-custom-repo         No need to change anything here by default
                                 if set to true, no repo will be added by this module, letting you to
                                 set it to some custom location. (current: true)
...
   --foreman-passenger-start-timeout  Amount of seconds to wait for Ruby application boot. (current: 90)
~~~
To:
~~~
   --foreman-custom-repo         No need to change anything here by default
                                 if set to true, no repo will be added by this module, letting you
                                 set it to some custom location. (current: true)
...
   --foreman-passenger-start-timeout  Number of seconds to wait for Ruby application boot. (current: 90)
~~~

Thanks in advance!