### PR TITLE
Refactor extras repo handling

### DIFF
--- a/manifests/repos/extra.pp
+++ b/manifests/repos/extra.pp
@@ -1,28 +1,23 @@
 # Configure thirdparty repos
 class foreman::repos::extra(
-  $configure_epel_repo      = $::foreman::configure_epel_repo,
-  $configure_scl_repo       = $::foreman::configure_scl_repo,
+  Boolean $configure_epel_repo = $::foreman::configure_epel_repo,
+  Boolean $configure_scl_repo = $::foreman::configure_scl_repo,
+  String $scl_repo_ensure = 'installed',
 ) {
-  $osreleasemajor = regsubst($::operatingsystemrelease, '^(\d+)\..*$', '\1')
-
   if $configure_epel_repo {
-    $epel_gpgkey = $osreleasemajor ? {
-      '7'     => 'https://fedoraproject.org/static/352C64E5.txt',
-      default => 'https://fedoraproject.org/static/0608B895.txt',
-    }
     yumrepo { 'epel':
-      descr      => "Extra Packages for Enterprise Linux ${osreleasemajor} - \$basearch",
-      mirrorlist => "https://mirrors.fedoraproject.org/metalink?repo=epel-${osreleasemajor}&arch=\$basearch",
-      baseurl    => "http://download.fedoraproject.org/pub/epel/${osreleasemajor}/\$basearch",
+      descr      => "Extra Packages for Enterprise Linux ${::operatingsystemmajrelease} - \$basearch",
+      mirrorlist => "https://mirrors.fedoraproject.org/metalink?repo=epel-${::operatingsystemmajrelease}&arch=\$basearch",
+      baseurl    => "http://download.fedoraproject.org/pub/epel/${::operatingsystemmajrelease}/\$basearch",
       enabled    => 1,
       gpgcheck   => 1,
-      gpgkey     => $epel_gpgkey,
+      gpgkey     => 'https://fedoraproject.org/static/352C64E5.txt',
     }
   }
 
   if $configure_scl_repo {
     package {'foreman-release-scl':
-      ensure => installed,
+      ensure => $scl_repo_ensure,
     }
   }
 }

--- a/spec/classes/foreman_repos_extra_spec.rb
+++ b/spec/classes/foreman_repos_extra_spec.rb
@@ -1,53 +1,49 @@
 require 'spec_helper'
 
 describe 'foreman::repos::extra' do
-
   on_os_under_test.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os}", if: facts[:osfamily] == 'RedHat' do
       let :facts do facts end
 
       describe 'when repos are fully enabled' do
-        case facts[:osfamily]
-        when 'RedHat'
-          if facts[:operatingsystem] != 'Fedora'
-            let(:params) do
-              {
-                :configure_scl_repo  => true,
-                :configure_epel_repo => true,
-              }
-            end
-
-            let(:gpgkey) do
-              case facts[:operatingsystemmajrelease]
-              when '6'
-                '0608B895'
-              when '7'
-                '352C64E5'
-              end
-            end
-
-            it { should contain_yumrepo('epel').with({
-              :mirrorlist => "https://mirrors.fedoraproject.org/metalink?repo=epel-#{facts[:operatingsystemmajrelease]}&arch=$basearch",
-              :gpgcheck   => 1,
-              :gpgkey     => "https://fedoraproject.org/static/#{gpgkey}.txt",
-            }) }
-            it { should contain_package('foreman-release-scl') }
-          end
+        let(:params) do
+          {
+            configure_scl_repo: true,
+            configure_epel_repo: true,
+          }
         end
+
+        it do
+          is_expected.to contain_yumrepo('epel')
+            .with_mirrorlist("https://mirrors.fedoraproject.org/metalink?repo=epel-#{facts[:operatingsystemmajrelease]}&arch=$basearch")
+            .with_gpgcheck(1)
+            .with_gpgkey('https://fedoraproject.org/static/352C64E5.txt')
+        end
+        it { is_expected.to contain_package('foreman-release-scl').with_ensure('installed') }
+      end
+
+      describe 'when scl repo set to latest' do
+        let(:params) do
+          {
+            configure_scl_repo: true,
+            configure_epel_repo: true,
+            scl_repo_ensure: 'latest',
+          }
+        end
+
+        it { is_expected.to contain_package('foreman-release-scl').with_ensure('latest') }
       end
 
       describe 'when fully disabled' do
         let(:params) do
           {
-            :configure_scl_repo       => false,
-            :configure_epel_repo      => false,
+            configure_scl_repo: false,
+            configure_epel_repo: false,
           }
         end
 
-        it { should_not contain_yumrepo('epel') }
-        it { should_not contain_package('foreman-release-scl') }
-        it { should_not contain_class('apt') }
-        it { should have_apt__ppa_resource_count(0) }
+        it { is_expected.to_not contain_yumrepo('epel') }
+        it { is_expected.to_not contain_package('foreman-release-scl') }
       end
     end
   end


### PR DESCRIPTION
This drops support for EL6 by only having the URL for the EL6 GPG key.

It also allows setting the package state of foreman-release-scl.