### PR TITLE
Switch AIO detection to use aio_agent_version fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,7 +133,7 @@ class foreman::params {
     }
   }
 
-  if $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/ {
+  if fact('aio_agent_version') =~ String[1] {
     $puppet_ssldir = '/etc/puppetlabs/puppet/ssl'
   } else {
     $puppet_ssldir = '/var/lib/puppet/ssl'

--- a/manifests/providers/params.pp
+++ b/manifests/providers/params.pp
@@ -3,17 +3,19 @@ class foreman::providers::params {
   # Dependency packages for different providers supplied in this module
   $oauth = true
 
+  $is_aio = fact('aio_agent_version') =~ String[1]
+
   # OS specific package names
   case $facts['os']['family'] {
     'RedHat': {
-      if $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/ {
+      if $is_aio {
         $oauth_package = 'puppet-agent-oauth'
       } else {
         $oauth_package = 'rubygem-oauth'
       }
     }
     'Debian': {
-      if $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/ {
+      if $is_aio {
         $oauth_package = 'puppet-agent-oauth'
       } else {
         $oauth_package = 'ruby-oauth'
@@ -28,7 +30,7 @@ class foreman::providers::params {
     'Linux': {
       case $facts['os']['name'] {
         'Amazon': {
-          if $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/ {
+          if $is_aio {
             $oauth_package = 'puppet-agent-oauth'
           } else {
             $oauth_package = 'rubygem-oauth'

--- a/manifests/puppetmaster/params.pp
+++ b/manifests/puppetmaster/params.pp
@@ -18,7 +18,7 @@ class foreman::puppetmaster::params {
   $puppetmaster_timeout = 60
   $puppetmaster_report_timeout = 60
 
-  if $facts['ruby']['sitedir'] =~ /\/opt\/puppetlabs\/puppet/ {
+  if fact('aio_agent_version') =~ String[1] {
     $puppet_basedir = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet'
     $puppet_etcdir = '/etc/puppetlabs/puppet'
     $puppet_home = '/opt/puppetlabs/server/data/puppetserver'

--- a/spec/support/aio.rb
+++ b/spec/support/aio.rb
@@ -1,9 +1,3 @@
-# This enforces the AIO Ruby sitedir
-add_custom_fact :ruby, ->(os, facts) do
-  # Non-AIO platforms
-  return if ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:os]['family'])
-  return unless facts[:ruby]
-
-  version = facts[:ruby]['version'].match(/^(\d+\.\d+)/)[1]
-  facts[:ruby].merge(sitedir: "/opt/puppetlabs/puppet/lib/ruby/site_ruby/#{version}.0")
+add_custom_fact :aio_agent_version, ->(os, facts) do
+  return facts[:puppetversion] unless ['Archlinux', 'FreeBSD', 'DragonFly', 'Windows'].include?(facts[:os]['family'])
 end


### PR DESCRIPTION
This fact is a core fact that's only set on AIO installs. Setting this custom fact is also easier than the structured fact in our test suite which increases reliability of our tests.

This is finishing what https://github.com/theforeman/puppet-foreman/pull/832 intended to fix.