### PR TITLE
Release 15.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [15.1.2](https://github.com/theforeman/puppet-foreman/tree/15.1.2) (2020-11-11)
+
+[Full Changelog](https://github.com/theforeman/puppet-foreman/compare/15.1.1...15.1.2)
+
+**Implemented enhancements:**
+
+ - [\#29938](https://projects.theforeman.org/issues/29938) - allow 'multiline_request_pattern' logging layout [\#902](https://github.com/theforeman/puppet-foreman/pull/902) ([domitea](https://github.com/domitea)) + [\#904](https://github.com/theforeman/puppet-foreman/pull/904) ([wbclark](https://github.com/wbclark))
+
+**Fixed bugs:**
+
+- Refs [\#30535](https://projects.theforeman.org/issues/30535) - Correctly unset remote user groups [\#896](https://github.com/theforeman/puppet-foreman/pull/896) ([tbrisker](https://github.com/tbrisker))
+
 ## [15.1.1](https://github.com/theforeman/puppet-foreman/tree/15.1.1) (2020-10-14)
 
 [Full Changelog](https://github.com/theforeman/puppet-foreman/compare/15.1.0...15.1.1)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-foreman",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "author": "theforeman",
   "summary": "Foreman server configuration",
   "license": "GPL-3.0+",


### PR DESCRIPTION
I bumped only the patch version despite https://github.com/theforeman/puppet-foreman/commit/cf178b3b65b7d2a7c4f7d13e24391b0ba75b35c8 being a breaking change.

I reason that this is OK because that commit does add notes to the README about overriding the new default parameter in order to maintain compatibility with Foreman older than 2.2, so this should be noted as a breaking change in the CHANGELOG and users can review that commit and find the necessary info if they are trying to use an older Foreman version.

CC: @tbrisker @ehelms @ekohl 