### PR TITLE
Support JSON fact files

### DIFF
--- a/manifests/puppetmaster.pp
+++ b/manifests/puppetmaster.pp
@@ -31,6 +31,8 @@
 #   The SSL certificate file path to use
 # @param ssl_key
 #   The SSL key file path to use
+# @param fact_extension
+#   The fact extension to use. Puppetserver < 7 defaults to yaml, >= 7 defaults to json.
 class foreman::puppetmaster (
   Stdlib::HTTPUrl $foreman_url = $foreman::puppetmaster::params::foreman_url,
   Boolean $reports = $foreman::puppetmaster::params::reports,
@@ -46,6 +48,7 @@ class foreman::puppetmaster (
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_ca = $foreman::puppetmaster::params::client_ssl_ca,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_cert = $foreman::puppetmaster::params::client_ssl_cert,
   Variant[Enum[''], Stdlib::Absolutepath] $ssl_key = $foreman::puppetmaster::params::client_ssl_key,
+  Enum['yaml', 'json'] $fact_extension = 'json',
 ) inherits foreman::puppetmaster::params {
 
   case $facts['os']['family'] {

--- a/templates/puppet.yaml.erb
+++ b/templates/puppet.yaml.erb
@@ -6,6 +6,7 @@
 :puppetdir: "<%= @puppet_home %>"
 :puppetuser: "<%= @puppet_user %>"
 :facts: <%= @receive_facts %>
+:fact_extension: "<%= @fact_extension %>"
 :timeout: <%= @timeout %>
 :report_timeout: <%= @report_timeout %>
 :threads: null


### PR DESCRIPTION
Puppetserver 7 defaults to JSON. This doesn't require a mac workaround.

This is a draft PR since I haven't had a chance to figure out how to get the puppetserver to actually write out JSON. We should also complete the migration to https://github.com/theforeman/puppet-puppetserver_foreman and submit it there. However, I wanted to share my work.