### PR TITLE
Use legacy facts for puppetmaster defaults

### DIFF
--- a/manifests/puppetmaster/params.pp
+++ b/manifests/puppetmaster/params.pp
@@ -48,12 +48,16 @@ class foreman::puppetmaster::params {
         }
       }
       'Archlinux': {
-        $puppet_basedir = regsubst($facts['ruby']['version'], '^(\d+\.\d+).*$', '/usr/lib/ruby/vendor_ruby/\1/puppet')
+        # lint:ignore:legacy_facts
+        $puppet_basedir = regsubst($facts['rubyversion'], '^(\d+\.\d+).*$', '/usr/lib/ruby/vendor_ruby/\1/puppet')
+        # lint:endignore
         $puppet_etcdir = '/etc/puppetlabs/puppet'
         $puppet_home = '/var/lib/puppet'
       }
       /^(FreeBSD|DragonFly)$/: {
-        $puppet_basedir = regsubst($facts['ruby']['version'], '^(\d+\.\d+).*$', '/usr/local/lib/ruby/site_ruby/\1/puppet')
+        # lint:ignore:legacy_facts
+        $puppet_basedir = regsubst($facts['rubyversion'], '^(\d+\.\d+).*$', '/usr/local/lib/ruby/site_ruby/\1/puppet')
+        # lint:endignore
         $puppet_etcdir = '/usr/local/etc/puppet'
         $puppet_home = '/var/puppet'
       }


### PR DESCRIPTION
875c8377f5dfadbe1cd69635d0925765e6c2a83b started to use modern facts.  However, for these branches there is no coverage and facterdb can't find these modern facts. This causes issues in puppet-puppet which does call these branches. Ignoring lint is the quickest fix now.

Longer term these classes will be split out to its own module as theforeman/puppetserver_foreman so there can be test coverage.