### PR TITLE
Simplify the memcache plugin

### DIFF
--- a/manifests/plugin/memcache.pp
+++ b/manifests/plugin/memcache.pp
@@ -13,11 +13,11 @@
 # $compress::   will gzip-compress values larger than 1K
 #
 class foreman::plugin::memcache (
-  Array[String] $hosts = $::foreman::plugin::memcache::params::hosts,
-  Integer[0] $expires_in = $::foreman::plugin::memcache::params::expires_in,
-  String $namespace = $::foreman::plugin::memcache::params::namespace,
-  Boolean $compress = $::foreman::plugin::memcache::params::compress,
-) inherits foreman::plugin::memcache::params {
+  Array[String] $hosts = [],
+  Integer[0] $expires_in = 86400,
+  String $namespace = 'foreman',
+  Boolean $compress = true,
+) {
   foreman::plugin {'memcache':
     config => template('foreman/foreman_memcache.yaml.erb'),
   }

--- a/manifests/plugin/memcache/params.pp
+++ b/manifests/plugin/memcache/params.pp
@@ -1,8 +1,0 @@
-# Default parameters for foreman::plugin::memcache
-class foreman::plugin::memcache::params {
-
-  $hosts                = []
-  $namespace            = 'foreman'
-  $expires_in           = 86400
-  $compress             = true
-}


### PR DESCRIPTION
Using params.pp for static values needlessly complicates the class.