### PR TITLE
Fixes #31964 - Assign equal weight to sidekiq queues

### DIFF
--- a/lib/puppet/functions/foreman/to_symbolized_yaml.rb
+++ b/lib/puppet/functions/foreman/to_symbolized_yaml.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'yaml'
+# @summary
+#   Convert a data structure and output it as YAML while symbolizing keys
+#
+# In Foreman often YAML files have symbols as keys. Since it's hard to do that
+# from Puppet, this function does it for you.
+#
+# @example How to output YAML
+#   # output yaml to a file
+#     file { '/tmp/my.yaml':
+#       ensure  => file,
+#       content => foreman::to_symbolized_yaml($myhash),
+#     }
+# @example Use options control the output format
+#   file { '/tmp/my.yaml':
+#     ensure  => file,
+#     content => foreman::to_symbolized_yaml($myhash, {indentation: 4})
+#   }
+Puppet::Functions.create_function(:'foreman::to_symbolized_yaml') do
+  # @param data
+  # @param options
+  #
+  # @return [String]
+  dispatch :to_symbolized_yaml do
+    param 'Any', :data
+    optional_param 'Hash', :options
+  end
+
+  def to_symbolized_yaml(data, options = {})
+    if data.is_a?(Hash)
+      data = Hash[data.map { |k, v| [k.to_sym, v] }]
+    end
+
+    data.to_yaml(options)
+  end
+end

--- a/manifests/dynflow/pool.pp
+++ b/manifests/dynflow/pool.pp
@@ -23,7 +23,7 @@ define foreman::dynflow::pool (
   String $service_name = $name,
   Integer[0] $instances = $foreman::dynflow_worker_instances,
   Integer[1] $concurrency = $foreman::dynflow_worker_concurrency,
-  Array[String[1], 1] $queues = [],
+  Array[Variant[String[1], Tuple[String, Integer[0]]], 1] $queues = [],
   Optional[String[1]] $config_owner = undef,
   Optional[String[1]] $config_group = undef,
 ) {

--- a/manifests/dynflow/worker.pp
+++ b/manifests/dynflow/worker.pp
@@ -23,7 +23,7 @@ define foreman::dynflow::worker (
   Enum['present', 'absent'] $ensure = 'present',
   String $service_name = $name,
   Integer[1] $concurrency = 1,
-  Array[String[1]] $queues = [],
+  Array[Variant[String[1], Tuple[String, Integer[0]]]] $queues = [],
   String[1] $config_owner = 'root',
   Optional[String[1]] $config_group = undef,
   Stdlib::Filemode $config_mode = '0644',
@@ -32,7 +32,7 @@ define foreman::dynflow::worker (
   $service = "dynflow-sidekiq@${service_name}"
 
   if $ensure == 'present' {
-    assert_type(Array[String[1], 1], $queues)
+    assert_type(Array[Variant[String[1], Tuple[String, Integer[0]]], 1], $queues)
 
     $config = {
       'concurrency' => $concurrency,

--- a/manifests/dynflow/worker.pp
+++ b/manifests/dynflow/worker.pp
@@ -34,12 +34,17 @@ define foreman::dynflow::worker (
   if $ensure == 'present' {
     assert_type(Array[String[1], 1], $queues)
 
+    $config = {
+      'concurrency' => $concurrency,
+      'queues'      => $queues,
+    }
+
     file { $filename:
       ensure  => file,
       owner   => $config_owner,
       group   => pick($config_group, $foreman::group),
       mode    => $config_mode,
-      content => template('foreman/dynflow_worker.yml.erb'),
+      content => foreman::to_symbolized_yaml($config),
     }
     ~> service { $service:
       ensure    => running,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,7 +22,7 @@ class foreman::service(
     }
 
     foreman::dynflow::pool { 'worker':
-      queues      => ['default', 'remote_execution'],
+      queues      => [['default', 1], ['remote_execution', 1]],
       instances   => $dynflow_worker_instances,
       concurrency => $dynflow_worker_concurrency,
     }

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -128,7 +128,7 @@ describe 'foreman' do
           should contain_foreman__dynflow__worker('worker-1')
             .with_ensure('present')
             .with_concurrency(5)
-            .with_queues(['default', 'remote_execution'])
+            .with_queues([['default', 1], ['remote_execution', 1]])
         end
 
         # service

--- a/spec/functions/foreman_to_symbolized_yaml_spec.rb
+++ b/spec/functions/foreman_to_symbolized_yaml_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'foreman::to_symbolized_yaml' do
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should symbolize keys' do
+    is_expected.to run.with_params({'a' => 'b'}).and_return("---\n:a: b\n")
+  end
+end

--- a/templates/dynflow_worker.yml.erb
+++ b/templates/dynflow_worker.yml.erb
@@ -1,5 +1,0 @@
-:concurrency: <%= scope['concurrency'] %>
-:queues:
-<% scope['queues'].each do |queue| -%>
-  - <%= queue %>
-<% end %>


### PR DESCRIPTION
The previous approach worker, but it made sidekiq default worker process all items from the default queue before moving to remote execution queue.  This change adds equal weight to the queues, making sidekiq pick jobs from both.

To achieve this a function is introduced to convert data to YAML. Foreman typically uses symbolized keys in config files. This is hard to achieve with pure Puppet so a Ruby function is used.

Replaces https://github.com/theforeman/puppet-foreman/pull/919