### PR TITLE
Refs #29144 - Correct socket override

### DIFF
--- a/templates/foreman.socket-overrides.erb
+++ b/templates/foreman.socket-overrides.erb
@@ -1,3 +1,3 @@
-[Service]
+[Socket]
 ListenSocket=
 ListenSocket=<%= @listen_socket %>


### PR DESCRIPTION
281f1966587ffd3d283cd8ea76371aed02f568b4 introduced the systemd socket override, but used Service instead of Socket. This causes the service to bind incorrectly.