### PR TITLE
Fixes #28200 - Change cockpit port from 9999 to 19090

### DIFF
--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -6,7 +6,7 @@ class foreman::plugin::remote_execution::cockpit {
   $foreman_url = $foreman::foreman_url
   $cockpit_path = '/webcon'
   $cockpit_host = '127.0.0.1'
-  $cockpit_port = 9999
+  $cockpit_port = 19090
   $cockpit_config = {
     'foreman_url' => $foreman_url,
     'ssl_ca_file' => $foreman::server_ssl_chain,

--- a/spec/acceptance/foreman_rex_cockpit_spec.rb
+++ b/spec/acceptance/foreman_rex_cockpit_spec.rb
@@ -77,7 +77,7 @@ describe 'Scenario: install foreman', if: os[:family] == 'centos' do
     it { is_expected.to be_listening }
   end
 
-  describe port(9999) do
+  describe port(19090) do
     it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
   end
 

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -64,8 +64,8 @@ describe 'foreman::plugin::remote_execution::cockpit' do
         is_expected.to contain_foreman__config__apache__fragment('cockpit')
           .without_content
           .with_ssl_content(%r{^<Location /webcon>$})
-          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           ws://127\.0\.0\.1:9999/webcon/\$1 \[P\]$})
-          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           http://127\.0\.0\.1:9999/webcon/\$1 \[P\]$})
+          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           ws://127\.0\.0\.1:19090/webcon/\$1 \[P\]$})
+          .with_ssl_content(%r{^  RewriteRule /webcon/\(\.\*\)           http://127\.0\.0\.1:19090/webcon/\$1 \[P\]$})
       end
     end
   end


### PR DESCRIPTION
This adjusts the installer to match changes done in the REX PR[1].

[1] - https://github.com/theforeman/foreman_remote_execution/pull/441