### PR TITLE
Fixes #30456 - Fix missing icons on /pub page

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -107,7 +107,7 @@ class foreman::config::apache(
   Stdlib::Port $server_ssl_port = 443,
   Stdlib::HTTPUrl $proxy_backend = 'http://localhost:3000/',
   Hash $proxy_params = {'retry' => '0'},
-  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pulp2', '/streamer', '/pub'],
+  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
   Boolean $ssl = false,
   Optional[Stdlib::Absolutepath] $ssl_ca = undef,
   Optional[Stdlib::Absolutepath] $ssl_chain = undef,

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -222,7 +222,7 @@ describe 'foreman::config::apache' do
                   'set SSL_CLIENT_VERIFY ""'
                 ])
                 .with_proxy_pass(
-                  "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub'],
+                  "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
                   "url"           => 'http://localhost:3000/',
                   "params"        => { "retry" => '0' },
@@ -249,7 +249,7 @@ describe 'foreman::config::apache' do
                 ])
                 .with_ssl_proxyengine(true)
                 .with_proxy_pass(
-                  "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub'],
+                  "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
                   "url"           => 'http://localhost:3000/',
                   "params"        => { "retry" => '0' },


### PR DESCRIPTION
The requests for `/icons/*` were being proxy-passed to puma, which didn't know about any icons and returned 404s.