### PR TITLE
Fixes #30299: Set ownership on certificates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,6 +47,16 @@ class foreman::config {
     ensure => absent,
   }
 
+  file { $foreman::client_ssl_cert:
+    group => $foreman::group,
+    mode  => '0640',
+  }
+
+  file { $foreman::client_ssl_key:
+    group => $foreman::group,
+    mode  => '0640',
+  }
+
   $listen_socket = $foreman::foreman_service_bind ? {
     Stdlib::IP::Address::V6 => "[${foreman::foreman_service_bind}]:${foreman::foreman_service_port}",
     default                 => "${foreman::foreman_service_bind}:${foreman::foreman_service_port}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class foreman::params {
   $manage_user       = true
   $user              = 'foreman'
   $group             = 'foreman'
-  $user_groups       = ['puppet']
+  $user_groups       = []
   $rails_env         = 'production'
   $version           = 'present'
   $plugin_version    = 'present'
@@ -133,27 +133,23 @@ class foreman::params {
     }
   }
 
-  if fact('aio_agent_version') =~ String[1] {
-    $puppet_ssldir = '/etc/puppetlabs/puppet/ssl'
-  } else {
-    $puppet_ssldir = '/var/lib/puppet/ssl'
-  }
+  $foreman_pki_dir = '/etc/foreman_pki'
 
   # If CA is specified, remote Foreman host will be verified in reports/ENC scripts
-  $client_ssl_ca   = "${puppet_ssldir}/certs/ca.pem"
+  $client_ssl_ca   = "${foreman_pki_dir}/ca/ca.crt"
   # Used to authenticate to Foreman, required if require_ssl_puppetmasters is enabled
-  $client_ssl_cert = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
-  $client_ssl_key  = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
+  $client_ssl_cert = "${foreman_pki_dir}/foreman/client.crt"
+  $client_ssl_key  = "${foreman_pki_dir}/foreman/client.key"
 
   $vhost_priority = '05'
 
   # Set these values if you want Passenger to serve a CA-provided cert instead of puppet's
-  $server_ssl_ca    = "${puppet_ssldir}/certs/ca.pem"
-  $server_ssl_chain = "${puppet_ssldir}/certs/ca.pem"
-  $server_ssl_cert  = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
+  $server_ssl_ca = "${foreman_pki_dir}/ca/ca.crt"
+  $server_ssl_chain = "${foreman_pki_dir}/ca/ca.crt"
+  $server_ssl_cert = "${foreman_pki_dir}/apache/apache.crt"
   $server_ssl_certs_dir = '' # lint:ignore:empty_string_assignment - this must be empty since we override a default
-  $server_ssl_key   = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
-  $server_ssl_crl   = "${puppet_ssldir}/crl.pem"
+  $server_ssl_key = "${foreman_pki_dir}/apache/apache.key"
+  $server_ssl_crl = ''
   $server_ssl_protocol = undef
   $server_ssl_verify_client = 'optional'
 


### PR DESCRIPTION
These are changes from testing a foreman_pki proof of concept as a default instead of Puppet CA.