### PR TITLE
Ensure plugins are installed before the database

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -320,6 +320,7 @@ class foreman (
   Class['foreman::repo'] ~> Class['foreman::install']
   Class['foreman::install'] ~> Class['foreman::config', 'foreman::service']
   Class['foreman::config'] ~> Class['foreman::database', 'foreman::service']
+  Class['foreman::database'] ~> Class['foreman::service']
   Class['foreman::service'] -> Foreman_smartproxy <| base_url == $foreman_url |>
 
   if $apache {
@@ -341,12 +342,6 @@ class foreman (
   Class['foreman::repo']
   ~> Package <| tag == 'foreman::providers' |>
   -> Class['foreman']
-
-  # lint:ignore:spaceship_operator_without_tag
-  Class['foreman::database']
-  ~> Foreman::Plugin <| |>
-  ~> Class['foreman::service']
-  # lint:endignore
 
   contain 'foreman::settings' # lint:ignore:relative_classname_inclusion (PUP-1597)
   Class['foreman::database'] -> Class['foreman::settings']

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -29,4 +29,7 @@ define foreman::plugin(
       require => Package[$real_package],
     }
   }
+
+  Foreman::Plugin[$name] -> Class['foreman::database']
+  Foreman::Plugin[$name] ~> Class['foreman::service']
 }

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -117,7 +117,11 @@ describe 'foreman' do
         end
 
         # database
-        it { should contain_class('foreman::database') }
+        it {
+          should contain_class('foreman::database')
+            .that_comes_before('Class[apache::service]')
+            .that_notifies('Class[foreman::service]')
+        }
         it {
           should contain_class('foreman::database::postgresql')
             .that_notifies('Foreman::Rake[db:migrate]')

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -18,8 +18,14 @@ describe 'foreman::plugin' do
                        when 'Debian'
                          'ruby-foreman-myplugin'
                        end
+        it { should compile.with_all_deps }
         it { should contain_package(package_name).with_ensure('present') }
         it { should_not contain_file('/etc/foreman/plugins/foreman_myplugin.yaml') }
+        it do
+          should contain_foreman__plugin('myplugin')
+            .that_comes_before('Class[foreman::database]')
+            .that_notifies('Class[foreman::service]')
+        end
       end
 
       context 'with package parameter' do
@@ -68,7 +74,7 @@ describe 'foreman::plugin' do
             .with_group('root')
             .with_mode('0644')
             .with_content('the config content')
-            .with_require("Package[#{params[:package]}]")
+            .that_requires('Package[myplugin]')
         end
       end
     end


### PR DESCRIPTION
Previously plugins were installed after the database was set up. This was usually ok because all the plugins did database migrations after being installed. However, if the migration would need any config, it could still fail.

This changes it to make sure all plugins are installed and (mostly) configured before the database is done setting up. If any plugin needs additional configuration to be present before migrating and seeding, the foreman::plugin::$myplugin class needs to additionally take care of this. Currently all existing classes do where needed.