### PR TITLE
Refs #28436 - Drop unused parameter

### DIFF
--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -7,7 +7,6 @@ class foreman::settings(
   $email_smtp_authentication = $::foreman::email_smtp_authentication,
   $email_smtp_user_name      = $::foreman::email_smtp_user_name,
   $email_smtp_password       = $::foreman::email_smtp_password,
-  $keycloak                  = $::foreman::keycloak,
 ) {
   unless empty($email_delivery_method) {
     foreman_config_entry { 'delivery_method':


### PR DESCRIPTION
0e8621418b1eb3418066552945218cbad8d71f2d added this, but was a left over from an earlier iteration.