### PR TITLE
Fixes #32175: Allow toggling task backup when cleaning them up

### DIFF
--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -6,9 +6,13 @@
 # @param cron_line
 #   Cron line defining when the cleanup cron job should run
 #
+# @param backup
+#   Enable creating a backup of cleaned up tasks in CSV format when automatic_cleanup is enabled
+#
 class foreman::plugin::tasks(
   Boolean $automatic_cleanup = false,
   String $cron_line = '45 19 * * *',
+  Boolean $backup = false,
 ) {
   foreman::plugin { 'tasks':
     package => $foreman::plugin_prefix.regsubst(/foreman[_-]/, 'foreman-tasks'),

--- a/spec/classes/plugin/tasks_spec.rb
+++ b/spec/classes/plugin/tasks_spec.rb
@@ -34,6 +34,7 @@ describe 'foreman::plugin::tasks' do
             with_content(%r{SHELL=/bin/sh}).
             with_content(%r{RAILS_ENV=production}).
             with_content(%r{FOREMAN_HOME=/usr/share/foreman}).
+            with_content(%r{TASK_BACKUP=false}).
             with_content(%r{/usr/sbin/foreman-rake foreman_tasks:cleanup}).
             with_content(%r{#{cron_line}}).
             with_ensure('file')

--- a/templates/tasks.cron.erb
+++ b/templates/tasks.cron.erb
@@ -1,6 +1,7 @@
 SHELL=/bin/sh
 RAILS_ENV=production
 FOREMAN_HOME=/usr/share/foreman
+TASK_BACKUP=<%= @backup %>
 
 # Clean up expired tasks from the database
 <% user = scope.lookupvar('foreman::user') %>


### PR DESCRIPTION
Changes the default behavior to disable task backup when enabling
the task cleanup cron job. Users who still want backups kept
on disk will need to set the parameter to true.