### PR TITLE
Make SSL parameters optional within foreman::puppetmaster

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -14,9 +14,9 @@ class foreman::puppetmaster (
   Stdlib::Absolutepath $puppet_etcdir = $::foreman::puppetmaster::params::puppet_etcdir,
   Integer $timeout = $::foreman::puppetmaster::params::puppetmaster_timeout,
   Integer $report_timeout = $::foreman::puppetmaster::params::puppetmaster_report_timeout,
-  Stdlib::Absolutepath $ssl_ca = $::foreman::puppetmaster::params::client_ssl_ca,
-  Stdlib::Absolutepath $ssl_cert = $::foreman::puppetmaster::params::client_ssl_cert,
-  Stdlib::Absolutepath $ssl_key = $::foreman::puppetmaster::params::client_ssl_key,
+  Variant[Enum[''], Stdlib::Absolutepath] $ssl_ca = $::foreman::puppetmaster::params::client_ssl_ca,
+  Variant[Enum[''], Stdlib::Absolutepath] $ssl_cert = $::foreman::puppetmaster::params::client_ssl_cert,
+  Variant[Enum[''], Stdlib::Absolutepath] $ssl_key = $::foreman::puppetmaster::params::client_ssl_key,
   Enum['v2'] $enc_api = 'v2',
   Enum['v2'] $report_api = 'v2',
 ) inherits foreman::puppetmaster::params {


### PR DESCRIPTION
Going from module version 9.2.0 to 10.0.0, `foreman::puppetmaster` changed`ssl_ca`, `ssl_cert`, `ssl_key`, the values of which end up in `foreman.yaml` from being anything-you-want to being Absolutepath.

However, both `external_node_v2.rb` and `foreman-report_v2.rb` (which consume `foreman.yaml`) have conditional logic which allow those ssl values to be empty.

This change seeks to allow those parameter values to be empty, if the user wishes.