### PR TITLE
Add rex cockpit integration support

### DIFF
--- a/manifests/plugin/remote_execution.pp
+++ b/manifests/plugin/remote_execution.pp
@@ -1,7 +1,70 @@
+# = Foreman Remote Execution
 # Installs foreman_remote_execution plugin
-class foreman::plugin::remote_execution {
+#
+# === Parameters:
+#
+# $cockpit:: Install cockpit support
+#
+class foreman::plugin::remote_execution (
+  Boolean $cockpit = $::foreman::plugin::remote_execution::params::cockpit,
+) inherits foreman::plugin::remote_execution::params {
   include ::foreman::plugin::tasks
 
   foreman::plugin {'remote_execution':
+  }
+
+  if $cockpit {
+    case $::osfamily {
+      'RedHat': {
+        case $::operatingsystem {
+          'fedora': {
+            $cockpit_package = 'rubygem-foreman_remote_execution-cockpit'
+          }
+          default: {
+            $cockpit_package = 'tfm-rubygem-foreman_remote_execution-cockpit'
+          }
+        }
+      }
+      default: {
+        fail("${::hostname}: foreman_remote_execution cockpit integration does not support osfamily ${::osfamily}")
+      }
+    }
+
+    package { $cockpit_package:
+      ensure => present,
+    }
+    ->
+    service { 'foreman-cockpit':
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+    }
+
+    file { '/etc/foreman/cockpit/cockpit.conf':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('foreman/remote_execution_cockpit.conf.erb'),
+      notify  => Service['foreman-cockpit'],
+    }
+
+    file { '/etc/foreman/cockpit/foreman-cockpit-session.yml':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template('foreman/remote_execution_cockpit_session.yml.erb'),
+      notify  => Service['foreman-cockpit'],
+    }
+
+    foreman::config::apache::fragment { 'cockpit':
+      ssl_content => template('foreman/cockpit-apache-ssl.conf.erb'),
+    }
+
+    foreman_config_entry { 'remote_execution_cockpit_url':
+      value => "/webcon/=%{host}",
+    }
   }
 }

--- a/manifests/plugin/remote_execution/params.pp
+++ b/manifests/plugin/remote_execution/params.pp
@@ -1,0 +1,4 @@
+# Data for the remote_execution plugin
+class foreman::plugin::remote_execution::params {
+  $cockpit = false
+}

--- a/manifests/plugin/remote_execution/params.pp
+++ b/manifests/plugin/remote_execution/params.pp
@@ -1,4 +1,0 @@
-# Data for the remote_execution plugin
-class foreman::plugin::remote_execution::params {
-  $cockpit = false
-}

--- a/templates/cockpit-apache-ssl.conf.erb
+++ b/templates/cockpit-apache-ssl.conf.erb
@@ -1,0 +1,14 @@
+### File managed with puppet ###
+
+<Location /webcon>
+  LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+  LoadModule proxy_http_module modules/mod_proxy_http.so
+
+  ProxyPreserveHost On
+
+  RewriteEngine On
+  RewriteCond %{HTTP:Upgrade} =websocket [NC]
+  RewriteRule /webcon/(.*)           ws://127.0.0.1:9999/webcon/$1 [P]
+  RewriteCond %{HTTP:Upgrade} !=websocket [NC]
+  RewriteRule /webcon/(.*)           http://127.0.0.1:9999/webcon/$1 [P]
+</Location>

--- a/templates/cockpit-apache-ssl.conf.erb
+++ b/templates/cockpit-apache-ssl.conf.erb
@@ -1,14 +1,11 @@
 ### File managed with puppet ###
 
-<Location /webcon>
-  LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
-  LoadModule proxy_http_module modules/mod_proxy_http.so
-
+<Location /<%= scope.lookupvar("cockpit_subpath") %>>
   ProxyPreserveHost On
 
   RewriteEngine On
   RewriteCond %{HTTP:Upgrade} =websocket [NC]
-  RewriteRule /webcon/(.*)           ws://127.0.0.1:9999/webcon/$1 [P]
+  RewriteRule /<%= scope.lookupvar("cockpit_subpath") %>/(.*)           ws://127.0.0.1:9999/<%= scope.lookupvar("cockpit_subpath") %>/$1 [P]
   RewriteCond %{HTTP:Upgrade} !=websocket [NC]
-  RewriteRule /webcon/(.*)           http://127.0.0.1:9999/webcon/$1 [P]
+  RewriteRule /<%= scope.lookupvar("cockpit_subpath") %>/(.*)           http://127.0.0.1:9999/<%= scope.lookupvar("cockpit_subpath") %>/$1 [P]
 </Location>

--- a/templates/remote_execution_cockpit.conf.erb
+++ b/templates/remote_execution_cockpit.conf.erb
@@ -1,7 +1,7 @@
 [WebService]
 LoginTitle = Foreman Cockpit
 UrlRoot = /webcon/
-Origins = https://<%= scope.lookupvar("::fqdn") %>
+Origins = <%= scope.lookupvar("foreman::foreman_url") %>
 
 [Bearer]
 Action = remote-login-ssh

--- a/templates/remote_execution_cockpit.conf.erb
+++ b/templates/remote_execution_cockpit.conf.erb
@@ -1,0 +1,14 @@
+[WebService]
+LoginTitle = Foreman Cockpit
+UrlRoot = /webcon/
+Origins = https://<%= scope.lookupvar("::fqdn") %>
+
+[Bearer]
+Action = remote-login-ssh
+
+[SSH-Login]
+command = /usr/sbin/foreman-cockpit-session
+
+[OAuth]
+Url = /cockpit/redirect
+

--- a/templates/remote_execution_cockpit.conf.erb
+++ b/templates/remote_execution_cockpit.conf.erb
@@ -1,6 +1,6 @@
 [WebService]
 LoginTitle = Foreman Cockpit
-UrlRoot = /webcon/
+UrlRoot = /<%= scope.lookupvar("cockpit_subpath") %>/
 Origins = <%= scope.lookupvar("foreman::foreman_url") %>
 
 [Bearer]

--- a/templates/remote_execution_cockpit_session.yml.erb
+++ b/templates/remote_execution_cockpit_session.yml.erb
@@ -1,4 +1,4 @@
-:foreman_url: https://<%= scope.lookupvar("::fqdn") %>
+:foreman_url: <%= scope.lookupvar("foreman::foreman_url") %>
 :ssl_ca_file: <%= scope.lookupvar("foreman::client_ssl_ca") %>
 :ssl_certificate: <%= scope.lookupvar("foreman::client_ssl_cert") %>
 :ssl_private_key: <%= scope.lookupvar("foreman::client_ssl_key") %>

--- a/templates/remote_execution_cockpit_session.yml.erb
+++ b/templates/remote_execution_cockpit_session.yml.erb
@@ -1,0 +1,4 @@
+:foreman_url: https://<%= scope.lookupvar("::fqdn") %>
+:ssl_ca_file: <%= scope.lookupvar("foreman::client_ssl_ca") %>
+:ssl_certificate: <%= scope.lookupvar("foreman::client_ssl_cert") %>
+:ssl_private_key: <%= scope.lookupvar("foreman::client_ssl_key") %>


### PR DESCRIPTION
This adds --foreman-plugin-remote-execution-cockpit boolean option to
add support for cockpit installation.

It enables foreman-cockpit.service (comming from
rubygem-foreman_remote_execution-cockpit package), that provides the
backend service for the cockpit tunel, and configures the settings
and authentication for the whole setup to work.

Requires:

- [ ]  https://github.com/theforeman/foreman-packaging/pull/4018.

When testing, SELinux needs to be disabled for now, as there are rules missing
for the foreman-cockpit service to work in enforcing mode.