### PR TITLE
Trying to fix rescue syntax in ENC script

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -368,7 +368,7 @@ if __FILE__ == $0 then
           result = enc(certname)
           cache(certname, result)
         end
-      rescue [TimeoutError, SocketError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, FactUploadError] => e
+      rescue TimeoutError, SocketError, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, FactUploadError => e
         $stderr.puts "Serving cached ENC: #{e}"
         # Read from cache, we got some sort of an error.
         result = read_cache(certname)


### PR DESCRIPTION
I'm not very familiar with Ruby, but I think there's some problem with the syntax.

Today I saw errors from the ENC script when the foreman server was under high load. I manually ran the script and it only gave me the following output (not sure why there weren't any stacktraces):

```
class or module required for rescue clause
```

After removing the square brackets it was able to output like this:

```
Serving cached ENC: execution expired
---
classes: {}
parameters:
```