### PR TITLE
Fix URI.escape deprecation warning

### DIFF
--- a/lib/puppet/functions/foreman/foreman.rb
+++ b/lib/puppet/functions/foreman/foreman.rb
@@ -37,6 +37,7 @@
 #
 # Happy Foreman API-ing!
 
+require "cgi"
 require "yaml"
 require "net/http"
 require "net/https"
@@ -61,7 +62,7 @@ Puppet::Functions.create_function(:'foreman::foreman') do
     raise Puppet::ParseError, "Foreman: Invalid filter_result: #{filter_result}, must not be boolean true" if filter_result == true
 
     begin
-      path = URI.escape("/api/#{item}?search=#{search}&per_page=#{per_page}")
+      path = "/api/#{CGI.escape(item)}?search=#{CGI.escape(search)}&per_page=#{CGI.escape(per_page)}"
 
       req = Net::HTTP::Get.new(path)
       req['Content-Type'] = 'application/json'

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -2,6 +2,7 @@
 # Foreman holds all the value names and their possible values,
 # this function simply ask foreman for the right value for this host.
 
+require "cgi"
 require "net/http"
 require "net/https"
 require "uri"
@@ -23,7 +24,7 @@ Puppet::Functions.create_function(:'foreman::smartvar') do
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
 
-    path = URI.escape("/hosts/#{fqdn}/lookup_keys/#{var}")
+    path = "/hosts/#{CGI.escape(fqdn)}/lookup_keys/#{CGI.escape(var)}"
     req = Net::HTTP::Get.new(path)
     req.basic_auth(foreman_user, foreman_pass)
     req['Content-Type'] = 'application/json'

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -16,7 +16,7 @@ Puppet::Functions.create_function(:'foreman::smartvar') do
     optional_param 'String', :foreman_pass
   end
 
-   def smartvar(var, foreman_url = "http://foreman", foreman_user = "admin", foreman_pass = "changeme")
+  def smartvar(var, foreman_url = "http://foreman", foreman_user = "admin", foreman_pass = "changeme")
     scope = closure_scope
     fqdn = scope['facts']['fqdn']
 

--- a/lib/puppet/parser/functions/foreman.rb
+++ b/lib/puppet/parser/functions/foreman.rb
@@ -38,6 +38,7 @@
 #
 # Happy Foreman API-ing!
 
+require "cgi"
 require "yaml"
 require "net/http"
 require "net/https"
@@ -65,7 +66,7 @@ module Puppet::Parser::Functions
     raise Puppet::ParseError, "Foreman: Invalid filter_result: #{filter_result}, must be a String or an Array" unless filter_result.is_a? String or filter_result.is_a? Array or filter_result.is_a? Hash or filter_result == false
 
     begin
-      path = URI.escape("/api/#{item}?search=#{search}&per_page=#{per_page}")
+      path = "/api/#{CGI.escape(item)}?search=#{CGI.escape(search)}&per_page=#{CGI.escape(per_page)}"
 
       req = Net::HTTP::Get.new(path)
       req['Content-Type'] = 'application/json'

--- a/lib/puppet/parser/functions/smartvar.rb
+++ b/lib/puppet/parser/functions/smartvar.rb
@@ -3,6 +3,7 @@
 # this function simply ask foreman for the right value for this host.
 
 
+require "cgi"
 require "net/http"
 require "net/https"
 require "uri"
@@ -24,7 +25,7 @@ module Puppet::Parser::Functions
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
 
-    path = URI.escape("/hosts/#{fqdn}/lookup_keys/#{var}")
+    path = "/hosts/#{CGI.escape(fqdn)}/lookup_keys/#{CGI.escape(var)}"
     req = Net::HTTP::Get.new(path)
     req.basic_auth(foreman_user, foreman_pass)
     req['Content-Type'] = 'application/json'

--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -1,7 +1,7 @@
 # Base provider for other Puppet types managing Foreman resources
 #
-# This provider uses Net::HTTP from Ruby stdlib, JSON (stdlib on 1.9+ or the
-# gem on 1.8) and the oauth gem for auth, so requiring minimal dependencies.
+# This provider uses Net::HTTP from Ruby stdlib, JSON and the oauth gem for
+# auth, so requiring minimal dependencies.
 
 require 'cgi'
 require 'uri'

--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -3,6 +3,7 @@
 # This provider uses Net::HTTP from Ruby stdlib, JSON (stdlib on 1.9+ or the
 # gem on 1.8) and the oauth gem for auth, so requiring minimal dependencies.
 
+require 'cgi'
 require 'uri'
 
 Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
@@ -59,7 +60,7 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
     base_url += '/' unless base_url.end_with?('/')
 
     uri = URI.join(base_url, path)
-    uri.query = params.map { |p,v| "#{URI.escape(p.to_s)}=#{URI.escape(v.to_s)}" }.join('&') unless params.empty?
+    uri.query = params.map { |p,v| "#{CGI.escape(p.to_s)}=#{CGI.escape(v.to_s)}" }.join('&') unless params.empty?
 
     headers = {
       'Accept' => 'application/json',


### PR DESCRIPTION
Ruby 2.7 deprecated URI.escape. It also fixes 2 other small (visual) issues.

I have not tested this myself.