### PR TITLE
Add options for rails_cache_store

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ on the host this module is applied to. Databases will be created with using the
 `en_US.utf8` locale, which means a respective OS locale must be available on
 the database host. The database management can be disabled with `db_manage`.
 
+## Rails Cache support
+
+Foreman supports different backends as Rails cache. This is handled by this
+module using the parameter `rails_cache_store`. The parameter takes a hash
+containing the type and options specfic to the backend.
+
+The default is the file backend, configured via `{'type' => 'file'}`. To
+setup for redis use a hash similar to `{'type' => 'redis', 'urls' => ['localhost:8479/0'], 'options' => {'compress' => 'true', 'namespace' => 'foreman'}}`
+where `urls` takes an array of redis urls which get prepended with `redis://`
+and `options` using a hash with options from [rails](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-store)
+falling back to `{'compress' => 'true', 'namespace' => 'foreman'}` if no
+option is provided.
+
+An example configuration for activating the redis backend with a local instance
+could look like this:
+
+```puppet
+class { 'foreman':
+  rails_cache_store => {
+    'type' => 'redis',
+    'urls' => ['localhost:8479/0'],
+    'options' => {
+      'compress' => 'true',
+      'namespace' => 'foreman'
+    }
+  }
+}
+```
+
 ## Support policy
 
 At any time, the module supports two releases, however the previous version

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,6 +196,8 @@
 #
 # $foreman_service_puma_workers::         Number of workers for Puma. Relevant only when Puma service is used and ignored when Passenger is used.
 #
+# $rails_cache_store::            Set rails cache store
+#
 # === Keycloak parameters:
 #
 # $keycloak::                     Enable Keycloak support. Note this is limited
@@ -301,6 +303,7 @@ class foreman (
   Integer[0] $foreman_service_puma_threads_min = $foreman::params::foreman_service_puma_threads_min,
   Integer[0] $foreman_service_puma_threads_max = $foreman::params::foreman_service_puma_threads_max,
   Integer[0] $foreman_service_puma_workers = $foreman::params::foreman_service_puma_workers,
+  Hash[String, Any] $rails_cache_store = $foreman::params::rails_cache_store,
   Boolean $keycloak = $foreman::params::keycloak,
   String[1] $keycloak_app_name = $foreman::params::keycloak_app_name,
   String[1] $keycloak_realm = $foreman::params::keycloak_realm,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,4 +47,10 @@ class foreman::install {
       ensure => installed,
     }
   }
+
+  if $foreman::rails_cache_store['type'] == 'redis' {
+    package { 'foreman-redis':
+      ensure => installed,
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -192,6 +192,9 @@ class foreman::params {
   $logging_layout = 'pattern'
   $loggers = {}
 
+  # Rails Cache Store
+  $rails_cache_store = { 'type' => 'file' }
+
   # Default ports for Apache to listen on
   $server_port     = 80
   $server_ssl_port = 443

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -340,6 +340,32 @@ describe 'foreman' do
         end
       end
 
+      describe 'with rails_cache_store file' do
+        let(:params) { super().merge(rails_cache_store: { type: "file" }) }
+        it 'should set rails_cache_store config' do
+          should contain_concat__fragment('foreman_settings+01-header.yaml')
+            .with_content(/^:rails_cache_store:\n\s+:type:\s*file$/)
+        end
+      end
+
+      describe 'with rails_cache_store redis' do
+        let(:params) { super().merge(rails_cache_store: { type: "redis", urls: [ "redis.example.com/0" ]}) }
+        it 'should set rails_cache_store config' do
+          should contain_concat__fragment('foreman_settings+01-header.yaml')
+            .with_content(/^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis:\/\/redis.example.com\/0\n\s+:options:\n\s+:compress:\s*true\n\s+:namespace:\s*foreman$/)
+        end
+        it { is_expected.to contain_package('foreman-redis') }
+      end
+
+      describe 'with rails_cache_store redis with options' do
+        let(:params) { super().merge(rails_cache_store: { type: "redis", urls: [ "redis.example.com/0", "redis2.example.com/0" ], options: {compress: "false", namespace: "katello"}}) }
+        it 'should set rails_cache_store config' do
+          should contain_concat__fragment('foreman_settings+01-header.yaml')
+            .with_content(/^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis:\/\/redis.example.com\/0\n\s*- redis:\/\/redis2.example.com\/0\n\s+:options:\n\s+:compress:\s*false\n\s+:namespace:\s*katello$/)
+        end
+        it { is_expected.to contain_package('foreman-redis') }
+      end
+
       describe 'with cors domains' do
         let(:params) { super().merge(cors_domains: ['https://example.com']) }
         it 'should set cors config' do

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -77,6 +77,28 @@
   :pool_size: <%= scope.lookupvar("foreman::dynflow_pool_size") %>
   :redis_url: <%= scope.lookupvar("foreman::config::jobs_redis_url") %>
 <% end -%>
+
+:rails_cache_store:
+  :type: <%= scope["foreman::rails_cache_store"]["type"] %>
+<% if scope["foreman::rails_cache_store"]["type"] == "redis" -%>
+   :urls:
+<%   if scope["foreman::rails_cache_store"].key?("urls") -%>
+<%     scope["foreman::rails_cache_store"]["urls"].each do |url| -%>
+     - redis://<%= url %>
+<%     end -%>
+<%   else -%>
+     - redis://localhost:8479/0
+<%   end -%>
+   :options:
+<%   if scope["foreman::rails_cache_store"].key?("options") -%>
+<%     scope["foreman::rails_cache_store"]["options"].each do |option,value| -%>
+     :<%= option %>: <%= value %>
+<%     end -%>
+<%   else -%>
+     :compress: true
+     :namespace: foreman
+<%   end -%>
+<% end -%>
 <% if scope.lookupvar("foreman::apache") && !scope.lookupvar("foreman::passenger") -%>
 
 # Configure reverse proxy headers


### PR DESCRIPTION
This allows to make use of redis as backend, but still defaults to file.

@timogoebel: Can you have a look as the feature was implemented by you and so you perhaps know best if the parameters make sense in this way?