### PR TITLE
Ensure Foreman is provisioned before configuring cockpit

### DIFF
--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -48,6 +48,7 @@ class foreman::plugin::remote_execution::cockpit {
   }
 
   foreman_config_entry { 'remote_execution_cockpit_url':
-    value => "${cockpit_path}/=%{host}",
+    value   => "${cockpit_path}/=%{host}",
+    require => Class['foreman::database'],
   }
 }

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -24,6 +24,11 @@ describe 'foreman::plugin::remote_execution::cockpit' do
 
       it { is_expected.to contain_service('foreman-cockpit').with_ensure('running').with_enable('true') }
 
+      it do
+        is_expected.to contain_foreman_config_entry('remote_execution_cockpit_url')
+          .that_requires(['Class[foreman::database]', 'Foreman::Plugin[remote_execution-cockpit]'])
+      end
+
       it 'creates configs' do
         is_expected.to contain_file('/etc/foreman/cockpit/cockpit.conf')
           .with_ensure('file')


### PR DESCRIPTION
Previously foreman_config_entry could be executed before the database was available. This ensures the database is ready and the plugin installed before attempting to change a config setting.

(cherry picked from commit 81a68c923a9e52a1579c599f95828042d0c95470)