### PR TITLE
Run migrations if there are pending migrations

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -6,7 +6,7 @@ class foreman::database {
     contain $db_class
 
     if $::foreman::db_manage_rake {
-      Class[$db_class] ~> Foreman_config_entry['db_pending_migration']
+      Class[$db_class] ~> Foreman::Rake['db:migrate']
     }
   }
 
@@ -21,11 +21,9 @@ class foreman::database {
       'SEED_LOCATION'         => $::foreman::initial_location,
     }
 
-    foreman_config_entry { 'db_pending_migration':
-      value => false,
-      dry   => true,
+    foreman::rake { 'db:migrate':
+      unless => '/usr/sbin/foreman-rake db:abort_if_pending_migrations',
     }
-    ~> foreman::rake { 'db:migrate': }
     ~> foreman_config_entry { 'db_pending_seed':
       value => false,
       dry   => true,

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -4,6 +4,7 @@ define foreman::rake(
   $timeout  = undef,
   $user     = $::foreman::user,
   $app_root = $::foreman::app_root,
+  $unless   = undef,
 ) {
   # https://github.com/rodjek/puppet-lint/issues/327
   # lint:ignore:arrow_alignment
@@ -12,8 +13,9 @@ define foreman::rake(
     user        => $user,
     environment => sort(join_keys_to_values(merge({'HOME' => $app_root}, $environment), '=')),
     logoutput   => 'on_failure',
-    refreshonly => true,
+    refreshonly => $unless =~ Undef,
     timeout     => $timeout,
+    unless      => $unless,
   }
   # lint:endignore
 }

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -11,7 +11,6 @@ describe 'foreman' do
 
         it { should_not contain_class('foreman::database::postgresql') }
 
-        it { should contain_foreman_config_entry('db_pending_migration') }
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }
@@ -24,7 +23,6 @@ describe 'foreman' do
         it { should compile.with_all_deps }
         it { should contain_class('foreman::database::postgresql') }
 
-        it { should_not contain_foreman_config_entry('db_pending_migration') }
         it { should_not contain_foreman__rake('db:migrate') }
         it { should_not contain_foreman_config_entry('db_pending_seed') }
         it { should_not contain_foreman__rake('db:seed') }

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -122,10 +122,9 @@ describe 'foreman' do
         it { should_not contain_class('foreman::database::mysql') }
         it {
           should contain_class('foreman::database::postgresql')
-            .that_notifies('Foreman_config_entry[db_pending_migration]')
+            .that_notifies('Foreman::Rake[db:migrate]')
         }
 
-        it { should contain_foreman_config_entry('db_pending_migration') }
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }

--- a/spec/defines/foreman_rake_spec.rb
+++ b/spec/defines/foreman_rake_spec.rb
@@ -8,55 +8,44 @@ describe 'foreman::rake' do
       on_supported_os['redhat-7-x86_64']
     end
 
-    context 'without parameters' do
-      # These parameters are inherited normally, but here we cheat for performance
-      let :params do
-        {
-          user: 'foreman',
-          app_root: '/usr/share/foreman'
-        }
-      end
+    # These parameters are inherited normally, but here we cheat for performance
+    let :params do
+      {
+        user: 'foreman',
+        app_root: '/usr/share/foreman'
+      }
+    end
 
-      it {
+    context 'without parameters' do
+      it do
         should contain_exec('foreman-rake-db:migrate')
           .with_command('/usr/sbin/foreman-rake db:migrate')
           .with_user('foreman')
           .with_environment(['HOME=/usr/share/foreman'])
           .with_logoutput('on_failure')
           .with_refreshonly(true)
-      }
+          .with_timeout(nil)
+          .with_unless(nil)
+      end
     end
 
     context 'with environment' do
-      let :params do
-        {
-          environment: { 'SEED_USER' => 'admin' },
-          user: 'foreman',
-          app_root: '/usr/share/foreman'
-        }
-      end
+      let(:params) { super().merge(environment: { 'SEED_USER' => 'admin' }) }
 
-      it {
+      it do
         should contain_exec('foreman-rake-db:migrate')
           .with_command('/usr/sbin/foreman-rake db:migrate')
           .with_user('foreman')
           .with_environment(['HOME=/usr/share/foreman', 'SEED_USER=admin'])
           .with_logoutput('on_failure')
           .with_refreshonly(true)
-          .with_timeout(nil)
-      }
+      end
     end
 
     context 'with timeout' do
-      let :params do
-        {
-          timeout: 60,
-          user: 'foreman',
-          app_root: '/usr/share/foreman'
-        }
-      end
+      let(:params) { super().merge(timeout: 60) }
 
-      it {
+      it do
         should contain_exec('foreman-rake-db:migrate')
           .with_command('/usr/sbin/foreman-rake db:migrate')
           .with_user('foreman')
@@ -64,7 +53,21 @@ describe 'foreman::rake' do
           .with_timeout(60)
           .with_logoutput('on_failure')
           .with_refreshonly(true)
-      }
+      end
+    end
+
+    context 'with unless' do
+      let(:params) { super().merge(unless: '/usr/bin/true') }
+
+      it do
+        should contain_exec('foreman-rake-db:migrate')
+          .with_command('/usr/sbin/foreman-rake db:migrate')
+          .with_user('foreman')
+          .with_environment(['HOME=/usr/share/foreman'])
+          .with_logoutput('on_failure')
+          .with_refreshonly(false)
+          .with_unless('/usr/bin/true')
+      end
     end
   end
 end


### PR DESCRIPTION
This drops relying on a settings entry in favor of lettings Rails
tell us when there are migrations that need to be applied.