### PR TITLE
Configurable: email_reply_address, email_subject_prefix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,10 @@
 #
 # $email_smtp_password::          Password for SMTP server auth, if authentication is enabled
 #
+# $email_reply_address::          Email reply address for emails that Foreman is sending
+#
+# $email_subject_prefix::         Prefix to add to all outgoing email
+#
 # $initial_organization::         Name of an initial organization
 #
 # $initial_location::             Name of an initial location
@@ -287,6 +291,8 @@ class foreman (
   Enum['none', 'plain', 'login', 'cram-md5'] $email_smtp_authentication = $foreman::params::email_smtp_authentication,
   Optional[String] $email_smtp_user_name = $foreman::params::email_smtp_user_name,
   Optional[String] $email_smtp_password = $foreman::params::email_smtp_password,
+  Optional[String] $email_reply_address = $foreman::params::email_reply_address,
+  Optional[String] $email_subject_prefix = $foreman::params::email_subject_prefix,
   String $telemetry_prefix = $foreman::params::telemetry_prefix,
   Boolean $telemetry_prometheus_enabled = $foreman::params::telemetry_prometheus_enabled,
   Boolean $telemetry_statsd_enabled = $foreman::params::telemetry_statsd_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,8 @@ class foreman::params {
   $email_smtp_authentication = 'none'
   $email_smtp_user_name      = undef
   $email_smtp_password       = undef
+  $email_reply_address       = undef
+  $email_subject_prefix      = undef
 
   # Telemetry
   $telemetry_prefix             = 'fm_rails'

--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -8,6 +8,8 @@ class foreman::settings(
   $email_smtp_authentication = $foreman::email_smtp_authentication,
   $email_smtp_user_name      = $foreman::email_smtp_user_name,
   $email_smtp_password       = $foreman::email_smtp_password,
+  $email_reply_address       = $foreman::email_reply_address,
+  $email_subject_prefix      = $foreman::email_subject_prefix,
 ) {
   unless empty($email_delivery_method) {
     foreman_config_entry { 'delivery_method':
@@ -40,6 +42,14 @@ class foreman::settings(
 
     foreman_config_entry { 'smtp_password':
       value => $email_smtp_password,
+    }
+
+    foreman_config_entry { 'email_reply_address':
+      value => $email_reply_address,
+    }
+
+    foreman_config_entry { 'email_subject_prefix':
+      value => $email_subject_prefix,
     }
   }
 }

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -250,6 +250,8 @@ describe 'foreman' do
             email_smtp_authentication: 'none',
             email_smtp_user_name: 'root',
             email_smtp_password: 'secret',
+            email_reply_address: 'noreply@foreman.domain',
+            email_subject_prefix: '[prefix]',
             keycloak: true,
             keycloak_app_name: 'cloak-app',
             keycloak_realm: 'myrealm',
@@ -409,7 +411,9 @@ describe 'foreman' do
               email_smtp_domain: 'example.com',
               email_smtp_authentication: 'none',
               email_smtp_user_name: 'smtp-username',
-              email_smtp_password: 'smtp-password'
+              email_smtp_password: 'smtp-password',
+              email_reply_address: 'noreply@foreman.domain',
+              email_subject_prefix: '[prefix]'
             )
           end
 
@@ -420,6 +424,8 @@ describe 'foreman' do
           it { should contain_foreman_config_entry('smtp_authentication').with_value('') }
           it { should contain_foreman_config_entry('smtp_user_name').with_value('smtp-username') }
           it { should contain_foreman_config_entry('smtp_password').with_value('smtp-password') }
+          it { should contain_foreman_config_entry('email_reply_address').with_value('noreply@foreman.domain') }
+          it { should contain_foreman_config_entry('email_subject_prefix').with_value('[prefix]') }
         end
 
         context 'with email_smtp_authentication=cram-md5' do


### PR DESCRIPTION
Simple patch which adds parameters to the main class to configure the two parameters email_reply_address and email_subject_prefix, which were missing on the interface. I needed to set at least the reply_address as our mail server denied the mails with the default domain ending. I appended the existing tests used for the settings already on the interface.