### PR TITLE
Use backwards compatible 'pattern' logging_layout by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -189,7 +189,7 @@ class foreman::params {
   # Application logging
   $logging_level = 'info'
   $logging_type = 'file'
-  $logging_layout = 'multiline_request_pattern'
+  $logging_layout = 'pattern'
   $loggers = {}
 
   # Rails Cache Store

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -280,7 +280,7 @@ describe 'foreman' do
                                             '  :level: info',
                                             '  :production:',
                                             '    :type: journald',
-                                            '    :layout: multiline_request_pattern'
+                                            '    :layout: pattern'
                                           ])
         end
       end


### PR DESCRIPTION
Foreman 2.2 and later supports the newer 'multiline_request_pattern'.
This commit preserves the older 'pattern' logging_layout as the default,
in order to maintain backwards compatibility with older Foreman versions.