### PR TITLE
Add certname to error output in external_node_v2.rb

### DIFF
--- a/files/external_node_v2.rb
+++ b/files/external_node_v2.rb
@@ -241,7 +241,7 @@ def upload_facts(certname, req)
       if response.code.start_with?('2')
         cache("#{certname}-push-facts", "Facts from this host were last pushed to #{uri} at #{Time.now}\n")
       else
-        $stderr.puts "During the fact upload the server responded with: #{response.code} #{response.message}. Error is ignored and the execution continues."
+        $stderr.puts "#{certname}: During the fact upload the server responded with: #{response.code} #{response.message}. Error is ignored and the execution continues."
         $stderr.puts response.body
       end
     end


### PR DESCRIPTION
This helps with debugging and gives error output more context. For
example Foreman will not accept pushed facts for a host that is
currently being built. With this change the error message changes from
this:

    During the fact upload the server responded with: 422 Unprocessable Entity. Error is ignored and the execution continues.
    {"message":"ERF42-9911 [Foreman::Exception]: Host is pending for Build"}

To this, which is preferable:

    app03.dev.example.com: During the fact upload the server responded with: 422 Unprocessable Entity. Error is ignored and the execution continues.
    {"message":"ERF42-9911 [Foreman::Exception]: Host is pending for Build"}