### PR TITLE
Refs #30535 - Correctly unset remote user groups

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -200,7 +200,7 @@ class foreman::config::apache(
         'unset REMOTE_USER_EMAIL',
         'unset REMOTE_USER_FIRSTNAME',
         'unset REMOTE_USER_LASTNAME',
-        'unset REMOTE_USER_USER_GROUPS',
+        'unset REMOTE_USER_GROUPS',
       ],
       'proxy_pass'          => {
         'no_proxy_uris' => $proxy_no_proxy_uris,
@@ -228,7 +228,7 @@ class foreman::config::apache(
         'unset REMOTE_USER_EMAIL',
         'unset REMOTE_USER_FIRSTNAME',
         'unset REMOTE_USER_LASTNAME',
-        'unset REMOTE_USER_USER_GROUPS',
+        'unset REMOTE_USER_GROUPS',
       ],
     }
 

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -224,7 +224,7 @@ describe 'foreman::config::apache' do
                   'unset REMOTE_USER_EMAIL',
                   'unset REMOTE_USER_FIRSTNAME',
                   'unset REMOTE_USER_LASTNAME',
-                  'unset REMOTE_USER_USER_GROUPS'
+                  'unset REMOTE_USER_GROUPS'
                 ])
                 .with_proxy_pass(
                   "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
@@ -255,7 +255,7 @@ describe 'foreman::config::apache' do
                   'unset REMOTE_USER_EMAIL',
                   'unset REMOTE_USER_FIRSTNAME',
                   'unset REMOTE_USER_LASTNAME',
-                  'unset REMOTE_USER_USER_GROUPS'
+                  'unset REMOTE_USER_GROUPS'
                 ])
                 .with_ssl_proxyengine(true)
                 .with_proxy_pass(


### PR DESCRIPTION
This corrects a typo in the previous change, which unset
REMOTE_USER_USER_GROUPS instead of REMOTE_USER_GROUPS in the apache
configuration.