### PR TITLE
Allow puppet/redis 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
6.x was breaking since it made repository management modules soft dependencies. Since we don't use these, it's not breaking here.