### PR TITLE
Make camptocamp/systemd a hard dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ Many Foreman plugins can be installed by adding additional `foreman::plugin::*`
 classes, extra compute resource support via `foreman::compute::*` classes and
 the Hammer CLI can be installed by adding `foreman::cli`.
 
-By default, it configures Foreman to run under Apache and Passenger plus
-with a PostgreSQL database. A standalone service can be configured instead by
-setting `passenger` to false, though this isn't recommended in production.
+By default, it configures Foreman to run as a standalone service fronted by
+Apache as a reverse proxy with a PostgreSQL database.
 
 The web interface is configured to use Puppet's SSL certificates by default, so
 ensure they're present first, reconfigure `server_ssl_*` or disable the `ssl`
@@ -47,14 +46,6 @@ previous stable release.
 ### Foreman version compatibility notes
 
 This module targets Foreman 2.0+.
-
-## Running without passenger
-
-To use this module without passenger, the `passenger` parameter must be set to
-`false`. This will install the `foreman-service` package and ensure the service
-is running.
-
-This introduces a soft dependency on `camptocamp-systemd`.
 
 ## Types and providers
 

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,10 @@
   ],
   "dependencies": [
     {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.2.0 < 3.0.0"
+    },
+    {
       "name": "puppetlabs/apache",
       "version_requirement": ">= 2.0.0 < 6.0.0"
     },

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,7 +13,6 @@ require 'beaker/module_install_helper'
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
-install_module_from_forge('camptocamp-systemd', '>= 1.0.0')
 
 RSpec.configure do |c|
   # Readable test descriptions


### PR DESCRIPTION
8bc1ba3027f5b65803cda115b25e1bc6194c58e7 made the default deployment use the Puma service. That means the default requires systemd and a soft dependency no longer makes sense.

It also updates the documentation in README to match.