### PR TITLE
Fixes #27716 - Mark foreman::compute::*::version as advanced

### DIFF
--- a/manifests/compute/ec2.pp
+++ b/manifests/compute/ec2.pp
@@ -1,8 +1,6 @@
-# = Foreman EC2 compute resource support
-#
 # Provides support for EC2 compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/foreman_compute.pp
+++ b/manifests/compute/foreman_compute.pp
@@ -1,7 +1,7 @@
 # Provides a common class to install foreman-compute
 # used by multiple compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/gce.pp
+++ b/manifests/compute/gce.pp
@@ -1,8 +1,6 @@
-# = Foreman Google Compute Engine compute resource support
-#
 # Provides support for Google Compute Engine compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/libvirt.pp
+++ b/manifests/compute/libvirt.pp
@@ -1,8 +1,6 @@
-# = Foreman LibVirt compute resource support
-#
 # Provides support for Libvirt compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/openstack.pp
+++ b/manifests/compute/openstack.pp
@@ -1,8 +1,6 @@
-# = Foreman OpenStack compute resource support
-#
 # Provides support for OpenStack compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/ovirt.pp
+++ b/manifests/compute/ovirt.pp
@@ -1,8 +1,6 @@
-# = Foreman oVirt compute resource support
-#
 # Provides support for oVirt compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/rackspace.pp
+++ b/manifests/compute/rackspace.pp
@@ -1,8 +1,6 @@
-# = Foreman Rackspace compute resource support
-#
 # Provides support for Rackspace compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #

--- a/manifests/compute/vmware.pp
+++ b/manifests/compute/vmware.pp
@@ -1,8 +1,6 @@
-# = Foreman VMware compute resource support
-#
 # Provides support for VMware compute resources
 #
-# === Parameters:
+# === Advanced Parameters:
 #
 # $version::  Package version to install, defaults to installed
 #


### PR DESCRIPTION
Most users won't change this away from installed to a specific version or latest. Especially in the installer. By making it an advanced parameter, we hide this from most users who won't care.