### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,14 +1,10 @@
 fixtures:
   repositories:
-    apache:           'git://github.com/puppetlabs/puppetlabs-apache'
-    apt:              'git://github.com/puppetlabs/puppetlabs-apt'
-    concat:           'git://github.com/puppetlabs/puppetlabs-concat'
-    extlib:           'git://github.com/voxpupuli/puppet-extlib'
-    mysql:            'git://github.com/puppetlabs/puppetlabs-mysql'
-    postgresql:       'git://github.com/puppetlabs/puppetlabs-postgresql'
-    puppet:           'git://github.com/theforeman/puppet-puppet'
-    stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'
-
-
-  symlinks:
-    foreman: "#{source_dir}"
+    apache:           'http://github.com/puppetlabs/puppetlabs-apache'
+    apt:              'http://github.com/puppetlabs/puppetlabs-apt'
+    concat:           'http://github.com/puppetlabs/puppetlabs-concat'
+    extlib:           'http://github.com/voxpupuli/puppet-extlib'
+    mysql:            'http://github.com/puppetlabs/puppetlabs-mysql'
+    postgresql:       'http://github.com/puppetlabs/puppetlabs-postgresql'
+    puppet:           'http://github.com/theforeman/puppet-puppet'
+    stdlib:           'http://github.com/puppetlabs/puppetlabs-stdlib'


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically