### PR TITLE
Correct casing on Stdlib::HTTPUrl

### DIFF
--- a/lib/puppet/functions/foreman/foreman.rb
+++ b/lib/puppet/functions/foreman/foreman.rb
@@ -48,7 +48,7 @@ Puppet::Functions.create_function(:'foreman::foreman') do
     required_param 'Enum["environments", "fact_values", "hosts", "hostgroups", "puppetclasses", "smart_proxies", "subnets"]', :item
     required_param 'String', :search
     optional_param 'Variant[Integer[0], Pattern[/\d+/]]', :per_page
-    optional_param 'Stdlib::Httpurl', :foreman_url
+    optional_param 'Stdlib::HTTPUrl', :foreman_url
     optional_param 'String', :foreman_user
     optional_param 'String', :foreman_pass
     optional_param 'Integer[0]', :timeout

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -10,7 +10,7 @@ require "timeout"
 Puppet::Functions.create_function(:'foreman::smartvar') do
   dispatch :smartvar do
     required_param 'String[1]', :var
-    optional_param 'Stdlib::Httpurl', :foreman_url
+    optional_param 'Stdlib::HTTPUrl', :foreman_url
     optional_param 'String', :foreman_user
     optional_param 'String', :foreman_pass
   end

--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -96,7 +96,7 @@ class foreman::config::apache(
   Array[Stdlib::Fqdn] $serveraliases = [],
   Stdlib::Port $server_port = 80,
   Stdlib::Port $server_ssl_port = 443,
-  Stdlib::Httpurl $proxy_backend = 'http://localhost:3000/',
+  Stdlib::HTTPUrl $proxy_backend = 'http://localhost:3000/',
   Hash $proxy_params = {'retry' => '0'},
   Array[String] $proxy_no_proxy_uris = ['/pulp', '/streamer', '/pub'],
   Boolean $ssl = false,

--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -2,7 +2,7 @@
 define foreman::repos::apt (
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
   Variant[String, Hash] $key = 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
-  Stdlib::Httpurl $location = 'https://deb.theforeman.org/',
+  Stdlib::HTTPUrl $location = 'https://deb.theforeman.org/',
 ) {
   include ::apt
 


### PR DESCRIPTION
While Puppet is case insensitive on data types, Kafo does care. This matches the type to its actual definition.