### PR TITLE
Expand error message on SP retrieval

### DIFF
--- a/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
+++ b/lib/puppet/provider/foreman_smartproxy/rest_v3.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:foreman_smartproxy).provide(:rest_v3, :parent => Puppet::Type
   def proxy
     @proxy ||= begin
       r = request(:get, 'api/v2/smart_proxies', :search => %{name="#{resource[:name]}"})
-      raise Puppet::Error.new("Proxy #{resource[:name]} cannot be retrieved: #{error_message(r)}") unless success?(r)
+      raise Puppet::Error.new("Proxy #{resource[:name]} cannot be retrieved from Foreman: #{error_message(r)}") unless success?(r)
       JSON.load(r.body)['results'][0]
     end
   end


### PR DESCRIPTION
It may not be clear to everyone that this is the response from Foreman. Often we see people only post the installer log but the that's not helpful when the Foreman application had an error.