### PR TITLE
CLI: Allow to configure use_sessions setting

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -14,6 +14,8 @@
 #
 # $manage_root_config::   Whether to manage /root/.hammer configuration.
 #
+# $use_sessions::         Enable using sessions
+#
 # $refresh_cache::        Check API documentation cache status on each request
 #
 # $request_timeout::      API request timeout, set -1 for infinity
@@ -31,6 +33,7 @@ class foreman::cli (
   Boolean $manage_root_config = $foreman::cli::params::manage_root_config,
   Optional[String] $username = $foreman::cli::params::username,
   Optional[String] $password = $foreman::cli::params::password,
+  Boolean $use_sessions = $foreman::cli::params::use_sessions,
   Boolean $refresh_cache = $foreman::cli::params::refresh_cache,
   Integer[-1] $request_timeout = $foreman::cli::params::request_timeout,
   Optional[Stdlib::Absolutepath] $ssl_ca_file = $foreman::cli::params::ssl_ca_file,

--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -7,6 +7,7 @@ class foreman::cli::params {
   $password = undef
   $refresh_cache = false
   $request_timeout = 120
+  $use_sessions = false
   $ssl_ca_file = undef
 
   # OS specific paths

--- a/spec/classes/foreman_cli_spec.rb
+++ b/spec/classes/foreman_cli_spec.rb
@@ -23,6 +23,7 @@ describe 'foreman::cli' do
                                     ':foreman:',
                                     '  :enable_module: true',
                                     "  :host: 'http://example.com'",
+                                    '  :use_sessions: false',
                                     '  :refresh_cache: false',
                                     '  :request_timeout: 120',
                                   ])
@@ -56,6 +57,7 @@ describe 'foreman::cli' do
                                       ':foreman:',
                                       '  :enable_module: true',
                                       "  :host: 'http://example.com'",
+                                      '  :use_sessions: false',
                                       '  :refresh_cache: false',
                                       '  :request_timeout: 120',
                                       ':ssl:',
@@ -96,6 +98,7 @@ describe 'foreman::cli' do
                                   ':foreman:',
                                   '  :enable_module: true',
                                   "  :host: 'https://foreman.example.com'",
+                                  '  :use_sessions: false',
                                   '  :refresh_cache: false',
                                   '  :request_timeout: 120',
                                   ':ssl:',

--- a/templates/hammer_etc.yml.erb
+++ b/templates/hammer_etc.yml.erb
@@ -5,11 +5,17 @@
   # Your foreman server address
   :host: '<%= @foreman_url_real %>'
 
+  # Enable using sessions
+  # When sessions are enabled, hammer ignores credentials stored in the config file
+  # and asks for them interactively at the begining of each session.
+  :use_sessions: <%= @use_sessions %>
+
   # Check API documentation cache status on each request
   :refresh_cache: <%= @refresh_cache %>
 
   # API request timeout in seconds, set -1 for infinity
   :request_timeout: <%= @request_timeout %>
+
 <% if @ssl_ca_file_real -%>
 
 :ssl:


### PR DESCRIPTION
This PR should be merged after #884 in order to keep changelog.

Hence the title, this PR provides a simple patch to allow user to setup a system-wide configuration file for hammer with a `use_sessions` parameter.