### PR TITLE
Changed managed user resource to system type

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -100,6 +100,7 @@ class foreman::config {
       home    => $foreman::app_root,
       gid     => $foreman::group,
       groups  => $foreman::user_groups,
+      system  => true,
     }
   }
 


### PR DESCRIPTION
Foreman packages by default deploy users as system users. This ensures the module does the same.