### PR TITLE
CLI: make refresh_cache and request_timeout params global

### DIFF
--- a/spec/classes/foreman_cli_spec.rb
+++ b/spec/classes/foreman_cli_spec.rb
@@ -22,7 +22,9 @@ describe 'foreman::cli' do
             verify_exact_contents(catalogue, '/etc/hammer/cli.modules.d/foreman.yml', [
                                     ':foreman:',
                                     '  :enable_module: true',
-                                    "  :host: 'http://example.com'"
+                                    "  :host: 'http://example.com'",
+                                    '  :refresh_cache: false',
+                                    '  :request_timeout: 120',
                                   ])
           end
         end
@@ -35,8 +37,6 @@ describe 'foreman::cli' do
                                     ':foreman:',
                                     "  :username: 'joe'",
                                     "  :password: 'secret'",
-                                    '  :refresh_cache: false',
-                                    '  :request_timeout: 120'
                                   ])
           end
         end
@@ -56,6 +56,8 @@ describe 'foreman::cli' do
                                       ':foreman:',
                                       '  :enable_module: true',
                                       "  :host: 'http://example.com'",
+                                      '  :refresh_cache: false',
+                                      '  :request_timeout: 120',
                                       ':ssl:',
                                       "  :ssl_ca_file: '/etc/ca.pub'"
                                     ])
@@ -94,6 +96,8 @@ describe 'foreman::cli' do
                                   ':foreman:',
                                   '  :enable_module: true',
                                   "  :host: 'https://foreman.example.com'",
+                                  '  :refresh_cache: false',
+                                  '  :request_timeout: 120',
                                   ':ssl:',
                                   "  :ssl_ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pub'"
                                 ])
@@ -104,8 +108,6 @@ describe 'foreman::cli' do
                                   ':foreman:',
                                   "  :username: 'jane'",
                                   "  :password: 'supersecret'",
-                                  '  :refresh_cache: false',
-                                  '  :request_timeout: 120'
                                 ])
         end
       end

--- a/templates/hammer_etc.yml.erb
+++ b/templates/hammer_etc.yml.erb
@@ -4,6 +4,12 @@
 
   # Your foreman server address
   :host: '<%= @foreman_url_real %>'
+
+  # Check API documentation cache status on each request
+  :refresh_cache: <%= @refresh_cache %>
+
+  # API request timeout in seconds, set -1 for infinity
+  :request_timeout: <%= @request_timeout %>
 <% if @ssl_ca_file_real -%>
 
 :ssl:

--- a/templates/hammer_root.yml.erb
+++ b/templates/hammer_root.yml.erb
@@ -2,9 +2,3 @@
   # Credentials. You'll be asked for the interactively if you leave them blank here
   :username: '<%= @username_real %>'
   :password: '<%= @password_real %>'
-
-  # Check API documentation cache status on each request
-  :refresh_cache: <%= @refresh_cache %>
-
-  # API request timeout in seconds, set -1 for infinity
-  :request_timeout: <%= @request_timeout %>


### PR DESCRIPTION
Considering the name of these parameters, they should be affect system-wide configuration but were set in root configuration file.
This commit fixes this unexpected behavior.