### PR TITLE
Clean up acceptance tests + make the apt repo parameters

### DIFF
--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -1,23 +1,27 @@
 # Install an apt repo
 define foreman::repos::apt (
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
+  Variant[String, Hash] $key = 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
+  Stdlib::Httpurl $location = 'https://deb.theforeman.org/',
 ) {
   include ::apt
 
-  Apt::Source {
-    location => 'https://deb.theforeman.org/',
-    key      => 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
+  ::apt::source { $name:
+    repos    => $repo,
+    location => $location,
+    key      => $key,
     include  => {
       src => false,
     },
   }
 
-  ::apt::source { $name:
-    repos => $repo,
-  }
-
   ::apt::source { "${name}-plugins":
-    release => 'plugins',
-    repos   => $repo,
+    release  => 'plugins',
+    repos    => $repo,
+    location => $location,
+    key      => $key,
+    include  => {
+      src => false,
+    },
   }
 }

--- a/spec/acceptance/foreman_basic_spec.rb
+++ b/spec/acceptance/foreman_basic_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman' do
   before(:context) do
-    case os[:family]
-    when /redhat|fedora/
+    case fact('osfamily')
+    when 'RedHat'
       on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when /debian|ubuntu/
+    when 'Debian'
       on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
       on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
       on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
@@ -13,7 +13,6 @@ describe 'Scenario: install foreman' do
   end
 
   let(:pp) do
-    configure = os[:family] == 'redhat' && os[:family] != 'fedora'
     <<-EOS
     # Workarounds
 
@@ -34,11 +33,7 @@ describe 'Scenario: install foreman' do
 
     # Actual test
     class { '::foreman':
-      custom_repo         => false,
       repo                => 'nightly',
-      gpgcheck            => true,
-      configure_epel_repo => #{configure},
-      configure_scl_repo  => #{configure},
       user_groups         => [],
       admin_username      => 'admin',
       admin_password      => 'changeme',

--- a/spec/acceptance/foreman_cli_plugins_spec.rb
+++ b/spec/acceptance/foreman_cli_plugins_spec.rb
@@ -28,6 +28,9 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
       password    => 'changeme',
     }
 
+    if $facts['osfamily'] == 'RedHat' {
+      include ::foreman::cli::ansible
+    }
     include ::foreman::cli::discovery
     include ::foreman::cli::remote_execution
     include ::foreman::cli::tasks

--- a/spec/acceptance/foreman_journald_spec.rb
+++ b/spec/acceptance/foreman_journald_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman' do
+describe 'Scenario: install foreman with journald' do
   before(:context) do
-    case os[:family]
-    when /redhat|fedora/
+    case fact('osfamily')
+    when 'RedHat'
       on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when /debian|ubuntu/
+    when 'Debian'
       on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
       on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
       on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
@@ -15,7 +15,6 @@ describe 'Scenario: install foreman' do
   service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
 
   let(:pp) do
-    configure = os[:family] == 'redhat' && os[:family] != 'fedora'
     <<-EOS
     # Workarounds
 
@@ -36,15 +35,11 @@ describe 'Scenario: install foreman' do
 
     # Actual test
     class { '::foreman':
-      custom_repo         => false,
-      repo                => 'nightly',
-      gpgcheck            => true,
-      configure_epel_repo => #{configure},
-      configure_scl_repo  => #{configure},
-      user_groups         => [],
-      admin_username      => 'admin',
-      admin_password      => 'changeme',
-      logging_type        => 'journald',
+      repo           => 'nightly',
+      user_groups    => [],
+      admin_username => 'admin',
+      admin_password => 'changeme',
+      logging_type   => 'journald',
     }
     EOS
   end

--- a/spec/acceptance/foreman_prometheus_spec.rb
+++ b/spec/acceptance/foreman_prometheus_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman' do
+describe 'Scenario: install foreman with prometheus' do
   before(:context) do
-    case os[:family]
-    when /redhat|fedora/
+    case fact('osfamily')
+    when 'RedHat'
       on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when /debian|ubuntu/
+    when 'Debian'
       on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
       on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
       on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
@@ -13,7 +13,6 @@ describe 'Scenario: install foreman' do
   end
 
   let(:pp) do
-    configure = os[:family] == 'redhat' && os[:family] != 'fedora'
     <<-EOS
     # Workarounds
 
@@ -34,11 +33,7 @@ describe 'Scenario: install foreman' do
 
     # Actual test
     class { '::foreman':
-      custom_repo                  => false,
       repo                         => 'nightly',
-      gpgcheck                     => true,
-      configure_epel_repo          => #{configure},
-      configure_scl_repo           => #{configure},
       user_groups                  => [],
       admin_username               => 'admin',
       admin_password               => 'changeme',

--- a/spec/acceptance/foreman_statsd_spec.rb
+++ b/spec/acceptance/foreman_statsd_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman' do
+describe 'Scenario: install foreman with statsd' do
   before(:context) do
-    case os[:family]
-    when /redhat|fedora/
+    case fact('osfamily')
+    when 'RedHat'
       on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when /debian|ubuntu/
+    when 'Debian'
       on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
       on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
       on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
@@ -13,7 +13,6 @@ describe 'Scenario: install foreman' do
   end
 
   let(:pp) do
-    configure = os[:family] == 'redhat' && os[:family] != 'fedora'
     <<-EOS
     # Workarounds
 
@@ -34,11 +33,7 @@ describe 'Scenario: install foreman' do
 
     # Actual test
     class { '::foreman':
-      custom_repo              => false,
       repo                     => 'nightly',
-      gpgcheck                 => true,
-      configure_epel_repo      => #{configure},
-      configure_scl_repo       => #{configure},
       user_groups              => [],
       admin_username           => 'admin',
       admin_password           => 'changeme',


### PR DESCRIPTION
This further unifies the tests and removes redundant workarounds. Also allows apt repo parameters to be overridden via hiera.