### PR TITLE
Refs #28067: Ensure dynflow worker config exists before service

### DIFF
--- a/manifests/dynflow/worker.pp
+++ b/manifests/dynflow/worker.pp
@@ -18,9 +18,9 @@ define foreman::dynflow::worker (
     mode    => '0644',
     content => template('foreman/dynflow_worker.yml.erb'),
   }
-
-  service { "dynflow-sidekiq@${service_name}":
-    ensure => $service_ensure,
-    enable => $service_enable,
+  ~> service { "dynflow-sidekiq@${service_name}":
+    ensure    => $service_ensure,
+    enable    => $service_enable,
+    subscribe => Class['foreman::database'],
   }
 }


### PR DESCRIPTION
If the dynflow worker service starts before the configuration file
has been deployed the worker will fail to start.