### PR TITLE
Fixes #28955 - Added puma configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -193,6 +193,12 @@
 #
 # $cors_domains::                 List of domains that show be allowed for Cross-Origin Resource Sharing. This requires Foreman 1.22+
 #
+# $foreman_service_puma_threads_min::     Minimum number of threads for Puma. Relevant only when Puma service is used and ignored when Passenger is used.
+#
+# $foreman_service_puma_threads_max::     Maximum number of threads for Puma. Relevant only when Puma service is used and ignored when Passenger is used.
+#
+# $foreman_service_puma_workers::         Number of workers for Puma. Relevant only when Puma service is used and ignored when Passenger is used.
+#
 class foreman (
   Stdlib::HTTPUrl $foreman_url = $::foreman::params::foreman_url,
   Boolean $unattended = $::foreman::params::unattended,
@@ -286,6 +292,9 @@ class foreman (
   Optional[Redis::RedisUrl] $jobs_sidekiq_redis_url = $::foreman::params::jobs_sidekiq_redis_url,
   Boolean $hsts_enabled = $::foreman::params::hsts_enabled,
   Array[Stdlib::HTTPUrl] $cors_domains = $::foreman::params::cors_domains,
+  Integer[0] $foreman_service_puma_threads_min = $::foreman::params::foreman_service_puma_threads_min,
+  Integer[0] $foreman_service_puma_threads_max = $::foreman::params::foreman_service_puma_threads_max,
+  Integer[0] $foreman_service_puma_workers = $::foreman::params::foreman_service_puma_workers,
 ) inherits foreman::params {
   if $db_sslmode == 'UNSET' and $db_root_cert {
     $db_sslmode_real = 'verify-full'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,6 +83,9 @@ class foreman::params {
   $foreman_service_ensure = 'running'
   $foreman_service_enable = true
   $foreman_service_port = 3000
+  $foreman_service_puma_threads_min = 0
+  $foreman_service_puma_threads_max = 16
+  $foreman_service_puma_workers = 2
 
   # Define job processing service properties
   $jobs_manage_service = true

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -6,3 +6,6 @@ Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
 Environment=FOREMAN_BIND=<%= scope['foreman::foreman_service_bind'] %>
 <% end -%>
 Environment=FOREMAN_PORT=<%= scope['foreman::foreman_service_port'] %>
+Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::foreman_service_puma_threads_min'] %>
+Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
+Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::foreman_service_puma_workers'] %>


### PR DESCRIPTION
~~I am creating this PR sooner with `DO NOT MERGE` tag to let everyone know how I am proceeding.~~
Any feedback is appreciated.

### About the configuration file puma_production.erb
- I have so far picked only 2 parameters - `threads` and `workers`. More will be picked in the future if need be. See [sample config](https://github.com/puma/puma/blob/f22dc6172235a57c56c28e3074c76ce421170b1c/examples/config.rb) for more info.

### Pending work in this PR
- [x] Externalize the parameters in the template (as environment variables?)
- [x] workers=4 is my test configuration. I need to test further to tune this to an appropriate default value.