### PR TITLE
Fixes #30026 - Ensure Foreman is provisioned before configuring puppetdb

### DIFF
--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -25,22 +25,20 @@ class foreman::plugin::puppetdb (
   foreman::plugin { 'puppetdb':
     package => $foreman::plugin_prefix.regsubst(/foreman[_-]/, 'puppetdb_foreman'),
   }
-  -> foreman_config_entry { 'puppetdb_enabled':
-    value => true,
+
+  $config = {
+    'puppetdb_enabled'         => true,
+    'puppetdb_address'         => $address,
+    'puppetdb_ssl_ca_file'     => $ssl_ca_file,
+    'puppetdb_ssl_certificate' => $ssl_certificate,
+    'puppetdb_ssl_private_key' => $ssl_private_key,
+    'puppetdb_api_version'     => $api_version,
   }
-  -> foreman_config_entry { 'puppetdb_address':
-    value => $address,
-  }
-  -> foreman_config_entry { 'puppetdb_ssl_ca_file':
-    value => $ssl_ca_file,
-  }
-  -> foreman_config_entry { 'puppetdb_ssl_certificate':
-    value => $ssl_certificate,
-  }
-  -> foreman_config_entry { 'puppetdb_ssl_private_key':
-    value => $ssl_private_key,
-  }
-  -> foreman_config_entry { 'puppetdb_api_version':
-    value => $api_version,
+
+  $config.each |$setting, $value| {
+    foreman_config_entry { $setting:
+      value   => $value,
+      require => Class['foreman::database'],
+    }
   }
 }

--- a/spec/classes/plugin/puppetdb_spec.rb
+++ b/spec/classes/plugin/puppetdb_spec.rb
@@ -19,6 +19,16 @@ describe 'foreman::plugin::puppetdb' do
 
       it { should compile.with_all_deps }
       it { should contain_foreman__plugin('puppetdb').with_package(package_name) }
+      it do
+        should contain_foreman_config_entry('puppetdb_enabled')
+          .with_value(true)
+          .that_requires(['Class[foreman::database]', 'Foreman::Plugin[puppetdb]'])
+      end
+      it do
+        should contain_foreman_config_entry('puppetdb_address')
+          .with_value('https://localhost:8081/pdb/cmd/v1')
+          .that_requires(['Class[foreman::database]', 'Foreman::Plugin[puppetdb]'])
+      end
     end
   end
 end


### PR DESCRIPTION
This is the same as 81a68c923a9e52a1579c599f95828042d0c95470 but for puppetdb.