### PR TITLE
Use string keys for custom facts

### DIFF
--- a/lib/facter/sssd.rb
+++ b/lib/facter/sssd.rb
@@ -4,8 +4,8 @@ if defined? Facter::Util::Sssd
   # == Fact: ipa
   Facter.add(:ipa, :type => :aggregate) do
     {
-      :default_realm => 'global/realm',
-      :default_server => 'global/server',
+      'default_realm' => 'global/realm',
+      'default_server' => 'global/server',
     }.each do |key, path|
       chunk(key) do
         val = Facter::Util::Sssd.ipa_value(path)
@@ -17,10 +17,10 @@ if defined? Facter::Util::Sssd
   # == Fact: sssd
   Facter.add(:sssd, :type => :aggregate) do
     {
-      :services => 'target[.="sssd"]/services',
-      :ldap_user_extra_attrs => 'target[.=~regexp("domain/.*")][1]/ldap_user_extra_attrs',
-      :allowed_uids => 'target[.="ifp"]/allowed_uids',
-      :user_attributes => 'target[.="ifp"]/user_attributes',
+      'services' => 'target[.="sssd"]/services',
+      'ldap_user_extra_attrs' => 'target[.=~regexp("domain/.*")][1]/ldap_user_extra_attrs',
+      'allowed_uids' => 'target[.="ifp"]/allowed_uids',
+      'user_attributes' => 'target[.="ifp"]/user_attributes',
     }.each do |key, path|
       chunk(key) do
         val = Facter::Util::Sssd.sssd_value(path)

--- a/spec/unit/facter/ipa_spec.rb
+++ b/spec/unit/facter/ipa_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'ipa' do
+  subject { Facter.value(:ipa) }
+
+  before do
+    Facter.reset
+    Facter.loadfacts
+    allow(Facter::Util::Sssd).to receive(:ipa_value).with('global/realm').and_return(default_realm)
+    allow(Facter::Util::Sssd).to receive(:ipa_value).with('global/server').and_return(default_server)
+  end
+
+  let(:default_realm) { nil }
+  let(:default_server) { nil }
+
+  context 'not enrolled' do
+    it { is_expected.to be_nil }
+  end
+
+  context 'enrolled' do
+    context 'default realm' do
+      let(:default_realm) { 'EXAMPLE.COM' }
+
+      it { is_expected.to eq({'default_realm' => 'EXAMPLE.COM'}) }
+    end
+
+    context 'default server' do
+      let(:default_server) { 'ipa.example.com' }
+
+      it { is_expected.to eq({'default_server' => 'ipa.example.com'}) }
+    end
+
+    context 'default server and realm' do
+      let(:default_server) { 'ipa.example.com' }
+      let(:default_realm) { 'EXAMPLE.COM' }
+
+      it { is_expected.to eq({'default_server' => 'ipa.example.com', 'default_realm' => 'EXAMPLE.COM'}) }
+    end
+  end
+end

--- a/spec/unit/facter/sssd_fact.rb
+++ b/spec/unit/facter/sssd_fact.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'sssd' do
+  subject { Facter.value(:sssd) }
+
+  before do
+    Facter.reset
+    Facter.loadfacts
+    allow(Facter::Util::Sssd).to receive(:sssd_value).with('target[.="sssd"]/services').and_return(services)
+    allow(Facter::Util::Sssd).to receive(:sssd_value).with('target[.=~regexp("domain/.*")][1]/ldap_user_extra_attrs').and_return(ldap_user_extra_attrs)
+    allow(Facter::Util::Sssd).to receive(:sssd_value).with('target[.="ifp"]/allowed_uids').and_return(allowed_uids)
+    allow(Facter::Util::Sssd).to receive(:sssd_value).with('target[.="ifp"]/user_attributes').and_return(user_attributes)
+  end
+
+  let(:services) { nil }
+  let(:ldap_user_extra_attrs) { nil }
+  let(:allowed_uids) { nil }
+  let(:user_attributes) { nil }
+
+  context 'not enrolled' do
+    it { is_expected.to be_nil }
+  end
+
+  context 'enrolled' do
+    context 'services' do
+      let(:services) { 'example' }
+
+      it { is_expected.to eq({'services' => 'example'}) }
+    end
+
+    context 'ldap_user_extra_attrs' do
+      let(:ldap_user_extra_attrs) { 'middlename:mid' }
+
+      it { is_expected.to eq({'ldap_user_extra_attrs' => 'middlename:mid'}) }
+    end
+
+    context 'allowed_uids' do
+      let(:allowed_uids) { 'joe' }
+
+      it { is_expected.to eq({'allowed_uids' => 'joe'}) }
+    end
+
+    context 'user_attributes' do
+      let(:user_attributes) { '+mid' }
+
+      it { is_expected.to eq({'user_attributes' => '+mid'}) }
+    end
+
+    context 'services and allowed_uids' do
+      let(:services) { 'example' }
+      let(:allowed_uids) { 'joe' }
+
+      it { is_expected.to eq({'services' => 'example', 'allowed_uids' => 'joe'}) }
+    end
+  end
+end


### PR DESCRIPTION
While adding tests, this was the only way to get a result. When using symbols, it returned nil instead of a hash.

Possible solution for GH-796. If this is a fix, then this needs a Redmine issue before merging.