### PR TITLE
Reduce duplication by using shared examples

### DIFF
--- a/spec/acceptance/foreman_basic_spec.rb
+++ b/spec/acceptance/foreman_basic_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman' do
-  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
-
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* mod_passenger && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-
-    on default, "systemctl stop #{apache_service_name}", { :acceptable_exit_codes => [0, 5] }
-  end
-
   let(:pp) do
     <<-EOS
     # Workarounds
@@ -61,17 +46,7 @@ describe 'Scenario: install foreman' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe service(apache_service_name) do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('dynflowd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
+  include_examples 'foreman via passenger'
 
   describe package('foreman-journald') do
     it { is_expected.not_to be_installed }
@@ -79,18 +54,5 @@ describe 'Scenario: install foreman' do
 
   describe package('foreman-telemetry') do
     it { is_expected.not_to be_installed }
-  end
-
-  describe port(80) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(443) do
-    it { is_expected.to be_listening }
-  end
-
-  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
-    its(:exit_status) { is_expected.to eq 0 }
   end
 end

--- a/spec/acceptance/foreman_cli_plugins_spec.rb
+++ b/spec/acceptance/foreman_cli_plugins_spec.rb
@@ -1,17 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-cli + plugins without foreman' do
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-  end
-
   let(:pp) do
     configure = fact('osfamily') == 'RedHat' && fact('operatingsystem') != 'Fedora'
     <<-EOS
@@ -38,7 +27,7 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
+  include_examples 'hammer'
 
   ['discovery', 'remote_execution', 'tasks', 'templates'].each do |plugin|
     package_name = case fact('osfamily')
@@ -53,9 +42,5 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
     describe package(package_name) do
       it { is_expected.to be_installed }
     end
-  end
-
-  describe command('hammer --version') do
-    its(:stdout) { is_expected.to match(/^hammer/) }
   end
 end

--- a/spec/acceptance/foreman_cli_spec.rb
+++ b/spec/acceptance/foreman_cli_spec.rb
@@ -1,17 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman-cli without foreman' do
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-  end
-
   let(:pp) do
     configure = fact('osfamily') == 'RedHat' && fact('operatingsystem') != 'Fedora'
     <<-EOS
@@ -29,9 +18,5 @@ describe 'Scenario: install foreman-cli without foreman' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe command('hammer --version') do
-    its(:stdout) { is_expected.to match(/^hammer/) }
-  end
+  include_examples 'hammer'
 end

--- a/spec/acceptance/foreman_prometheus_spec.rb
+++ b/spec/acceptance/foreman_prometheus_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman with prometheus' do
-  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
-
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* mod_passenger && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-
-    on default, "systemctl stop #{apache_service_name}", { :acceptable_exit_codes => [0, 5] }
-  end
-
   let(:pp) do
     <<-EOS
     # Workarounds
@@ -62,33 +47,10 @@ describe 'Scenario: install foreman with prometheus' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe service(apache_service_name) do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('dynflowd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
+  include_examples 'foreman via passenger'
 
   describe package('foreman-telemetry') do
     it { is_expected.to be_installed }
-  end
-
-  describe port(80) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(443) do
-    it { is_expected.to be_listening }
-  end
-
-  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
-    its(:exit_status) { is_expected.to eq 0 }
   end
 
   # TODO: actually verify prometheus functionality

--- a/spec/acceptance/foreman_reverse_proxy_spec.rb
+++ b/spec/acceptance/foreman_reverse_proxy_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman' do
-  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
-
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* mod_passenger && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-
-    on default, "systemctl stop #{apache_service_name}", { :acceptable_exit_codes => [0, 5] }
-  end
-
   let(:pp) do
     <<-EOS
     $directory = '/etc/foreman'
@@ -52,37 +37,5 @@ describe 'Scenario: install foreman' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe service(apache_service_name) do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('dynflowd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('foreman') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe port(80) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(443) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(3000) do
-    it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
-  end
-
-  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
-    its(:exit_status) { is_expected.to eq 0 }
-  end
+  include_examples 'foreman via puma'
 end

--- a/spec/acceptance/foreman_rex_cockpit_spec.rb
+++ b/spec/acceptance/foreman_rex_cockpit_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman', if: os[:family] == 'centos' do
-  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
-
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* mod_passenger && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-
-    on default, "systemctl stop #{apache_service_name}", { :acceptable_exit_codes => [0, 5] }
-  end
-
   let(:pp) do
     <<-EOS
     $directory = '/etc/foreman'
@@ -52,37 +37,9 @@ describe 'Scenario: install foreman', if: os[:family] == 'centos' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe service(apache_service_name) do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('dynflowd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('foreman') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe port(80) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(443) do
-    it { is_expected.to be_listening }
-  end
+  include_examples 'foreman via passenger'
 
   describe port(19090) do
     it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
-  end
-
-  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
-    its(:exit_status) { is_expected.to eq 0 }
   end
 end

--- a/spec/acceptance/foreman_statsd_spec.rb
+++ b/spec/acceptance/foreman_statsd_spec.rb
@@ -1,21 +1,6 @@
 require 'spec_helper_acceptance'
 
 describe 'Scenario: install foreman with statsd' do
-  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
-
-  before(:context) do
-    case fact('osfamily')
-    when 'RedHat'
-      on default, 'yum -y remove foreman* tfm-* mod_passenger && rm -rf /etc/yum.repos.d/foreman*.repo'
-    when 'Debian'
-      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
-      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
-    end
-
-    on default, "systemctl stop #{apache_service_name}", { :acceptable_exit_codes => [0, 5] }
-  end
-
   let(:pp) do
     <<-EOS
     # Workarounds
@@ -62,33 +47,10 @@ describe 'Scenario: install foreman with statsd' do
     EOS
   end
 
-  it_behaves_like 'a idempotent resource'
-
-  describe service(apache_service_name) do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
-
-  describe service('dynflowd') do
-    it { is_expected.to be_enabled }
-    it { is_expected.to be_running }
-  end
+  include_examples 'foreman via passenger'
 
   describe package('foreman-telemetry') do
     it { is_expected.to be_installed }
-  end
-
-  describe port(80) do
-    it { is_expected.to be_listening }
-  end
-
-  describe port(443) do
-    it { is_expected.to be_listening }
-  end
-
-  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
-    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
-    its(:exit_status) { is_expected.to eq 0 }
   end
 
   # TODO: actually verify statsd functionality

--- a/spec/support/acceptance/foreman.rb
+++ b/spec/support/acceptance/foreman.rb
@@ -1,0 +1,76 @@
+shared_examples 'foreman application' do
+  apache_service_name = ['debian', 'ubuntu'].include?(os[:family]) ? 'apache2' : 'httpd'
+
+  before(:context) do
+    case fact('osfamily')
+    when 'RedHat'
+      on default, 'yum -y remove foreman* tfm-* mod_passenger'
+      on default, 'rm -rf /etc/yum.repos.d/foreman*.repo'
+    when 'Debian'
+      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
+      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
+      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
+    end
+
+    on default, puppet('resource', 'service', apache_service_name, 'ensure=stopped')
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe service(apache_service_name) do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe service('dynflowd') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(443) do
+    it { is_expected.to be_listening }
+  end
+
+  describe command("curl -s --cacert /etc/foreman/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do
+    its(:stdout) { is_expected.to eq("https://#{host_inventory['fqdn']}/users/login") }
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end
+
+shared_examples 'foreman via passenger' do
+  include_examples 'foreman application'
+
+  describe package('foreman-service') do
+    it { is_expected.not_to be_installed }
+  end
+
+  describe service('foreman') do
+    it { is_expected.not_to be_enabled }
+    it { is_expected.not_to be_running }
+  end
+
+  describe port(3000) do
+    it { is_expected.not_to be_listening.on('127.0.0.1') }
+  end
+end
+
+shared_examples 'foreman via puma' do
+  include_examples 'foreman application'
+
+  describe package('foreman-service') do
+    it { is_expected.to be_installed }
+  end
+
+  describe service('foreman') do
+    it { is_expected.to be_enabled }
+    it { is_expected.to be_running }
+  end
+
+  describe port(3000) do
+    it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
+  end
+end

--- a/spec/support/acceptance/hammer.rb
+++ b/spec/support/acceptance/hammer.rb
@@ -1,0 +1,18 @@
+shared_examples 'hammer' do
+  before(:context) do
+    case fact('osfamily')
+    when 'RedHat'
+      on default, 'yum -y remove foreman* tfm-* && rm -rf /etc/yum.repos.d/foreman*.repo'
+    when 'Debian'
+      on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }
+      on default, 'apt-get purge -y ruby-hammer-cli-*', { :acceptable_exit_codes => [0, 100] }
+      on default, 'rm -rf /etc/apt/sources.list.d/foreman*'
+    end
+  end
+
+  it_behaves_like 'a idempotent resource'
+
+  describe command('hammer --version') do
+    its(:stdout) { is_expected.to match(/^hammer/) }
+  end
+end


### PR DESCRIPTION
The acceptance tests always test the same basic set. By using shared
examples, the duplication can be avoided.