### PR TITLE
Fixes #32208 - accept trailing slash in Krb auth url

### DIFF
--- a/templates/lookup_identity.conf.erb
+++ b/templates/lookup_identity.conf.erb
@@ -1,5 +1,5 @@
 
-<LocationMatch ^/users/(ext)?login$>
+<LocationMatch ^/users/(ext)?login/?$>
   LookupUserAttr email REMOTE_USER_EMAIL
   LookupUserAttr firstname REMOTE_USER_FIRSTNAME
   LookupUserAttr lastname REMOTE_USER_LASTNAME


### PR DESCRIPTION
The Kerberos url is quite strict, but accepting trailing `/` is probably not bad and can avoid a lot of confusion