### PR TITLE
Refs #29144 - Use systemd socket activation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -333,7 +333,7 @@ class foreman (
     $foreman_service_bind = '127.0.0.1'
   } else {
     $use_foreman_service = true
-    $foreman_service_bind = undef
+    $foreman_service_bind = '0.0.0.0'
   }
 
   include ::foreman::repo

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -2,9 +2,7 @@
 User=<%= scope['foreman::user'] %>
 Environment=FOREMAN_ENV=<%= scope['foreman::rails_env'] %>
 Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
-<% if scope['foreman::foreman_service_bind'] -%>
 Environment=FOREMAN_BIND=<%= scope['foreman::foreman_service_bind'] %>
-<% end -%>
 Environment=FOREMAN_PORT=<%= scope['foreman::foreman_service_port'] %>
 Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::foreman_service_puma_threads_min'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>

--- a/templates/foreman.socket-overrides.erb
+++ b/templates/foreman.socket-overrides.erb
@@ -1,0 +1,3 @@
+[Service]
+ListenSocket=
+ListenSocket=<%= @listen_socket %>


### PR DESCRIPTION
When using systemd socket activation, it's important that the ListenSocket matches what Puma binds on. Otherwise it may fail. This happens when is configured on [::]:3000 (dual stack) and Puma on 0.0.0.0:3000. Puma will then attempt to bind and fail because the port is already in use.

The service bind is now made explicit because systemd's ListenSocket=3000 binds on :: where Puma by default binds on 0.0.0.0:3000. This is IPv4-only, but is what was done prior to this as well. Apache is configured dual stack and the recommended deployment.

Note this depends on https://github.com/theforeman/foreman/pull/7536 and https://github.com/theforeman/foreman-packaging/pull/4894 (deb) / https://github.com/theforeman/foreman-packaging/pull/4895 (rpm).