### PR TITLE
Notify when the ENC cache is used

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -380,7 +380,8 @@ if __FILE__ == $0 then
           result = enc(certname)
           cache(certname, result)
         end
-      rescue TimeoutError, SocketError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, FactUploadError
+      rescue [TimeoutError, SocketError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, FactUploadError] => e
+        $stderr.puts "Serving cached ENC: #{e}"
         # Read from cache, we got some sort of an error.
         result = read_cache(certname)
       end


### PR DESCRIPTION
When for whatever reason the ENC doesn't respond we silenty serve a
cached entry. This can lead to hard to debug problems. This adds a
warning on STDERR which tells the user something is wrong.