### PR TITLE
Fixes #31964 - Assign equal weight to sidekiq queues

### DIFF
--- a/manifests/dynflow/worker.pp
+++ b/manifests/dynflow/worker.pp
@@ -23,7 +23,7 @@
 define foreman::dynflow::worker (
   String $service_name = $name,
   Integer[1] $concurrency = $foreman::dynflow_pool_size,
-  Array[String] $queues = ['default', 'remote_execution'],
+  Array[String] $queues = ['["default", 1]', '["remote_execution", 1]'],
   String $config_owner = 'root',
   String $config_group = $foreman::group,
   Stdlib::Ensure::Service $service_ensure = $foreman::jobs_service_ensure,

--- a/spec/defines/foreman_dynflow_worker_spec.rb
+++ b/spec/defines/foreman_dynflow_worker_spec.rb
@@ -19,7 +19,7 @@ describe 'foreman::dynflow::worker' do
             .with_group('foreman')
             .with_mode('0644')
             .with_content(/:concurrency: 5/)
-            .with_content(/:queues:\n  - default\n  - remote_execution/)
+            .with_content(/:queues:\n  - ["default", 1]\n  - ["remote_execution", 1]/)
         }
         it {
           should contain_service('dynflow-sidekiq@test_worker')

--- a/spec/defines/foreman_dynflow_worker_spec.rb
+++ b/spec/defines/foreman_dynflow_worker_spec.rb
@@ -19,7 +19,7 @@ describe 'foreman::dynflow::worker' do
             .with_group('foreman')
             .with_mode('0644')
             .with_content(/:concurrency: 5/)
-            .with_content(/:queues:\n  - ["default", 1]\n  - ["remote_execution", 1]/)
+            .with_content(/:queues:\n  - \["default", 1\]\n  - \["remote_execution", 1\]/)
         }
         it {
           should contain_service('dynflow-sidekiq@test_worker')


### PR DESCRIPTION
The previous approach worker, but it made sidekiq default worker process all
items from the default queue before moving to remote execution queue. This
change adds equal weight to the queues, making sidekiq pick jobs from both.