### PR TITLE
Refactor Puppet handling

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,10 +124,6 @@
 #
 # $user_groups::                  Additional groups for the Foreman user
 #
-# $puppet_home::                  Puppet home directory
-#
-# $puppet_ssldir::                Puppet SSL directory
-#
 # $passenger_interface::          Defines which network interface passenger should listen on, undef means all interfaces
 #
 # $passenger_prestart::           Pre-start the first passenger worker instance process during httpd start.
@@ -259,8 +255,6 @@ class foreman (
   String $group = $::foreman::params::group,
   Array[String] $user_groups = $::foreman::params::user_groups,
   String $rails_env = $::foreman::params::rails_env,
-  Stdlib::Absolutepath $puppet_home = $::foreman::params::puppet_home,
-  Stdlib::Absolutepath $puppet_ssldir = $::foreman::params::puppet_ssldir,
   Boolean $locations_enabled = $::foreman::params::locations_enabled,
   Boolean $organizations_enabled = $::foreman::params::organizations_enabled,
   Optional[String] $passenger_interface = $::foreman::params::passenger_interface,

--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -1,25 +1,25 @@
 # This class includes the necessary scripts for Foreman on the puppetmaster and
 # is intented to be added to your puppetmaster
 class foreman::puppetmaster (
-  $foreman_url      = $::foreman::params::foreman_url,
-  $foreman_user     = $::foreman::params::foreman_user,
-  $foreman_password = $::foreman::params::foreman_password,
-  $reports          = $::foreman::params::reports,
-  $enc              = $::foreman::params::enc,
-  $receive_facts    = $::foreman::params::receive_facts,
-  $puppet_home      = $::foreman::params::puppet_home,
-  $puppet_user      = $::foreman::params::puppet_user,
-  $puppet_group     = $::foreman::params::puppet_group,
-  $puppet_basedir   = $::foreman::params::puppet_basedir,
-  $puppet_etcdir    = $::foreman::params::puppet_etcdir,
-  $timeout          = $::foreman::params::puppetmaster_timeout,
-  $report_timeout   = $::foreman::params::puppetmaster_report_timeout,
-  $ssl_ca           = $::foreman::params::client_ssl_ca,
-  $ssl_cert         = $::foreman::params::client_ssl_cert,
-  $ssl_key          = $::foreman::params::client_ssl_key,
-  $enc_api          = 'v2',
-  $report_api       = 'v2',
-) inherits foreman::params {
+  Stdlib::HTTPUrl $foreman_url = $::foreman::puppetmaster::params::foreman_url,
+  Optional[String] $foreman_user = $::foreman::puppetmaster::params::foreman_user,
+  Optional[String] $foreman_password = $::foreman::puppetmaster::params::foreman_password,
+  Boolean $reports = $::foreman::puppetmaster::params::reports,
+  Boolean $enc = $::foreman::puppetmaster::params::enc,
+  Boolean $receive_facts = $::foreman::puppetmaster::params::receive_facts,
+  Stdlib::Absolutepath $puppet_home = $::foreman::puppetmaster::params::puppet_home,
+  String $puppet_user = $::foreman::puppetmaster::params::puppet_user,
+  String $puppet_group = $::foreman::puppetmaster::params::puppet_group,
+  Stdlib::Absolutepath $puppet_basedir = $::foreman::puppetmaster::params::puppet_basedir,
+  Stdlib::Absolutepath $puppet_etcdir = $::foreman::puppetmaster::params::puppet_etcdir,
+  Integer $timeout = $::foreman::puppetmaster::params::puppetmaster_timeout,
+  Integer $report_timeout = $::foreman::puppetmaster::params::puppetmaster_report_timeout,
+  Stdlib::Absolutepath $ssl_ca = $::foreman::puppetmaster::params::client_ssl_ca,
+  Stdlib::Absolutepath $ssl_cert = $::foreman::puppetmaster::params::client_ssl_cert,
+  Stdlib::Absolutepath $ssl_key = $::foreman::puppetmaster::params::client_ssl_key,
+  Enum['v2'] $enc_api = 'v2',
+  Enum['v2'] $report_api = 'v2',
+) inherits foreman::puppetmaster::params {
 
   case $::osfamily {
     'Debian': { $json_package = 'ruby-json' }

--- a/manifests/puppetmaster/params.pp
+++ b/manifests/puppetmaster/params.pp
@@ -1,0 +1,77 @@
+# Defaults for the puppetmaster
+class foreman::puppetmaster::params {
+  $lower_fqdn = downcase($::fqdn)
+
+  # Basic configurations
+  $foreman_url      = "https://${lower_fqdn}"
+  $foreman_user     = undef
+  $foreman_password = undef
+  # Should foreman act as an external node classifier (manage puppet class
+  # assignments)
+  $enc            = true
+  # Should foreman receive reports from puppet
+  $reports        = true
+  # Should foreman receive facts from puppet
+  $receive_facts  = true
+
+  $puppet_user = 'puppet'
+  $puppet_group = 'puppet'
+
+  $puppetmaster_timeout = 60
+  $puppetmaster_report_timeout = 60
+
+  if $::rubysitedir =~ /\/opt\/puppetlabs\/puppet/ {
+    $puppet_basedir = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet'
+    $puppet_etcdir = '/etc/puppetlabs/puppet'
+    $puppet_home = '/opt/puppetlabs/server/data/puppetserver'
+    $puppet_ssldir = '/etc/puppetlabs/puppet/ssl'
+  } else {
+    case $::osfamily {
+      'RedHat': {
+        $puppet_basedir  = '/usr/share/ruby/vendor_ruby/puppet'
+        $puppet_etcdir = '/etc/puppet'
+        $puppet_home = '/var/lib/puppet'
+      }
+      'Debian': {
+        $puppet_basedir  = '/usr/lib/ruby/vendor_ruby/puppet'
+        $puppet_etcdir = '/etc/puppet'
+        $puppet_home = '/var/lib/puppet'
+      }
+      'Linux': {
+        case $::operatingsystem {
+          'Amazon': {
+            $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/lib/ruby/site_ruby/\1/puppet')
+            $puppet_etcdir = '/etc/puppet'
+            $puppet_home = '/var/lib/puppet'
+          }
+          default: {
+            fail("${::hostname}: This module does not support operatingsystem ${::operatingsystem}")
+          }
+        }
+      }
+      'Archlinux': {
+        $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/lib/ruby/vendor_ruby/\1/puppet')
+        $puppet_etcdir = '/etc/puppetlabs/puppet'
+        $puppet_home = '/var/lib/puppet'
+      }
+      /^(FreeBSD|DragonFly)$/: {
+        $puppet_basedir = regsubst($::rubyversion, '^(\d+\.\d+).*$', '/usr/local/lib/ruby/site_ruby/\1/puppet')
+        $puppet_etcdir = '/usr/local/etc/puppet'
+        $puppet_home = '/var/puppet'
+      }
+      default: {
+        $puppet_basedir = undef
+        $puppet_etcdir = undef
+        $puppet_home = undef
+      }
+    }
+
+    $puppet_ssldir = "${puppet_home}/ssl"
+  }
+
+  # If CA is specified, remote Foreman host will be verified in reports/ENC scripts
+  $client_ssl_ca   = "${puppet_ssldir}/certs/ca.pem"
+  # Used to authenticate to Foreman, required if require_ssl_puppetmasters is enabled
+  $client_ssl_cert = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
+  $client_ssl_key  = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
+}

--- a/spec/classes/foreman_config_spec.rb
+++ b/spec/classes/foreman_config_spec.rb
@@ -20,7 +20,6 @@ describe 'foreman::config' do
             with_content(/^:locations_enabled:\s*false$/).
             with_content(/^:organizations_enabled:\s*false$/).
             with_content(/^:puppetrun:\s*false$/).
-            with_content(/^:puppetssldir:\s*\/var\/lib\/puppet\/ssl$/).
             with_content(/^:oauth_active:\s*true$/).
             with_content(/^:oauth_map_users:\s*false$/).
             with_content(/^:oauth_consumer_key:\s*\w+$/).
@@ -268,24 +267,6 @@ describe 'foreman::config' do
         end
 
         it { should contain_foreman_config_entry('delivery_method').with_value('sendmail') }
-      end
-
-      if Puppet.version >= '4.0'
-        describe 'with AIO Puppet packages' do
-          let :pre_condition do
-            "class {'foreman':}"
-          end
-          let :facts do
-            facts.merge({
-              :rubysitedir => '/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0',
-            })
-          end
-          it 'should set up puppetssldir accordingly' do
-            should contain_concat__fragment('foreman_settings+01-header.yaml').
-                with_content(/^:puppetssldir:\s*\/etc\/puppetlabs\/puppet\/ssl$/).
-                with({})
-          end
-        end
       end
     end
   end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -80,8 +80,6 @@ describe 'foreman' do
           :group                     => 'foreman',
           :user_groups               => ['adm', 'wheel'],
           :rails_env                 => 'production',
-          :puppet_home               => '/var/lib/puppet',
-          :puppet_ssldir             => '/var/lib/puppet/ssl',
           :locations_enabled         => false,
           :organizations_enabled     => true,
           :passenger_interface       => 'lo0',

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -12,7 +12,6 @@
 :locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>
 :organizations_enabled: <%= scope.lookupvar("foreman::organizations_enabled") %>
 :puppetrun: <%= scope.lookupvar("foreman::puppetrun") %>
-:puppetssldir: <%= scope.lookupvar("foreman::puppet_ssldir") %>
 
 # The following values are used for providing default settings during db migrate
 :oauth_active: <%= scope.lookupvar("foreman::oauth_active") %>


### PR DESCRIPTION
This moves all puppetmaster defaults to its own parameters file.
Parameters that were used in both are duplicated. It also adds Puppet
types to all parameters.

This removes puppet settings from the top level. The puppet_ssldir is
now an internal detail to determine defaults. It is also no longer set
in Foreman since it's only used as a base for determining SSL paths
which we explicitly set. There is a PR open to remove this setting
altogether.