### PR TITLE
Fixes #29649 - Prefix ipa and sssd facts with foreman_

### DIFF
--- a/lib/facter/sssd.rb
+++ b/lib/facter/sssd.rb
@@ -2,7 +2,13 @@ require 'facter/util/sssd'
 
 if defined? Facter::Util::Sssd
   # == Fact: ipa
-  Facter.add(:ipa, :type => :aggregate) do
+  # Deprecated but here for compatibility
+  Facter.add(:ipa) do
+    setcode { Facter.value(:foreman_ipa) }
+  end
+
+  # == Fact: foreman_ipa
+  Facter.add(:foreman_ipa, :type => :aggregate) do
     {
       :default_realm => 'global/realm',
       :default_server => 'global/server',
@@ -15,7 +21,13 @@ if defined? Facter::Util::Sssd
   end
 
   # == Fact: sssd
-  Facter.add(:sssd, :type => :aggregate) do
+  # Deprecated but here for compatibility
+  Facter.add(:sssd) do
+    setcode { Facter.value(:foreman_sssd) }
+  end
+
+  # == Fact: foreman_sssd
+  Facter.add(:foreman_sssd, :type => :aggregate) do
     {
       :services => 'target[.="sssd"]/services',
       :ldap_user_extra_attrs => 'target[.=~regexp("domain/.*")][1]/ldap_user_extra_attrs',

--- a/spec/classes/foreman_config_ipa_spec.rb
+++ b/spec/classes/foreman_config_ipa_spec.rb
@@ -27,11 +27,11 @@ describe 'foreman' do
         describe 'enrolled system' do
           let(:facts) do
             super().merge(
-              ipa: {
+              foreman_ipa: {
                 default_server: 'ipa.example.com',
                 default_realm: 'REALM'
               },
-              sssd: {
+              foreman_sssd: {
                 services: ['ifp']
               }
             )

--- a/templates/auth_kerb.conf.erb
+++ b/templates/auth_kerb.conf.erb
@@ -5,7 +5,7 @@
   AuthName "Kerberos Login"
   KrbMethodNegotiate On
   KrbMethodK5Passwd Off
-  KrbAuthRealms <%= @facts['ipa']['default_realm'] %>
+  KrbAuthRealms <%= @facts['foreman_ipa']['default_realm'] %>
   Krb5KeyTab <%= scope.lookupvar('::foreman::http_keytab') %>
   KrbLocalUserMapping On
   # require valid-user


### PR DESCRIPTION
This prevents a collision with the ipa fact from the ipa module.

In this cherry pick the old fact is kept for compatibility.

(cherry picked from commit 631f4a6a4dbdff3580592ab28771b34d6b52bfb0)

Currently a draft since I need to test this on a real system and a PR made that easier.