### PR TITLE
Fixes #30803: Bind to socket for Puma and Apache

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -325,10 +325,10 @@ class foreman (
 
   if $apache {
     $use_foreman_service = ! $passenger
-    $foreman_service_bind = '127.0.0.1'
+    $foreman_service_bind = 'unix:///run/foreman.sock'
   } else {
     $use_foreman_service = true
-    $foreman_service_bind = '0.0.0.0'
+    $foreman_service_bind = 'tcp://0.0.0.0:3000'
   }
 
   include foreman::install

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,7 +74,6 @@ class foreman::params {
   $foreman_service = 'foreman'
   $foreman_service_ensure = 'running'
   $foreman_service_enable = true
-  $foreman_service_port = 3000
   $foreman_service_puma_threads_min = 0
   $foreman_service_puma_threads_max = 16
   $foreman_service_puma_workers = 2

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,9 +40,15 @@ class foreman::service(
   }
 
   if $use_foreman_service {
-    service { $foreman_service:
+    service { "${foreman_service}.socket":
       ensure => $foreman_service_ensure,
       enable => $foreman_service_enable,
+    }
+
+    service { $foreman_service:
+      ensure  => $foreman_service_ensure,
+      enable  => $foreman_service_enable,
+      require => Service["${foreman_service}.socket"],
     }
   }
 }

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -229,14 +229,14 @@ describe 'foreman::config::apache' do
                 .with_proxy_pass(
                   "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
-                  "url"           => 'http://localhost:3000/',
+                  "url"           => 'unix:///run/foreman.sock|http://foo.example.com/',
                   "params"        => { "retry" => '0' },
                 )
                 .with_rewrites([
                   {
                     'comment'      => 'Upgrade Websocket connections',
                     'rewrite_cond' => '%{HTTP:Upgrade} =websocket [NC]',
-                    'rewrite_rule' => '/(.*) ws://localhost:3000/$1 [P,L]',
+                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foo.example.com/$1 [P,L]',
                   },
                 ])
             end
@@ -261,14 +261,14 @@ describe 'foreman::config::apache' do
                 .with_proxy_pass(
                   "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
-                  "url"           => 'http://localhost:3000/',
+                  "url"           => 'unix:///run/foreman.sock|http://foo.example.com/',
                   "params"        => { "retry" => '0' },
                 )
                 .with_rewrites([
                   {
                     'comment'      => 'Upgrade Websocket connections',
                     'rewrite_cond' => '%{HTTP:Upgrade} =websocket [NC]',
-                    'rewrite_rule' => '/(.*) ws://localhost:3000/$1 [P,L]',
+                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foo.example.com/$1 [P,L]',
                   },
                 ])
             end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -154,8 +154,8 @@ describe 'foreman' do
 
         it { should compile.with_all_deps }
         it { should contain_class('foreman::config::apache').with_passenger(false) }
-        it { should contain_systemd__dropin_file('foreman-socket').with_filename('installer.conf').with_unit('foreman.socket').with_content(/^ListenStream=127\.0\.0\.1:3000$/) }
-        it { should contain_systemd__dropin_file('foreman-service').with_filename('installer.conf').with_unit('foreman.service').with_content(/^Environment=FOREMAN_BIND=127.0.0.1$/) }
+        it { should contain_systemd__dropin_file('foreman-socket').with_filename('installer.conf').with_unit('foreman.socket').with_content(/^ListenStream=\/run\/foreman\.sock$/) }
+        it { should contain_systemd__dropin_file('foreman-service').with_filename('installer.conf').with_unit('foreman.service').with_content(/^Environment=FOREMAN_BIND=unix:\/\/\/run\/foreman\.sock$/) }
         it do
           should contain_concat__fragment('foreman_settings+01-header.yaml')
             .with_content(/^:ssl_client_dn_env: HTTP_SSL_CLIENT_S_DN$/)

--- a/spec/support/acceptance/examples.rb
+++ b/spec/support/acceptance/examples.rb
@@ -19,8 +19,8 @@ shared_examples 'the foreman application' do
     it { is_expected.to be_listening }
   end
 
-  describe port(3000) do
-    it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
+  describe file('/run/foreman.sock') do
+    it { should be_socket }
   end
 
   describe command("curl -s --cacert /etc/foreman-certs/certificate.pem https://#{host_inventory['fqdn']} -w '\%{redirect_url}' -o /dev/null") do

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -3,7 +3,6 @@ User=<%= scope['foreman::user'] %>
 Environment=FOREMAN_ENV=<%= scope['foreman::rails_env'] %>
 Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
 Environment=FOREMAN_BIND=<%= scope['foreman::foreman_service_bind'] %>
-Environment=FOREMAN_PORT=<%= scope['foreman::foreman_service_port'] %>
 Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::foreman_service_puma_threads_min'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
 Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::foreman_service_puma_workers'] %>

--- a/templates/foreman.socket-overrides.erb
+++ b/templates/foreman.socket-overrides.erb
@@ -1,3 +1,7 @@
 [Socket]
 ListenStream=
-ListenStream=<%= @listen_socket %>
+ListenStream=<%= @listen_stream %>
+<% if scope['foreman::apache'] -%>
+SocketUser=<%= scope['apache::user'] %>
+SocketMode=0600
+<% end -%>


### PR DESCRIPTION
The goal of this change is to switch to using local unix sockets to bind Puma to, and also to have Apache reverse proxy to increasing the security of the communication from the reverse proxy to the socket. 

I am looking to understand if I need to enforce permissions and user-group on the socket to enhance security. There is also currently SELinux denials that are associated with this change we will need to account for. On my test system they are:

```
type=AVC msg=audit(1599591946.533:10070): avc:  denied  { connectto } for  pid=6405 comm="httpd" path="/run/puma.sock" scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:system_r:foreman_rails_t:s0 tclass=unix_stream_socket
```

SELinux policy changes needed to address -- https://github.com/theforeman/foreman-selinux/pull/113