### PR TITLE
Release 11.0.3 with the actual fix for #26695

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
-## [11.0.2](https://github.com/theforeman/puppet-foreman/tree/11.0.2) (2019-09-18)
+## [11.0.3](https://github.com/theforeman/puppet-foreman/tree/11.0.3) (2019-09-18)
 
-[Full Changelog](https://github.com/theforeman/puppet-foreman/compare/11.0.1...11.0.2)
+[Full Changelog](https://github.com/theforeman/puppet-foreman/compare/11.0.2...11.0.3)
 
 **Fixed bugs:**
 
 - Fixes [\#26695](https://projects.theforeman.org/issues/26695) - remove puppetdb\_dashboard\_address [\#729](https://github.com/theforeman/puppet-foreman/pull/729) ([mmoll](https://github.com/mmoll))
+
+## [11.0.2](https://github.com/theforeman/puppet-foreman/tree/11.0.2) (2019-09-18)
+
+[Full Changelog](https://github.com/theforeman/puppet-foreman/compare/11.0.1...11.0.2)
+
+Due to a mistake 11.0.2 was effectively the same release as 11.0.1.
 
 ## [11.0.1](https://github.com/theforeman/puppet-foreman/tree/11.0.1) (2019-04-02)
 

--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -40,9 +40,6 @@ class foreman::plugin::puppetdb (
   -> foreman_config_entry { 'puppetdb_address':
     value => $address,
   }
-  -> foreman_config_entry { 'puppetdb_dashboard_address':
-    value => $dashboard_address,
-  }
   -> foreman_config_entry { 'puppetdb_ssl_ca_file':
     value => $ssl_ca_file,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-foreman",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "author": "theforeman",
   "summary": "Foreman server configuration",
   "license": "GPL-3.0+",


### PR DESCRIPTION
dca5d41234bf54470ec96e3858caabbc4970f8f6 was intended to reduce fb5d38f8bea69ad8c6cb1300ce4d803fd89aace3 to an implementation only change but ended up being a full revert. This removes the dead setting that actively breaks installations.