### PR TITLE
Fixes #27932 - Add REX Cockpit support

### DIFF
--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -1,0 +1,52 @@
+# Installs remote execution cockpit plugin
+class foreman::plugin::remote_execution::cockpit {
+  require foreman::plugin::remote_execution
+
+  $config_directory = '/etc/foreman/cockpit'
+  $foreman_url = $foreman::foreman_url
+  $cockpit_path = '/webcon'
+  $cockpit_host = '127.0.0.1'
+  $cockpit_port = 9999
+  $cockpit_config = {
+    'foreman_url' => $foreman_url,
+    'ssl_ca_file' => $foreman::client_ssl_ca,
+    'ssl_certificate' => $foreman::client_ssl_cert,
+    'ssl_private_key' => $foreman::client_ssl_key,
+  }
+
+  foreman::plugin { 'remote_execution-cockpit': }
+  -> service { 'foreman-cockpit':
+    ensure => running,
+    enable => true,
+  }
+
+  file { "${config_directory}/cockpit.conf":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('foreman/remote_execution_cockpit.conf.erb'),
+    require => Foreman::Plugin['remote_execution-cockpit'],
+    notify  => Service['foreman-cockpit'],
+  }
+
+  file { "${config_directory}/foreman-cockpit-session.yml":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('foreman/remote_execution_cockpit_session.yml.erb'),
+    require => Foreman::Plugin['remote_execution-cockpit'],
+    notify  => Service['foreman-cockpit'],
+  }
+
+  include apache::mod::proxy_wstunnel
+  include apache::mod::proxy_http
+  foreman::config::apache::fragment { 'cockpit':
+    ssl_content => template('foreman/cockpit-apache-ssl.conf.erb'),
+  }
+
+  foreman_config_entry { 'remote_execution_cockpit_url':
+    value => "/${cockpit_path}/=%{host}",
+  }
+}

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::remote_execution::cockpit' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) do
+        <<-PUPPET
+        class {'foreman':
+          foreman_url     => 'https://foreman.example.com',
+          client_ssl_ca   => '/path/to/ca.pem',
+          client_ssl_cert => '/path/to/cert.pem',
+          client_ssl_key  => '/path/to/key.pem',
+        }
+        PUPPET
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_foreman__plugin('remote_execution-cockpit').that_notifies("Class[foreman::service]") }
+      it 'contains dependencies' do
+        is_expected.to contain_foreman__plugin('remote_execution')
+        is_expected.to contain_foreman__plugin('tasks')
+      end
+
+      it { is_expected.to contain_service('foreman-cockpit').with_ensure('running').with_enable('true') }
+
+      it 'creates configs' do
+        is_expected.to contain_file('/etc/foreman/cockpit/cockpit.conf')
+          .with_ensure('file')
+          .with_content([
+            '[WebService]',
+            'LoginTitle = Foreman Cockpit',
+            'UrlRoot = /webcon/',
+            'Origins = https://foreman.example.com',
+            '',
+            '[Bearer]',
+            'Action = remote-login-ssh',
+            '',
+            '[SSH-Login]',
+            'command = /usr/sbin/foreman-cockpit-session',
+            '',
+            '[OAuth]',
+            'Url = /cockpit/redirect',
+          ].join("\n") + "\n")
+          .that_requires('Foreman::Plugin[remote_execution-cockpit]')
+          .that_notifies('Service[foreman-cockpit]')
+
+        is_expected.to contain_file('/etc/foreman/cockpit/foreman-cockpit-session.yml')
+          .with_ensure('file')
+          .with_content([
+            '---',
+            ':foreman_url: "https://foreman.example.com"',
+            ':ssl_ca_file: "/path/to/ca.pem"',
+            ':ssl_certificate: "/path/to/cert.pem"',
+            ':ssl_private_key: "/path/to/key.pem"',
+          ].join("\n") + "\n")
+          .that_requires('Foreman::Plugin[remote_execution-cockpit]')
+          .that_notifies('Service[foreman-cockpit]')
+      end
+
+      it 'configures apache' do
+        is_expected.to contain_class('apache::mod::proxy_wstunnel')
+        is_expected.to contain_class('apache::mod::proxy_http')
+        is_expected.to contain_foreman__config__apache__fragment('cockpit')
+          .without_content
+          .with_ssl_content(%r{^<Location /webcon>$})
+          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           ws://127\.0\.0\.1:9999/webcon/\$1 \[P\]$})
+          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           http://127\.0\.0\.1:9999/webcon/\$1 \[P\]$})
+      end
+    end
+  end
+end

--- a/templates/cockpit-apache-ssl.conf.erb
+++ b/templates/cockpit-apache-ssl.conf.erb
@@ -1,0 +1,11 @@
+### File managed with puppet ###
+
+<Location <%= @cockpit_path %>>
+  ProxyPreserveHost On
+
+  RewriteEngine On
+  RewriteCond %{HTTP:Upgrade} =websocket [NC]
+  RewriteRule <%= @cockpit_path %>/(.*)           ws://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>/$1 [P]
+  RewriteCond %{HTTP:Upgrade} !=websocket [NC]
+  RewriteRule <%= @cockpit_path %>/(.*)           http://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>/$1 [P]
+</Location>

--- a/templates/remote_execution_cockpit.conf.erb
+++ b/templates/remote_execution_cockpit.conf.erb
@@ -1,0 +1,13 @@
+[WebService]
+LoginTitle = Foreman Cockpit
+UrlRoot = <%= @cockpit_path %>/
+Origins = <%= @foreman_url %>
+
+[Bearer]
+Action = remote-login-ssh
+
+[SSH-Login]
+command = /usr/sbin/foreman-cockpit-session
+
+[OAuth]
+Url = /cockpit/redirect

--- a/templates/remote_execution_cockpit_session.yml.erb
+++ b/templates/remote_execution_cockpit_session.yml.erb
@@ -1,0 +1,4 @@
+---
+<% @cockpit_config.each do |key, value| -%>
+:<%= key %>: "<%= value %>"
+<% end -%>


### PR DESCRIPTION
This only works with REX 1.8.3 and newer on RPMs.

Replaces https://github.com/theforeman/puppet-foreman/pull/748. It takes a different approach by making a separate class rather than a parameter.