### PR TITLE
Drop compatibility with Foreman 1.20 and older + puppetrun parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,11 @@ previous stable release.
 
 ### Foreman version compatibility notes
 
-Running without passenger is only supported on Foreman 1.22+.
+This module targets Foreman 1.21+. Running without passenger is only supported
+on Foreman 1.22+.
 
-The parameters `locations_enabled`, `organizations_enabled` and `authentication`
-will only have any affect on Foreman 1.20 or older, in newer versions these
-settings have been removed.
-
-**Warning** Users configuring Foreman 1.20 and earlier will need to pay
-particular attention. Some defaults have been flipped, including all user
-authentication.
-
-| Setting                    | module 11.x with 1.20 | module 10.x with 1.20 |
-|----------------------------|-----------------------|-----------------------|
-| `authentication` (`login`) | false                 | true                  |
-| `locations_enabled`        | true                  | false                 |
-| `organizations_enabled `   | true                  | false                 |
-
-For Foreman 1.16 or older, please use the 9.x release series of this module.
+The Foreman userdata plugin has been merged into Foreman 1.23 and removed from
+this module.
 
 ## Running without passenger
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,13 +46,6 @@
 #
 # $unattended_url::               URL hosts will retrieve templates from during build (normally http as many installers don't support https)
 #
-# $locations_enabled::            Enable locations? (Unused since 1.21)
-#
-# $organizations_enabled::        Enable organizations? (Unused since 1.21)
-#
-# $authentication::               Enable user authentication. (Unused since 1.21)
-#                                 Initial credentials are set using initial_admin_username and initial_admin_password.
-#
 # $passenger::                    Configure foreman via apache and passenger
 #
 # $passenger_ruby::               Ruby interpreter used to run Foreman under Passenger
@@ -220,7 +213,6 @@ class foreman (
   Boolean $puppetrun = $::foreman::params::puppetrun,
   Boolean $unattended = $::foreman::params::unattended,
   Optional[Stdlib::HTTPUrl] $unattended_url = $::foreman::params::unattended_url,
-  Optional[Boolean] $authentication = $::foreman::params::authentication,
   Boolean $passenger = $::foreman::params::passenger,
   Optional[String] $passenger_ruby = $::foreman::params::passenger_ruby,
   Optional[String] $passenger_ruby_package = $::foreman::params::passenger_ruby_package,
@@ -253,8 +245,6 @@ class foreman (
   String $group = $::foreman::params::group,
   Array[String] $user_groups = $::foreman::params::user_groups,
   String $rails_env = $::foreman::params::rails_env,
-  Optional[Boolean] $locations_enabled = $::foreman::params::locations_enabled,
-  Optional[Boolean] $organizations_enabled = $::foreman::params::organizations_enabled,
   Optional[String] $passenger_interface = $::foreman::params::passenger_interface,
   String $vhost_priority = $::foreman::params::vhost_priority,
   Stdlib::Port $server_port = $::foreman::params::server_port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,8 +36,6 @@
 #
 # $ipa_authentication::           Enable configuration for external authentication via IPA
 #
-# $puppetrun::                    Should Foreman be able to start Puppet runs on nodes
-#
 # === Advanced parameters:
 #
 # $foreman_url::                  URL on which foreman is going to run
@@ -210,7 +208,6 @@
 #
 class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
-  Boolean $puppetrun = $::foreman::params::puppetrun,
   Boolean $unattended = $::foreman::params::unattended,
   Optional[Stdlib::HTTPUrl] $unattended_url = $::foreman::params::unattended_url,
   Boolean $passenger = $::foreman::params::passenger,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,6 @@ class foreman::params {
   # should foreman manage host provisioning as well
   $unattended     = true
   $unattended_url = undef
-  # Enable users authentication (default user:admin pw:changeme) (Unused since 1.21)
-  $authentication = undef
   # configure foreman via apache and passenger
   $passenger      = true
   # Server name of the VirtualHost
@@ -25,9 +23,6 @@ class foreman::params {
   $passenger_prestart = true
   $passenger_min_instances = 1
   $passenger_start_timeout = 90
-  # Choose whether you want to enable locations and organizations. (Unused since 1.21)
-  $locations_enabled     = undef
-  $organizations_enabled = undef
 
   # Additional software repos
   $configure_epel_repo      = ($::osfamily == 'RedHat' and $::operatingsystem != 'Fedora')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -190,9 +190,6 @@ class foreman::params {
   $logging_layout = 'pattern'
   $loggers = {}
 
-  # Starting puppet runs with foreman
-  $puppetrun = false
-
   # KeepAlive settings of Apache
   $keepalive              = true
   $max_keepalive_requests = 100

--- a/manifests/plugin/userdata.pp
+++ b/manifests/plugin/userdata.pp
@@ -1,5 +1,0 @@
-# Installs foreman_userdata plugin
-class foreman::plugin::userdata {
-  foreman::plugin { 'userdata':
-  }
-}

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -49,7 +49,6 @@ describe 'foreman' do
             .with_content(/^:unattended:\s*true$/)
             .without_content(/^:unattended_url:/)
             .with_content(/^:require_ssl:\s*true$/)
-            .with_content(/^:puppetrun:\s*false$/)
             .with_content(/^:oauth_active:\s*true$/)
             .with_content(/^:oauth_map_users:\s*false$/)
             .with_content(/^:oauth_consumer_key:\s*\w+$/)
@@ -176,7 +175,6 @@ describe 'foreman' do
         let :params do
           {
             foreman_url: 'http://localhost',
-            puppetrun: false,
             unattended: true,
             passenger: true,
             passenger_ruby: '/usr/bin/ruby',

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -178,7 +178,6 @@ describe 'foreman' do
             foreman_url: 'http://localhost',
             puppetrun: false,
             unattended: true,
-            authentication: true,
             passenger: true,
             passenger_ruby: '/usr/bin/ruby',
             passenger_ruby_package: 'ruby-gem-passenger',
@@ -210,8 +209,6 @@ describe 'foreman' do
             group: 'foreman',
             user_groups: %w[adm wheel],
             rails_env: 'production',
-            locations_enabled: false,
-            organizations_enabled: true,
             passenger_interface: 'lo0',
             vhost_priority: '5',
             server_port: 80,
@@ -284,10 +281,7 @@ describe 'foreman' do
         let :params do
           {
             unattended: false,
-            authentication: false,
             ssl: false,
-            locations_enabled: true,
-            organizations_enabled: true,
             oauth_active: false,
             oauth_map_users: true,
             oauth_consumer_key: 'abc',
@@ -298,10 +292,7 @@ describe 'foreman' do
         it 'should have changed parameters' do
           should contain_concat__fragment('foreman_settings+01-header.yaml')
             .with_content(/^:unattended:\s*false$/)
-            .with_content(/^:login:\s*false$/)
             .with_content(/^:require_ssl:\s*false$/)
-            .with_content(/^:locations_enabled:\s*true$/)
-            .with_content(/^:organizations_enabled:\s*true$/)
             .with_content(/^:oauth_active:\s*false$/)
             .with_content(/^:oauth_map_users:\s*true$/)
             .with_content(/^:oauth_consumer_key:\s*abc$/)

--- a/spec/classes/plugin/userdata_spec.rb
+++ b/spec/classes/plugin/userdata_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe 'foreman::plugin::userdata' do
-  include_examples 'basic foreman plugin tests', 'userdata'
-end

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -7,16 +7,7 @@
 <% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::unattended_url")) -%>
 :unattended_url: <%= scope.lookupvar("foreman::unattended_url") %>
 <% end -%>
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::authentication")) -%>
-:login: <%= scope.lookupvar("foreman::authentication") %>
-<% end -%>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::locations_enabled")) -%>
-:locations_enabled: <%= scope.lookupvar("foreman::locations_enabled") %>
-<% end -%>
-<% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::organizations_enabled")) -%>
-:organizations_enabled: <%= scope.lookupvar("foreman::organizations_enabled") %>
-<% end -%>
 :puppetrun: <%= scope.lookupvar("foreman::puppetrun") %>
 
 # The following values are used for providing default settings during db migrate

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -8,7 +8,6 @@
 :unattended_url: <%= scope.lookupvar("foreman::unattended_url") %>
 <% end -%>
 :require_ssl: <%= scope.lookupvar("foreman::ssl") %>
-:puppetrun: <%= scope.lookupvar("foreman::puppetrun") %>
 
 # The following values are used for providing default settings during db migrate
 :oauth_active: <%= scope.lookupvar("foreman::oauth_active") %>


### PR DESCRIPTION
The puppetrun feature has become much less prominent and we shouldn't set this via the YAML file. This can be changed at runtime if desired or via the foreman_config_entry type.