### PR TITLE
Refactor repo handling

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,8 +47,8 @@ class foreman::params {
   # if set to true, no repo will be added by this module, letting you
   # set it to some custom location.
   $custom_repo       = false
-  # this can be stable, or nightly
-  $repo              = 'stable'
+  # this can be a version or nightly
+  $repo              = '1.18'
   $app_root          = '/usr/share/foreman'
   $plugin_config_dir = '/etc/foreman/plugins'
   $manage_user       = true
@@ -119,14 +119,12 @@ class foreman::params {
       case $::operatingsystem {
         'fedora': {
           $puppet_basedir  = '/usr/share/ruby/vendor_ruby/puppet'
-          $yumcode = "f${::operatingsystemrelease}"
           $passenger_ruby = undef
           $passenger_ruby_package = undef
           $plugin_prefix = 'rubygem-foreman_'
         }
         default: {
           $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
-          $yumcode = "el${osreleasemajor}"
           $puppet_basedir = $osreleasemajor ? {
             '6'     => regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/lib/ruby/site_ruby/\1/puppet'),
             default => '/usr/share/ruby/vendor_ruby/puppet',
@@ -154,7 +152,6 @@ class foreman::params {
           $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/lib/ruby/site_ruby/\1/puppet')
           $puppet_etcdir = '/etc/puppet'
           $puppet_home = '/var/lib/puppet'
-          $yumcode = 'el6'
           # add passenger::install::scl as EL uses SCL on Foreman 1.2+
           $passenger_ruby = '/usr/bin/tfm-ruby'
           $passenger_ruby_package = 'tfm-rubygem-passenger-native'
@@ -185,7 +182,6 @@ class foreman::params {
       $puppet_basedir = undef
       $puppet_etcdir = undef
       $puppet_home = undef
-      $yumcode = undef
       $passenger_ruby = undef
       $passenger_ruby_package = undef
       $plugin_prefix = undef

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,21 +6,17 @@ class foreman::repo(
   $configure_epel_repo = $::foreman::configure_epel_repo,
   $configure_scl_repo  = $::foreman::configure_scl_repo,
 ) {
-  anchor { 'foreman::repo::begin': }
-
-  if ! $custom_repo {
-    Anchor['foreman::repo::begin']
-    -> foreman::repos { 'foreman':
+  unless $custom_repo {
+    foreman::repos { 'foreman':
       repo     => $repo,
       gpgcheck => $gpgcheck,
+      before   => Class['foreman::repos::extra'],
     }
-    -> Class['::foreman::repos::extra']
   }
 
-  Anchor['foreman::repo::begin']
-  -> class { '::foreman::repos::extra':
+  class { '::foreman::repos::extra':
     configure_epel_repo => $configure_epel_repo,
     configure_scl_repo  => $configure_scl_repo,
   }
-  -> anchor { 'foreman::repo::end': }
+  contain ::foreman::repos::extra
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,35 +1,25 @@
 # Set up a repository for foreman
 define foreman::repos(
-  $repo = stable,
-  $gpgcheck = true
+  Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
+  Boolean $gpgcheck = true,
 ) {
-  include ::foreman::params
-
   case $::osfamily {
-    'RedHat': {
+    'RedHat', 'Linux': {
+      $yumcode = $::operatingsystem ? {
+        'Amazon' => 'el7',
+        'Fedora' => "f${::operatingsystemmajrelease}",
+        default  => "el${::operatingsystemmajrelease}",
+      }
+
       foreman::repos::yum {$name:
         repo     => $repo,
-        yumcode  => $::foreman::params::yumcode,
+        yumcode  => $yumcode,
         gpgcheck => $gpgcheck,
       }
     }
     'Debian': {
       foreman::repos::apt {$name:
         repo => $repo,
-      }
-    }
-    'Linux': {
-      case $::operatingsystem {
-        'Amazon': {
-          foreman::repos::yum {$name:
-            repo     => $repo,
-            yumcode  => $::foreman::params::yumcode,
-            gpgcheck => $gpgcheck,
-          }
-        }
-        default: {
-          fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")
-        }
       }
     }
     default: {

--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -1,10 +1,11 @@
 # Install an apt repo
-define foreman::repos::apt ($repo) {
-
+define foreman::repos::apt (
+  Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
+) {
   include ::apt
 
   Apt::Source {
-    location => 'http://deb.theforeman.org/',
+    location => 'https://deb.theforeman.org/',
     key      => 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
     include  => {
       src => false,
@@ -19,5 +20,4 @@ define foreman::repos::apt ($repo) {
     release => 'plugins',
     repos   => $repo,
   }
-
 }

--- a/manifests/repos/yum.pp
+++ b/manifests/repos/yum.pp
@@ -1,20 +1,9 @@
 # Install a yum repo
 define foreman::repos::yum (
-  Variant[Enum['stable', 'nightly'], Pattern['^(releases\/)?\d+\.\d+$']] $repo,
+  Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
   String $yumcode,
   Boolean $gpgcheck,
 ) {
-  $repo_path = $repo ? {
-    'stable'      => 'releases/latest',
-    /^releases\// => $repo,
-    'nightly'     => $repo,
-    default       => "releases/${repo}",
-  }
-  $plugins_repo_path = $repo ? {
-    'stable'      => 'plugins/latest',
-    /^releases\// => regsubst($repo, '^releases/(.*?)', 'plugins/\1'),
-    default       => "plugins/${repo}",
-  }
   $gpgcheck_enabled_default = $gpgcheck ? {
     false   => '0',
     default => '1',
@@ -25,28 +14,35 @@ define foreman::repos::yum (
   }
   yumrepo { $name:
     descr    => "Foreman ${repo}",
-    baseurl  => "http://yum.theforeman.org/${repo_path}/${yumcode}/\$basearch",
+    baseurl  => "https://yum.theforeman.org/releases/${repo}/${yumcode}/\$basearch",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "https://yum.theforeman.org/${repo_path}/RPM-GPG-KEY-foreman",
+    gpgkey   => "https://yum.theforeman.org/releases/${repo}/RPM-GPG-KEY-foreman",
     enabled  => '1',
   }
   yumrepo { "${name}-source":
     descr    => "Foreman ${repo} - source",
-    baseurl  => "http://yum.theforeman.org/${repo_path}/${yumcode}/source",
+    baseurl  => "https://yum.theforeman.org/releases/${repo}/${yumcode}/source",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "https://yum.theforeman.org/${repo_path}/RPM-GPG-KEY-foreman",
+    gpgkey   => "https://yum.theforeman.org/releases/${repo}/RPM-GPG-KEY-foreman",
     enabled  => '0',
   }
   yumrepo { "${name}-plugins":
     descr    => "Foreman plugins ${repo}",
-    baseurl  => "http://yum.theforeman.org/${plugins_repo_path}/${yumcode}/\$basearch",
+    baseurl  => "https://yum.theforeman.org/plugins/${repo}/${yumcode}/\$basearch",
     gpgcheck => '0',
     enabled  => '1',
   }
   yumrepo { "${name}-plugins-source":
     descr    => "Foreman plugins ${repo} - source",
-    baseurl  => "http://yum.theforeman.org/${plugins_repo_path}/${yumcode}/source",
+    baseurl  => "https://yum.theforeman.org/plugins/${repo}/${yumcode}/source",
     gpgcheck => '0',
     enabled  => '0',
+  }
+  yumrepo { "${name}-rails":
+    descr    => "Rails SCL for Foreman ${repo}",
+    baseurl  => "https://yum.theforeman.org/rails/foreman-${repo}/${yumcode}/\$basearch",
+    gpgcheck => $gpgcheck_enabled,
+    enabled  => '1',
+    gpgkey   => "https://yum.theforeman.org/rails/foreman-${repo}/RPM-GPG-KEY-copr",
   }
 }

--- a/spec/classes/foreman_repo_spec.rb
+++ b/spec/classes/foreman_repo_spec.rb
@@ -13,7 +13,7 @@ describe 'foreman::repo' do
         let :params do
           {
             'custom_repo'         => false,
-            'repo'                => 'stable',
+            'repo'                => '1.19',
             'gpgcheck'            => true,
             'configure_epel_repo' => configure,
             'configure_scl_repo'  => configure,
@@ -22,7 +22,7 @@ describe 'foreman::repo' do
 
         it 'should include OS repos' do
           is_expected.to contain_foreman__repos('foreman')
-            .with_repo('stable')
+            .with_repo('1.19')
             .with_gpgcheck(true)
         end
 

--- a/spec/defines/foreman_repos_apt_spec.rb
+++ b/spec/defines/foreman_repos_apt_spec.rb
@@ -7,34 +7,12 @@ describe 'foreman::repos::apt' do
     on_supported_os['debian-9-x86_64']
   end
 
-  context 'with repo => stable' do
-    let(:params) { {:repo => 'stable'} }
+  let(:apt_key) do
+    'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6'
+  end
 
-    it { should contain_class('apt') }
-
-    it 'should add the stable repo' do
-      should contain_apt__source('foreman').
-        with_location('http://deb.theforeman.org/').
-        with_repos('stable')
-
-      should contain_file('/etc/apt/sources.list.d/foreman.list').
-        with_content(%r{deb http://deb\.theforeman\.org/ stretch stable})
-
-      should contain_apt__source('foreman-plugins').
-        with_location('http://deb.theforeman.org/').
-        with_release('plugins').
-        with_repos('stable')
-    end
-
-    let(:apt_key) do
-      'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6'
-    end
-    let(:apt_key_title) do
-      "Add key: #{apt_key} from Apt::Source foreman"
-    end
-
-    it { should contain_apt_key(apt_key_title) }
-    it { should contain_apt_key(apt_key_title).with_id(apt_key) }
+  let(:apt_key_title) do
+    "Add key: #{apt_key} from Apt::Source foreman"
   end
 
   context 'with repo => 1.18' do
@@ -44,17 +22,19 @@ describe 'foreman::repos::apt' do
 
     it 'should add the 1.18 repo' do
       should contain_apt__source('foreman').
-        with_location('http://deb.theforeman.org/').
+        with_location('https://deb.theforeman.org/').
         with_repos('1.18')
 
       should contain_file('/etc/apt/sources.list.d/foreman.list').
-        with_content(%r{deb http://deb\.theforeman\.org/ stretch 1\.18})
+        with_content(%r{deb https://deb\.theforeman\.org/ stretch 1\.18})
 
       should contain_apt__source('foreman-plugins').
-        with_location('http://deb.theforeman.org/').
+        with_location('https://deb.theforeman.org/').
         with_release('plugins').
         with_repos('1.18')
     end
+
+    it { should contain_apt_key(apt_key_title).with_id(apt_key) }
   end
 
   context 'with repo => nightly' do
@@ -64,17 +44,19 @@ describe 'foreman::repos::apt' do
 
     it 'should add the nightly repo' do
       should contain_apt__source('foreman').
-        with_location('http://deb.theforeman.org/').
+        with_location('https://deb.theforeman.org/').
         with_repos('nightly')
 
       should contain_file('/etc/apt/sources.list.d/foreman.list').
-        with_content(%r{deb http://deb\.theforeman\.org/ stretch nightly})
+        with_content(%r{deb https://deb\.theforeman\.org/ stretch nightly})
 
       should contain_apt__source('foreman-plugins').
-        with_location('http://deb.theforeman.org/').
+        with_location('https://deb.theforeman.org/').
         with_release('plugins').
         with_repos('nightly')
     end
+
+    it { should contain_apt_key(apt_key_title).with_id(apt_key) }
   end
 
 end

--- a/spec/defines/foreman_repos_yum_spec.rb
+++ b/spec/defines/foreman_repos_yum_spec.rb
@@ -1,302 +1,184 @@
 require 'spec_helper'
 
-
 describe 'foreman::repos::yum' do
   let(:title) { 'foreman' }
 
-  context 'with repo => stable' do
-    context 'with gpgcheck => true' do
-      let(:params) { {:repo => 'stable', :yumcode => 'el6', :gpgcheck => true} }
-
-      it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman stable',
-          :baseurl  => 'http://yum.theforeman.org/releases/latest/el6/$basearch',
-          :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman stable - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/latest/el6/source',
-          :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman',
-          :enabled  => '0',
-        })
-
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins stable',
-          :baseurl  => 'http://yum.theforeman.org/plugins/latest/el6/$basearch',
-          :gpgcheck => '0',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins stable - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/latest/el6/source',
-          :gpgcheck => '0',
-          :enabled  => '0',
-        })
-
-      end
-    end
-
-    context 'with gpgcheck => false' do
-      let(:params) { {:repo => 'stable', :yumcode => 'el6', :gpgcheck => false} }
-
-      it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman stable',
-          :baseurl  => 'http://yum.theforeman.org/releases/latest/el6/$basearch',
-          :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman stable - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/latest/el6/source',
-          :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/latest/RPM-GPG-KEY-foreman',
-          :enabled  => '0',
-        })
-
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins stable',
-          :baseurl  => 'http://yum.theforeman.org/plugins/latest/el6/$basearch',
-          :gpgcheck => '0',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins stable - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/latest/el6/source',
-          :gpgcheck => '0',
-          :enabled  => '0',
-        })
-      end
-    end
-  end
-
   context 'with repo => nightly' do
     context 'gpgcheck => true' do
-      let(:params) { {:repo => 'nightly', :yumcode => 'el6', :gpgcheck => true} }
+      let(:params) { {:repo => 'nightly', :yumcode => 'el7', :gpgcheck => true} }
 
       it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
+        should contain_yumrepo('foreman').with(
           :descr    => 'Foreman nightly',
-          :baseurl  => 'http://yum.theforeman.org/nightly/el6/$basearch',
+          :baseurl  => 'https://yum.theforeman.org/releases/nightly/el7/$basearch',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/nightly/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-source').with({
+        should contain_yumrepo('foreman-source').with(
           :descr    => 'Foreman nightly - source',
-          :baseurl  => 'http://yum.theforeman.org/nightly/el6/source',
+          :baseurl  => 'https://yum.theforeman.org/releases/nightly/el7/source',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/nightly/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman',
           :enabled  => '0',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins').with({
+        should contain_yumrepo('foreman-plugins').with(
           :descr    => 'Foreman plugins nightly',
-          :baseurl  => 'http://yum.theforeman.org/plugins/nightly/el6/$basearch',
+          :baseurl  => 'https://yum.theforeman.org/plugins/nightly/el7/$basearch',
           :gpgcheck => '0',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins-source').with({
+        should contain_yumrepo('foreman-plugins-source').with(
           :descr    => 'Foreman plugins nightly - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/nightly/el6/source',
+          :baseurl  => 'https://yum.theforeman.org/plugins/nightly/el7/source',
           :gpgcheck => '0',
           :enabled  => '0',
-        })
+        )
+
+        should contain_yumrepo('foreman-rails').with(
+          :descr    => 'Rails SCL for Foreman nightly',
+          :baseurl  => 'https://yum.theforeman.org/rails/foreman-nightly/el7/$basearch',
+          :gpgcheck => '0',
+          :enabled  => '1',
+          :gpgkey   => 'https://yum.theforeman.org/rails/foreman-nightly/RPM-GPG-KEY-copr',
+        )
       end
     end
 
     context 'gpgcheck => false' do
-      let(:params) { {:repo => 'nightly', :yumcode => 'el6', :gpgcheck => false} }
+      let(:params) { {:repo => 'nightly', :yumcode => 'el7', :gpgcheck => false} }
 
       it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
+        should contain_yumrepo('foreman').with(
           :descr    => 'Foreman nightly',
-          :baseurl  => 'http://yum.theforeman.org/nightly/el6/$basearch',
+          :baseurl  => 'https://yum.theforeman.org/releases/nightly/el7/$basearch',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/nightly/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-source').with({
+        should contain_yumrepo('foreman-source').with(
           :descr    => 'Foreman nightly - source',
-          :baseurl  => 'http://yum.theforeman.org/nightly/el6/source',
+          :baseurl  => 'https://yum.theforeman.org/releases/nightly/el7/source',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/nightly/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman',
           :enabled  => '0',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins').with({
+        should contain_yumrepo('foreman-plugins').with(
           :descr    => 'Foreman plugins nightly',
-          :baseurl  => 'http://yum.theforeman.org/plugins/nightly/el6/$basearch',
+          :baseurl  => 'https://yum.theforeman.org/plugins/nightly/el7/$basearch',
           :gpgcheck => '0',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins-source').with({
+        should contain_yumrepo('foreman-plugins-source').with(
           :descr    => 'Foreman plugins nightly - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/nightly/el6/source',
+          :baseurl  => 'https://yum.theforeman.org/plugins/nightly/el7/source',
           :gpgcheck => '0',
           :enabled  => '0',
-        })
+        )
+
+        should contain_yumrepo('foreman-rails').with(
+          :descr    => 'Rails SCL for Foreman nightly',
+          :baseurl  => 'https://yum.theforeman.org/rails/foreman-nightly/el7/$basearch',
+          :gpgcheck => '0',
+          :enabled  => '1',
+          :gpgkey   => 'https://yum.theforeman.org/rails/foreman-nightly/RPM-GPG-KEY-copr',
+        )
       end
     end
   end
 
-  context 'with repo => 1.7' do
+  context 'with repo => 1.19' do
     context 'gpgcheck => true' do
-      let(:params) { {:repo => '1.7', :yumcode => 'el6', :gpgcheck => true} }
+      let(:params) { {:repo => '1.19', :yumcode => 'el7', :gpgcheck => true} }
 
       it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman 1.7',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/$basearch',
+        should contain_yumrepo('foreman').with(
+          :descr    => 'Foreman 1.19',
+          :baseurl  => 'https://yum.theforeman.org/releases/1.19/el7/$basearch',
           :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman 1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/source',
+        should contain_yumrepo('foreman-source').with(
+          :descr    => 'Foreman 1.19 - source',
+          :baseurl  => 'https://yum.theforeman.org/releases/1.19/el7/source',
           :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman',
           :enabled  => '0',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins 1.7',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/$basearch',
+        should contain_yumrepo('foreman-plugins').with(
+          :descr    => 'Foreman plugins 1.19',
+          :baseurl  => 'https://yum.theforeman.org/plugins/1.19/el7/$basearch',
           :gpgcheck => '0',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins 1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/source',
+        should contain_yumrepo('foreman-plugins-source').with(
+          :descr    => 'Foreman plugins 1.19 - source',
+          :baseurl  => 'https://yum.theforeman.org/plugins/1.19/el7/source',
           :gpgcheck => '0',
           :enabled  => '0',
-        })
+        )
+
+        should contain_yumrepo('foreman-rails').with(
+          :descr    => 'Rails SCL for Foreman 1.19',
+          :baseurl  => 'https://yum.theforeman.org/rails/foreman-1.19/el7/$basearch',
+          :gpgcheck => '1',
+          :enabled  => '1',
+          :gpgkey   => 'https://yum.theforeman.org/rails/foreman-1.19/RPM-GPG-KEY-copr',
+        )
       end
     end
 
     context 'gpgcheck => false' do
-      let(:params) { {:repo => '1.7', :yumcode => 'el6', :gpgcheck => false} }
+      let(:params) { {:repo => '1.19', :yumcode => 'el7', :gpgcheck => false} }
 
       it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman 1.7',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/$basearch',
+        should contain_yumrepo('foreman').with(
+          :descr    => 'Foreman 1.19',
+          :baseurl  => 'https://yum.theforeman.org/releases/1.19/el7/$basearch',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman 1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/source',
+        should contain_yumrepo('foreman-source').with(
+          :descr    => 'Foreman 1.19 - source',
+          :baseurl  => 'https://yum.theforeman.org/releases/1.19/el7/source',
           :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
+          :gpgkey   => 'https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman',
           :enabled  => '0',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins 1.7',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/$basearch',
-          :gpgcheck => '0',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins 1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/source',
-          :gpgcheck => '0',
-          :enabled  => '0',
-        })
-      end
-    end
-  end
-
-  context 'with repo => releases/1.7' do
-    context 'gpgcheck => true' do
-      let(:params) { {:repo => 'releases/1.7', :yumcode => 'el6', :gpgcheck => true} }
-
-      it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman releases/1.7',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/$basearch',
-          :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman releases/1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/source',
-          :gpgcheck => '1',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
-          :enabled  => '0',
-        })
-
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins releases/1.7',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/$basearch',
+        should contain_yumrepo('foreman-plugins').with(
+          :descr    => 'Foreman plugins 1.19',
+          :baseurl  => 'https://yum.theforeman.org/plugins/1.19/el7/$basearch',
           :gpgcheck => '0',
           :enabled  => '1',
-        })
+        )
 
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins releases/1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/source',
+        should contain_yumrepo('foreman-plugins-source').with(
+          :descr    => 'Foreman plugins 1.19 - source',
+          :baseurl  => 'https://yum.theforeman.org/plugins/1.19/el7/source',
           :gpgcheck => '0',
           :enabled  => '0',
-        })
-      end
-    end
+        )
 
-    context 'gpgcheck => false' do
-      let(:params) { {:repo => 'releases/1.7', :yumcode => 'el6', :gpgcheck => false} }
-
-      it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman').with({
-          :descr    => 'Foreman releases/1.7',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/$basearch',
-          :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
-          :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-source').with({
-          :descr    => 'Foreman releases/1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/releases/1.7/el6/source',
-          :gpgcheck => '0',
-          :gpgkey   => 'https://yum.theforeman.org/releases/1.7/RPM-GPG-KEY-foreman',
-          :enabled  => '0',
-        })
-
-        should contain_yumrepo('foreman-plugins').with({
-          :descr    => 'Foreman plugins releases/1.7',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/$basearch',
+        should contain_yumrepo('foreman-rails').with(
+          :descr    => 'Rails SCL for Foreman 1.19',
+          :baseurl  => 'https://yum.theforeman.org/rails/foreman-1.19/el7/$basearch',
           :gpgcheck => '0',
           :enabled  => '1',
-        })
-
-        should contain_yumrepo('foreman-plugins-source').with({
-          :descr    => 'Foreman plugins releases/1.7 - source',
-          :baseurl  => 'http://yum.theforeman.org/plugins/1.7/el6/source',
-          :gpgcheck => '0',
-          :enabled  => '0',
-        })
+          :gpgkey   => 'https://yum.theforeman.org/rails/foreman-1.19/RPM-GPG-KEY-copr',
+        )
       end
     end
   end


### PR DESCRIPTION
* Drop use of the 'stable' repository
* Disallow releases/ as part of the repository
* Add foreman-rails repository
* Stop including foreman::params
* Remove anchor pattern
* Move to https

Will need https://github.com/theforeman/puppet-foreman/pull/659 for the acceptance tests to pass.

Note that the foreman-rails repository assumes Foreman 1.17+ so that'll become the new minimum version. I'm going to continue with removing some compatibility with older versions in follow up PRs.