### PR TITLE
Set the reverse proxy host to the name of the service

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -135,7 +135,7 @@ class foreman::config::apache(
   $docroot = "${app_root}/public"
 
   if $proxy_backend =~ 'unix://' {
-    $_proxy_backend = "${proxy_backend}|http://${servername}/"
+    $_proxy_backend = "${proxy_backend}|http://foreman/"
   } else {
     $_proxy_backend = regsubst($proxy_backend, 'tcp://', 'http://')
   }

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -228,14 +228,14 @@ describe 'foreman::config::apache' do
                 .with_proxy_pass(
                   "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
-                  "url"           => 'unix:///run/foreman.sock|http://foo.example.com/',
+                  "url"           => 'unix:///run/foreman.sock|http://foreman/',
                   "params"        => { "retry" => '0' },
                 )
                 .with_rewrites([
                   {
                     'comment'      => 'Upgrade Websocket connections',
                     'rewrite_cond' => '%{HTTP:Upgrade} =websocket [NC]',
-                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foo.example.com/$1 [P,L]',
+                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foreman/$1 [P,L]',
                   },
                 ])
             end
@@ -260,14 +260,14 @@ describe 'foreman::config::apache' do
                 .with_proxy_pass(
                   "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
                   "path"          => '/',
-                  "url"           => 'unix:///run/foreman.sock|http://foo.example.com/',
+                  "url"           => 'unix:///run/foreman.sock|http://foreman/',
                   "params"        => { "retry" => '0' },
                 )
                 .with_rewrites([
                   {
                     'comment'      => 'Upgrade Websocket connections',
                     'rewrite_cond' => '%{HTTP:Upgrade} =websocket [NC]',
-                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foo.example.com/$1 [P,L]',
+                    'rewrite_rule' => '/(.*) unix:///run/foreman.sock|ws://foreman/$1 [P,L]',
                   },
                 ])
             end


### PR DESCRIPTION
This change stems from the breakage and investigation here:
https://community.theforeman.org/t/katello-nightly-rpm-pipeline-769-failed/21468/4?u=ehelms

The shadowing of the /v2/ in Pulpcore API by Katello to provide auth causes
it to clash with the reverse proxying within the same Vhost to Foreman.
This appears to be tied to how the unix socket based reverse proxy handles things.