### PR TITLE
Fixes #30789 - Set DB pool size dynamically

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,12 @@ class foreman::config {
     mode  => '0640',
   }
 
+  if $foreman::use_foreman_service {
+    $db_pool = max($foreman::db_pool, $foreman::foreman_service_puma_threads_max)
+  } else {
+    $db_pool = $foreman::db_pool
+  }
+
   file { '/etc/foreman/database.yml':
     owner   => 'root',
     group   => $foreman::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,8 @@
 #
 # $db_root_cert::                 Root cert used to verify SSL connection to postgres
 #
-# $db_pool::                      Database 'production' size of connection pool
+# $db_pool::                      Database 'production' size of connection pool. When running as a reverse proxy,
+#                                 the value of `$foreman_service_puma_threads_max` is used if it's higher than `$db_pool`.
 #
 # $db_manage_rake::               if enabled, will run rake jobs, which depend on the database
 #

--- a/templates/database.yml.erb
+++ b/templates/database.yml.erb
@@ -27,6 +27,4 @@
 <% unless (password = scope.lookupvar("::foreman::db_password")) == 'UNSET' -%>
   password: "<%= password %>"
 <% end -%>
-<% unless (pool = scope.lookupvar("::foreman::db_pool")) == 'UNSET' -%>
-  pool: <%= pool %>
-<% end -%>
+  pool: <%= @db_pool %>


### PR DESCRIPTION
Every thread in the Puma worker can open a database connection. This
means it needs to be taken into account to avoid exhasuting the pool.

(cherry picked from commit 026d47434316b8ae318c5e42936edc12859ab475)