### PR TITLE
Fixes #22940 - Ensure the PG root cert is installed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,6 +50,25 @@ class foreman::config {
     ensure  => directory,
   }
 
+  if $::foreman::db_root_cert and $::foreman::db_type == 'postgresql' {
+    $pg_cert_dir = "${::foreman::app_root}/.postgresql"
+
+    file { $pg_cert_dir:
+      ensure => 'directory',
+      owner  => 'root',
+      group  => $::foreman::group,
+      mode   => '0640',
+    }
+
+    file { "${pg_cert_dir}/root.crt":
+      ensure => file,
+      source => $::foreman::db_root_cert,
+      owner  => 'root',
+      group  => $::foreman::group,
+      mode   => '0640',
+    }
+  }
+
   if $::foreman::manage_user {
     user { $::foreman::user:
       ensure  => 'present',

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -10,25 +10,6 @@ class foreman::database::postgresql {
     default => postgresql_password($::foreman::db_username, $::foreman::db_password),
   }
 
-  if $::foreman::db_root_cert {
-    $pg_cert_dir = "${::foreman::app_root}/.postgresql"
-
-    file { $pg_cert_dir:
-      ensure => 'directory',
-      owner  => 'root',
-      group  => $::foreman::group,
-      mode   => '0640',
-    }
-
-    file { "${pg_cert_dir}/root.crt":
-      ensure => file,
-      source => $::foreman::db_root_cert,
-      owner  => 'root',
-      group  => $::foreman::group,
-      mode   => '0640',
-    }
-  }
-
   # Prevents errors if run from /root etc.
   Postgresql_psql {
     cwd => '/',


### PR DESCRIPTION
When a remote database is used the postgres server is not managed. This
meant that the certificate was not placed. It's moved to the config
since it's a client config that always needs to happen.