### PR TITLE
Drop the selinux parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -88,7 +88,7 @@ class foreman::config {
         fail("${::hostname}: The system does not seem to be IPA-enrolled")
       }
 
-      if $::foreman::selinux or (str2bool($::selinux) and $::foreman::selinux != false) {
+      if $facts['selinux'] {
         selboolean { ['allow_httpd_mod_auth_pam', 'httpd_dbus_sssd']:
           persistent => true,
           value      => 'on',

--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -97,7 +97,6 @@ class foreman::config::apache(
   Boolean $ipa_authentication = $::foreman::ipa_authentication,
   Hash[String, Any] $http_vhost_options = {},
   Hash[String, Any] $https_vhost_options = {},
-  Optional[Boolean] $selinux = $::foreman::selinux,
 ) {
   $docroot = "${app_root}/public"
   $suburi_parts = split($foreman_url, '/')
@@ -184,7 +183,7 @@ class foreman::config::apache(
       ],
     }
 
-    if $selinux or ($facts['selinux'] and $selinux != false) {
+    if $facts['selinux'] {
       selboolean { 'httpd_can_network_connect':
         persistent => true,
         value      => 'on',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,9 +66,6 @@
 # $configure_scl_repo::           If disabled the SCL repo will not be configured on Red Hat clone systems.
 #                                 (Currently only installs repos for CentOS and Scientific)
 #
-# $selinux::                      When undef, foreman-selinux will be installed if SELinux is enabled
-#                                 setting to false/true will override this check (e.g. set to false on 1.1)
-#
 # $gpgcheck::                     Turn on/off gpg check in repo files (effective only on RedHat family systems)
 #
 # $version::                      Foreman package version, it's passed to ensure parameter of package resource
@@ -219,7 +216,6 @@ class foreman (
   Optional[String] $repo = $::foreman::params::repo,
   Boolean $configure_epel_repo = $::foreman::params::configure_epel_repo,
   Boolean $configure_scl_repo = $::foreman::params::configure_scl_repo,
-  Optional[Boolean] $selinux = $::foreman::params::selinux,
   Boolean $gpgcheck = $::foreman::params::gpgcheck,
   String $version = $::foreman::params::version,
   Enum['installed', 'present', 'latest'] $plugin_version = $::foreman::params::plugin_version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class foreman::install {
     ensure => $::foreman::version,
   }
 
-  if $::foreman::selinux or (str2bool($::selinux) and $::foreman::selinux != false) {
+  if $facts['selinux'] {
     package { 'foreman-selinux':
       ensure => $::foreman::version,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,10 +47,6 @@ class foreman::params {
 
   $cors_domains = []
 
-  # when undef, foreman-selinux will be installed if SELinux is enabled
-  # setting to false/true will override this check (e.g. set to false on 1.1)
-  $selinux     = undef
-
   # if enabled, will install and configure the database server on this host
   $db_manage   = true
   # Database 'production' settings

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -33,7 +33,6 @@ describe 'foreman::config::apache' do
           server_ssl_port: 443,
           proxy_backend: 'http://127.0.0.1:3000/',
           ipa_authentication: false,
-          selinux: true
         }
       end
 

--- a/spec/classes/foreman_config_ipa_spec.rb
+++ b/spec/classes/foreman_config_ipa_spec.rb
@@ -62,20 +62,7 @@ describe 'foreman' do
 
           context 'on selinux system' do
             let(:facts) { super().merge(selinux: true) }
-
-            describe 'with disabled by user' do
-              let(:params) { super().merge(selinux: false) }
-              it { should_not contain_selboolean('httpd_dbus_sssd') }
-            end
-
-            describe 'with enabled by user' do
-              let(:params) { super().merge(selinux: true) }
-              it { should contain_selboolean('httpd_dbus_sssd') }
-            end
-
-            describe 'with automatic' do
-              it { should contain_selboolean('httpd_dbus_sssd') }
-            end
+            it { should contain_selboolean('httpd_dbus_sssd') }
           end
         end
       end

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -21,38 +21,12 @@ describe 'foreman' do
 
       context 'with SELinux enabled' do
         let(:facts) { super().merge(selinux: true) }
-
-        describe 'with selinux => false' do
-          let(:params) { super().merge(selinux: false) }
-          it { should_not contain_package('foreman-selinux') }
-        end
-
-        describe 'with selinux => true' do
-          let(:params) { super().merge(selinux: true) }
-          it { should contain_package('foreman-selinux') }
-        end
-
-        describe 'with selinux => undef' do
-          it { should contain_package('foreman-selinux') }
-        end
+        it { should contain_package('foreman-selinux') }
       end
 
       context 'with SELinux disabled' do
         let(:facts) { super().merge(selinux: false) }
-
-        describe 'with selinux => false' do
-          let(:params) { super().merge(selinux: false) }
-          it { should_not contain_package('foreman-selinux') }
-        end
-
-        describe 'with selinux => true' do
-          let(:params) { super().merge(selinux: true) }
-          it { should contain_package('foreman-selinux') }
-        end
-
-        describe 'with selinux => undef' do
-          it { should_not contain_package('foreman-selinux') }
-        end
+        it { should_not contain_package('foreman-selinux') }
       end
     end
   end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -200,7 +200,6 @@ describe 'foreman' do
             repo: 'nightly',
             configure_epel_repo: true,
             configure_scl_repo: false,
-            selinux: true,
             gpgcheck: true,
             version: '1.12',
             plugin_version: 'installed',

--- a/spec/defines/foreman_config_apache_fragment_spec.rb
+++ b/spec/defines/foreman_config_apache_fragment_spec.rb
@@ -44,7 +44,6 @@ describe 'foreman::config::apache::fragment' do
               server_ssl_port         => 443,
               proxy_backend           => 'http://127.0.0.1:3000/',
               ipa_authentication      => false,
-              selinux                 => true,
           }"
         end
 
@@ -102,7 +101,6 @@ describe 'foreman::config::apache::fragment' do
               server_ssl_port         => 443,
               proxy_backend           => 'http://127.0.0.1:3000/',
               ipa_authentication      => false,
-              selinux                 => true,
           }"
         end
 


### PR DESCRIPTION
This was needed before we had foreman-selinux but that was introduced in Foreman 1.1. By now we can rely on only the selinux fact.