### PR TITLE
Drop database seeding and let Foreman app handle

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -22,13 +22,10 @@ class foreman::database {
     foreman::rake { 'db:migrate':
       unless => '/usr/sbin/foreman-rake db:abort_if_pending_migrations',
     }
-    ~> foreman_config_entry { 'db_pending_seed':
-      value => false,
-      dry   => true,
-    }
-    ~> foreman::rake { 'db:seed':
+    ~> Foreman::Rake['apipie:cache:index']
+
+    foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
     }
-    ~> Foreman::Rake['apipie:cache:index']
   }
 }


### PR DESCRIPTION
For lack of a better option, I went with creating a file on seed that can be removed by RPMs. This will allow RPMs to be simplified and still indicate when seeding is needed. Within the katello scenario, we can also drop this post upgrade task:

https://github.com/theforeman/foreman-installer/blob/develop/katello/hooks/post/30-upgrade.rb#L16