### PR TITLE
Package foreman-release-scl -> latest

### DIFF
--- a/manifests/repos/extra.pp
+++ b/manifests/repos/extra.pp
@@ -22,7 +22,7 @@ class foreman::repos::extra(
 
   if $configure_scl_repo {
     package {'foreman-release-scl':
-      ensure => installed,
+      ensure => latest,
     }
   }
 }


### PR DESCRIPTION
If foreman version entirely managed by puppet migration to a newest version will fail is not up to date.
This's related mostly when used with $repo + $version.
Tested with fresh build + updates + upgrades