### PR TITLE
Make foreman::config::apache standalone

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,6 +94,33 @@ class foreman::config {
   }
 
   if $::foreman::apache  {
+    class { 'foreman::config::apache':
+      passenger               => $::foreman::passenger,
+      app_root                => $::foreman::app_root,
+      passenger_ruby          => $::foreman::passenger_ruby,
+      priority                => $::foreman::vhost_priority,
+      servername              => $::foreman::servername,
+      serveraliases           => $::foreman::serveraliases,
+      server_port             => $::foreman::server_port,
+      server_ssl_port         => $::foreman::server_ssl_port,
+      proxy_backend           => "http://${::foreman::foreman_service_bind}:${::foreman::foreman_service_port}/",
+      ssl                     => $::foreman::ssl,
+      ssl_ca                  => $::foreman::server_ssl_ca,
+      ssl_chain               => $::foreman::server_ssl_chain,
+      ssl_cert                => $::foreman::server_ssl_cert,
+      ssl_certs_dir           => $::foreman::server_ssl_certs_dir,
+      ssl_key                 => $::foreman::server_ssl_key,
+      ssl_crl                 => $::foreman::server_ssl_crl,
+      ssl_protocol            => $::foreman::server_ssl_protocol,
+      ssl_verify_client       => $::foreman::server_ssl_verify_client,
+      user                    => $::foreman::user,
+      passenger_prestart      => $::foreman::passenger_prestart,
+      passenger_min_instances => $::foreman::passenger_min_instances,
+      passenger_start_timeout => $::foreman::passenger_start_timeout,
+      foreman_url             => $::foreman::foreman_url,
+      ipa_authentication      => $::foreman::ipa_authentication,
+    }
+
     contain foreman::config::apache
 
     if $::foreman::ipa_authentication {

--- a/spec/defines/foreman_config_apache_fragment_spec.rb
+++ b/spec/defines/foreman_config_apache_fragment_spec.rb
@@ -5,7 +5,7 @@ describe 'foreman::config::apache::fragment' do
 
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      let :facts do facts end
+      let(:facts) { facts }
 
       confd_dir = case facts[:osfamily]
                   when 'RedHat'
@@ -16,32 +16,11 @@ describe 'foreman::config::apache::fragment' do
 
       context 'with ssl turned off' do
         let :pre_condition do
-          "class { '::foreman::config::apache':
-              app_root                => '/usr/share/foreman',
-              priority                => '05',
-              ssl                     => false,
-              ssl_cert                => '/cert.pem',
-              ssl_certs_dir           => '',
-              ssl_key                 => '/key.pem',
-              ssl_ca                  => '/ca.pem',
-              ssl_chain               => '/ca.pem',
-              ssl_crl                 => '/crl.pem',
-              ssl_protocol            => '-all +TLSv1.2',
-              ssl_verify_client       => 'optional',
-              user                    => 'foreman',
-              passenger               => true,
-              passenger_ruby          => '/usr/bin/tfm-ruby',
-              passenger_prestart      => true,
-              passenger_min_instances => 1,
-              passenger_start_timeout => 600,
-              servername              => '#{facts[:fqdn]}',
-              serveraliases           => ['foreman'],
-              foreman_url             => 'https://#{facts[:fqdn]}',
-              server_port             => 80,
-              server_ssl_port         => 443,
-              proxy_backend           => 'http://127.0.0.1:3000/',
-              ipa_authentication      => false,
-          }"
+          <<~PUPPET
+          class { 'foreman::config::apache':
+            ssl => false,
+          }
+          PUPPET
         end
 
         context 'with default parameters' do
@@ -70,32 +49,11 @@ describe 'foreman::config::apache::fragment' do
 
       context 'with ssl turned on' do
         let :pre_condition do
-          "class { '::foreman::config::apache':
-              app_root                => '/usr/share/foreman',
-              priority                => '05',
-              ssl                     => true,
-              ssl_cert                => '/cert.pem',
-              ssl_certs_dir           => '',
-              ssl_key                 => '/key.pem',
-              ssl_ca                  => '/ca.pem',
-              ssl_chain               => '/ca.pem',
-              ssl_crl                 => '/crl.pem',
-              ssl_protocol            => '-all +TLSv1.2',
-              ssl_verify_client       => 'optional',
-              user                    => 'foreman',
-              passenger               => true,
-              passenger_ruby          => '/usr/bin/tfm-ruby',
-              passenger_prestart      => true,
-              passenger_min_instances => 1,
-              passenger_start_timeout => 600,
-              servername              => '#{facts[:fqdn]}',
-              serveraliases           => ['foreman'],
-              foreman_url             => 'https://#{facts[:fqdn]}',
-              server_port             => 80,
-              server_ssl_port         => 443,
-              proxy_backend           => 'http://127.0.0.1:3000/',
-              ipa_authentication      => false,
-          }"
+          <<~PUPPET
+          class { 'foreman::config::apache':
+            ssl => true,
+          }
+          PUPPET
         end
 
         context 'with ssl_content parameter' do


### PR DESCRIPTION
By not relying on the foreman class parameters, it becomes easier to use this class without Foreman. This can be useful when deploying it using a git checkout rather than packages. An example of that is https://github.com/theforeman/puppet-katello_devel/pull/225