### PR TITLE
Drop listen_on_interface

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -4,9 +4,6 @@
 #
 # $app_root::                 Root of the application.
 #
-# $listen_on_interface::      Specify which interface to bind passenger to.
-#                             Defaults to all interfaces.
-#
 # $passenger_ruby::           Path to Ruby interpreter
 #
 # $priority::                 Apache vhost priority
@@ -59,7 +56,6 @@
 class foreman::config::apache(
   Boolean $passenger = $::foreman::passenger,
   Stdlib::Absolutepath $app_root = $::foreman::app_root,
-  Optional[String] $listen_on_interface = $::foreman::passenger_interface,
   Optional[String] $passenger_ruby = $::foreman::passenger_ruby,
   String $priority = $::foreman::vhost_priority,
   Stdlib::Fqdn $servername = $::foreman::servername,
@@ -190,13 +186,6 @@ class foreman::config::apache(
     include ::apache::mod::auth_kerb
   }
 
-  # Check the value in case the interface doesn't exist, otherwise listen on all interfaces
-  if $listen_on_interface and $listen_on_interface in split($::interfaces, ',') {
-    $listen_interface = fact("ipaddress_${listen_on_interface}")
-  } else {
-    $listen_interface = undef
-  }
-
   file { "${apache::confd_dir}/${priority}-foreman.d":
     ensure  => 'directory',
     owner   => 'root',
@@ -210,7 +199,6 @@ class foreman::config::apache(
     add_default_charset   => 'UTF-8',
     docroot               => $docroot,
     manage_docroot        => false,
-    ip                    => $listen_interface,
     options               => ['SymLinksIfOwnerMatch'],
     port                  => $server_port,
     priority              => $priority,
@@ -245,7 +233,6 @@ class foreman::config::apache(
       add_default_charset   => 'UTF-8',
       docroot               => $docroot,
       manage_docroot        => false,
-      ip                    => $listen_interface,
       options               => ['SymLinksIfOwnerMatch'],
       port                  => $server_ssl_port,
       priority              => $priority,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,8 +104,6 @@
 #
 # $user_groups::                  Additional groups for the Foreman user
 #
-# $passenger_interface::          Defines which network interface passenger should listen on, undef means all interfaces
-#
 # $passenger_prestart::           Pre-start the first passenger worker instance process during httpd start.
 #
 # $passenger_min_instances::      Minimum passenger worker instances to keep when application is idle.
@@ -227,7 +225,6 @@ class foreman (
   String $group = $::foreman::params::group,
   Array[String] $user_groups = $::foreman::params::user_groups,
   String $rails_env = $::foreman::params::rails_env,
-  Optional[String] $passenger_interface = $::foreman::params::passenger_interface,
   String $vhost_priority = $::foreman::params::vhost_priority,
   Stdlib::Port $server_port = $::foreman::params::server_port,
   Stdlib::Port $server_ssl_port = $::foreman::params::server_ssl_port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,10 +17,8 @@ class foreman::params {
   $servername     = $::fqdn
   # Server aliases of the VirtualHost
   $serveraliases  = [ 'foreman' ]
-  # force SSL (note: requires passenger)
+  # force SSL (note: requires apache)
   $ssl            = true
-  #define which interface passenger should listen on, undef means all interfaces
-  $passenger_interface = undef
   # further passenger parameters
   $passenger_prestart = true
   $passenger_min_instances = 1

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -7,7 +7,6 @@ describe 'foreman::config::apache' do
       let(:params) do
         {
           app_root: '/usr/share/foreman',
-          listen_on_interface: '192.168.0.1',
           priority: '05',
           servername: facts[:fqdn],
           serveraliases: ['foreman', 'also.foreman'],

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -107,7 +107,6 @@ describe 'foreman' do
                            end
 
           should contain_class('foreman::config::apache')
-            .with_listen_on_interface(nil)
             .with_passenger_ruby(passenger_ruby)
         end
 
@@ -170,21 +169,6 @@ describe 'foreman' do
         it { should_not contain_exec('restart_foreman') }
       end
 
-      describe 'with passenger interface' do
-        let :pre_condition do
-          <<-PUPPET
-          class {'apache':
-            default_vhost => false,
-          }
-          PUPPET
-        end
-
-        let(:params) { super().merge(passenger_interface: 'lo') }
-
-        it { should compile.with_all_deps }
-        it { should contain_class('foreman::config::apache').with_listen_on_interface('lo') }
-      end
-
       describe 'with all parameters' do
         let :params do
           {
@@ -218,7 +202,6 @@ describe 'foreman' do
             group: 'foreman',
             user_groups: %w[adm wheel],
             rails_env: 'production',
-            passenger_interface: 'lo0',
             vhost_priority: '5',
             server_port: 80,
             server_ssl_port: 443,

--- a/spec/defines/foreman_config_apache_fragment_spec.rb
+++ b/spec/defines/foreman_config_apache_fragment_spec.rb
@@ -18,7 +18,6 @@ describe 'foreman::config::apache::fragment' do
         let :pre_condition do
           "class { '::foreman::config::apache':
               app_root                => '/usr/share/foreman',
-              listen_on_interface     => '192.168.0.1',
               priority                => '05',
               ssl                     => false,
               ssl_cert                => '/cert.pem',
@@ -72,7 +71,6 @@ describe 'foreman::config::apache::fragment' do
         let :pre_condition do
           "class { '::foreman::config::apache':
               app_root                => '/usr/share/foreman',
-              listen_on_interface     => '192.168.0.1',
               priority                => '05',
               ssl                     => true,
               ssl_cert                => '/cert.pem',


### PR DESCRIPTION
This parameter doesn't work well since you need to configure Apache slightly different as well since out of the box it doesn't work. Users who care about this functionality can use Hiera with the `http_vhost_options` and `https_vhost_options` parameters to set the ip directly.