### PR TITLE
Fix wrong variable name in enc function

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -202,7 +202,7 @@ def enc(certname)
     response = http.request(req)
 
     unless response.code == "200"
-      raise "Error retrieving node #{certname}: #{res.class}\nCheck Foreman's /var/log/foreman/production.log for more information."
+      raise "Error retrieving node #{certname}: #{response.class}\nCheck Foreman's /var/log/foreman/production.log for more information."
     end
     response.body
   end


### PR DESCRIPTION
Since https://github.com/theforeman/puppet-foreman/commit/db49c49e3b1e5a95cb5ecb34b5f1c3b494ef5938 when a node doesn't exists

Current

```bash
$ ruby node.rb fake.notexists.com
undefined local variable or method `res' for main:Object
```
Expected

```bash
$ /etc/puppet/node.rb fake.notexists.com
Error retrieving node fake.notexists.com: Net::HTTPNotFound
Check Foreman's /var/log/foreman/production.log for more information.
```
