### PR TITLE
Remove default repo management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,11 +70,7 @@
 #
 # $ssl::                          Enable and set require_ssl in Foreman settings (note: requires passenger, SSL does not apply to kickstarts)
 #
-# $custom_repo::                  No need to change anything here by default
-#                                 if set to true, no repo will be added by this module, letting you 
-#                                 set it to some custom location.
-#
-# $repo::                         This can be stable, nightly or a specific version i.e. 1.7
+# $repo::                         This can be a specific version or nightly
 #
 # $configure_epel_repo::          If disabled the EPEL repo will not be configured on Red Hat family systems.
 #
@@ -229,8 +225,7 @@ class foreman (
   Stdlib::Fqdn $servername = $::foreman::params::servername,
   Array[Stdlib::Fqdn] $serveraliases = $::foreman::params::serveraliases,
   Boolean $ssl = $::foreman::params::ssl,
-  Boolean $custom_repo = $::foreman::params::custom_repo,
-  String $repo = $::foreman::params::repo,
+  Optional[String] $repo = $::foreman::params::repo,
   Boolean $configure_epel_repo = $::foreman::params::configure_epel_repo,
   Boolean $configure_scl_repo = $::foreman::params::configure_scl_repo,
   Optional[Boolean] $selinux = $::foreman::params::selinux,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,12 +36,9 @@ class foreman::params {
   # Only configure extra SCL repos on EL
   $configure_scl_repo       = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')
 
-  # Advanced configuration - no need to change anything here by default
-  # if set to true, no repo will be added by this module, letting you
-  # set it to some custom location.
-  $custom_repo       = false
+  # Advanced configuration
   # this can be a version or nightly
-  $repo              = '1.18'
+  $repo              = undef
   $app_root          = '/usr/share/foreman'
   $plugin_config_dir = '/etc/foreman/plugins'
   $manage_user       = true

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,12 +1,11 @@
 # Configure the foreman repo
 class foreman::repo(
-  $custom_repo         = $::foreman::custom_repo,
   $repo                = $::foreman::repo,
   $gpgcheck            = $::foreman::gpgcheck,
   $configure_epel_repo = $::foreman::configure_epel_repo,
   $configure_scl_repo  = $::foreman::configure_scl_repo,
 ) {
-  unless $custom_repo {
+  if $repo {
     foreman::repos { 'foreman':
       repo     => $repo,
       gpgcheck => $gpgcheck,

--- a/spec/acceptance/foreman_cli_plugins_spec.rb
+++ b/spec/acceptance/foreman_cli_plugins_spec.rb
@@ -16,7 +16,6 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
     configure = fact('osfamily') == 'RedHat' && fact('operatingsystem') != 'Fedora'
     <<-EOS
     class { '::foreman::repo':
-      custom_repo         => false,
       repo                => 'nightly',
       gpgcheck            => true,
       configure_epel_repo => #{configure},

--- a/spec/acceptance/foreman_cli_spec.rb
+++ b/spec/acceptance/foreman_cli_spec.rb
@@ -16,7 +16,6 @@ describe 'Scenario: install foreman-cli without foreman' do
     configure = fact('osfamily') == 'RedHat' && fact('operatingsystem') != 'Fedora'
     <<-EOS
     class { '::foreman::repo':
-      custom_repo         => false,
       repo                => 'nightly',
       gpgcheck            => true,
       configure_epel_repo => #{configure},

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -8,15 +8,15 @@ describe 'foreman' do
 
       describe 'with version' do
         let(:params) { super().merge(version: 'latest') }
-        it { should contain_foreman__repos('foreman') }
+        it { should_not contain_foreman__repos('foreman') }
         it { should contain_package('foreman-postgresql').with_ensure('latest') }
       end
 
-      describe 'with custom repo' do
-        let(:params) { super().merge(custom_repo: true) }
+      describe 'with repo' do
+        let(:params) { super().merge(repo: 'nightly') }
         it { should contain_class('foreman::repo') }
-        it { should_not contain_foreman__repos('foreman') }
-        it { should contain_package('foreman-postgresql') }
+        it { should contain_foreman__repos('foreman') }
+        it { should contain_package('foreman-postgresql').that_requires('Class[foreman::repo]') }
       end
 
       context 'with SELinux enabled' do

--- a/spec/classes/foreman_repo_spec.rb
+++ b/spec/classes/foreman_repo_spec.rb
@@ -8,7 +8,6 @@ describe 'foreman::repo' do
       describe 'with explicit parameters' do
         let :params do
           {
-            custom_repo: false,
             repo: '1.19',
             gpgcheck: true,
             configure_epel_repo: false,

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -11,10 +11,10 @@ describe 'foreman' do
 
         # repo
         it { should contain_class('foreman::repo').that_notifies('Class[foreman::install]') }
+        it { should_not contain_foreman__repos('foreman') }
         case facts[:osfamily]
         when 'RedHat'
           configure_repo = facts[:operatingsystem] != 'Fedora'
-          it { should contain_foreman__repos('foreman') }
           it {
             should contain_class('foreman::repos::extra')
               .with_configure_scl_repo(configure_repo)
@@ -25,7 +25,6 @@ describe 'foreman' do
             it { should contain_package('tfm-rubygem-passenger-native') }
           end
         when 'Debian'
-          it { should contain_foreman__repos('foreman') }
           it {
             should contain_class('foreman::repos::extra')
               .with_configure_scl_repo(false)
@@ -211,7 +210,6 @@ describe 'foreman' do
             servername: 'localhost',
             serveraliases: ['foreman'],
             ssl: true,
-            custom_repo: false,
             repo: 'nightly',
             configure_epel_repo: true,
             configure_scl_repo: false,


### PR DESCRIPTION
Because we're trying to move people away from the latest repository, we set it to configure an explicit version with a default. Because this default would need to be updated all the time, it's a bad idea.

This patch removes the $custom_repo and makes $repo undef by default. This means users get no repository by default and need to explicitly choose which repository to use.