### PR TITLE
Add check for file to migrate and seed database

### DIFF
--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -4,6 +4,7 @@ define foreman::rake(
   $timeout  = undef,
   $user     = $::foreman::user,
   $app_root = $::foreman::app_root,
+  $unless   = undef,
 ) {
   # https://github.com/rodjek/puppet-lint/issues/327
   # lint:ignore:arrow_alignment
@@ -14,6 +15,7 @@ define foreman::rake(
     logoutput   => 'on_failure',
     refreshonly => true,
     timeout     => $timeout,
+    unless      => $unless,
   }
   # lint:endignore
 }


### PR DESCRIPTION
This is working to replace RPMs running migration steps by driving the database migration and seed via  the existence of files. There are two approaches that could be taken:

 1) Create a file when migration or seed occurs, have users or packages remove those files to signal migration/seed is needed
 2) Have users or packages create files to signal a migration/seed is needed and have the intsaller only run these steps if those files exist and then remove them

I went back and forth and landed on a more installer centric view via #1. I perceived benefits were:

 * the installer just works initially since it does not rely on something creating a file first
 * this allows some tracking of the last time migrations or seeds were ran via the file timestamp
 * packages can remove the files to signal the need for installation

I'm open to option #2 as an alternative this just puts a burden on external creation of these files for the initial installer run (which can reasonably be expected but feels bad).