### PR TITLE
metadata.json: bump allowed version of puppetlabs-apt to 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Changelog: https://forge.puppet.com/puppetlabs/apt/changelog#500-2018-07-18

This is to avoid warnings with dependencies.