### PR TITLE
Fixes #29255 - Set plugin config file mode to 0640

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,9 +1,33 @@
-# Installs the package for a given Foreman plugin
+# @summary Manages a plugin installation and optionally its configuration
+#
+# @param version
+#   The version to ensure
+#
+# @param package
+#   The package to manage
+#
+# @param config
+#   Content of the configg
+#
+# @param config_file
+#   The path to the config file. Only relevant if `config` is given.
+#
+# @param config_file_mode
+#   The mode of the config file. Only relevant if `config` is given.
+#
+# @param config_file_owner
+#   The owner of the config file. Only relevant if `config` is given.
+#
+# @param config_file_group
+#   The mode of the config file. Only relevant if `config` is given.
 define foreman::plugin(
-  $version     = $foreman::plugin_version,
-  $package     = "${foreman::plugin_prefix}${title}",
-  $config_file = "${foreman::plugin_config_dir}/foreman_${title}.yaml",
-  $config      = undef,
+  String[1] $version = $foreman::plugin_version,
+  String[1] $package = "${foreman::plugin_prefix}${title}",
+  Stdlib::Absolutepath $config_file = "${foreman::plugin_config_dir}/foreman_${title}.yaml",
+  String[1] $config_file_owner = 'root',
+  String[1] $config_file_group = $foreman::group,
+  Stdlib::Filemode $config_file_mode = '0640',
+  Optional[String] $config = undef,
 ) {
   # Debian gem2deb converts underscores to hyphens
   case $::osfamily {
@@ -22,9 +46,9 @@ define foreman::plugin(
   if $config {
     file { $config_file:
       ensure  => file,
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0644',
+      owner   => $config_file_owner,
+      group   => $config_file_group,
+      mode    => $config_file_mode,
       content => $config,
       require => Package[$real_package],
     }

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -71,8 +71,8 @@ describe 'foreman::plugin' do
           should contain_file('/etc/foreman/plugins/foreman_myplugin.yaml')
             .with_ensure('file')
             .with_owner('root')
-            .with_group('root')
-            .with_mode('0644')
+            .with_group('foreman')
+            .with_mode('0640')
             .with_content('the config content')
             .that_requires('Package[myplugin]')
         end


### PR DESCRIPTION
This sets the config file mode to 0640 by default because they may contain secrets such as credentials. To keep it readable for Foreman, the group is modified to $foreman::group.