### PR TITLE
Fixes #29780 - Drop Passenger support and target Foreman 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,7 @@ previous stable release.
 
 ### Foreman version compatibility notes
 
-This module targets Foreman 2.0+.
-
-If you're running Foreman instance older than Foreman 2.2 you need to change logging layout parameter from
-`multiline_request_pattern` to `multiline_pattern` due to compatibility.
+This module targets Foreman 2.4+.
 
 ## Types and providers
 

--- a/files/settings-reverse-proxy-headers.yaml
+++ b/files/settings-reverse-proxy-headers.yaml
@@ -1,0 +1,5 @@
+
+# Configure reverse proxy headers
+:ssl_client_dn_env: HTTP_SSL_CLIENT_S_DN
+:ssl_client_verify_env: HTTP_SSL_CLIENT_VERIFY
+:ssl_client_cert_env: HTTP_SSL_CLIENT_CERT

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,11 +35,7 @@ class foreman::config {
     mode  => '0640',
   }
 
-  if $foreman::use_foreman_service {
-    $db_pool = max($foreman::db_pool, $foreman::foreman_service_puma_threads_max)
-  } else {
-    $db_pool = $foreman::db_pool
-  }
+  $db_pool = max($foreman::db_pool, $foreman::foreman_service_puma_threads_max)
 
   file { '/etc/foreman/database.yml':
     owner   => 'root',
@@ -48,24 +44,22 @@ class foreman::config {
     content => template('foreman/database.yml.erb'),
   }
 
-  if $foreman::use_foreman_service {
-    if $foreman::apache {
-      include apache
-    }
+  if $foreman::apache {
+    include apache
+  }
 
-    $listen_stream = regsubst($foreman::foreman_service_bind, 'unix://|tcp://', '')
+  $listen_stream = regsubst($foreman::foreman_service_bind, 'unix://|tcp://', '')
 
-    systemd::dropin_file { 'foreman-socket':
-      filename => 'installer.conf',
-      unit     => "${foreman::foreman_service}.socket",
-      content  => template('foreman/foreman.socket-overrides.erb'),
-    }
+  systemd::dropin_file { 'foreman-socket':
+    filename => 'installer.conf',
+    unit     => "${foreman::foreman_service}.socket",
+    content  => template('foreman/foreman.socket-overrides.erb'),
+  }
 
-    systemd::dropin_file { 'foreman-service':
-      filename => 'installer.conf',
-      unit     => "${foreman::foreman_service}.service",
-      content  => template('foreman/foreman.service-overrides.erb'),
-    }
+  systemd::dropin_file { 'foreman-service':
+    filename => 'installer.conf',
+    unit     => "${foreman::foreman_service}.service",
+    content  => template('foreman/foreman.service-overrides.erb'),
   }
 
   file { $foreman::app_root:
@@ -107,33 +101,28 @@ class foreman::config {
 
   if $foreman::apache  {
     class { 'foreman::config::apache':
-      passenger               => $foreman::passenger,
-      app_root                => $foreman::app_root,
-      passenger_ruby          => $foreman::passenger_ruby,
-      priority                => $foreman::vhost_priority,
-      servername              => $foreman::servername,
-      serveraliases           => $foreman::serveraliases,
-      server_port             => $foreman::server_port,
-      server_ssl_port         => $foreman::server_ssl_port,
-      proxy_backend           => $foreman::foreman_service_bind,
-      ssl                     => $foreman::ssl,
-      ssl_ca                  => $foreman::server_ssl_ca,
-      ssl_chain               => $foreman::server_ssl_chain,
-      ssl_cert                => $foreman::server_ssl_cert,
-      ssl_certs_dir           => $foreman::server_ssl_certs_dir,
-      ssl_key                 => $foreman::server_ssl_key,
-      ssl_crl                 => $foreman::server_ssl_crl,
-      ssl_protocol            => $foreman::server_ssl_protocol,
-      ssl_verify_client       => $foreman::server_ssl_verify_client,
-      user                    => $foreman::user,
-      passenger_prestart      => $foreman::passenger_prestart,
-      passenger_min_instances => $foreman::passenger_min_instances,
-      passenger_start_timeout => $foreman::passenger_start_timeout,
-      foreman_url             => $foreman::foreman_url,
-      ipa_authentication      => $foreman::ipa_authentication,
-      keycloak                => $foreman::keycloak,
-      keycloak_app_name       => $foreman::keycloak_app_name,
-      keycloak_realm          => $foreman::keycloak_realm,
+      app_root           => $foreman::app_root,
+      priority           => $foreman::vhost_priority,
+      servername         => $foreman::servername,
+      serveraliases      => $foreman::serveraliases,
+      server_port        => $foreman::server_port,
+      server_ssl_port    => $foreman::server_ssl_port,
+      proxy_backend      => $foreman::foreman_service_bind,
+      ssl                => $foreman::ssl,
+      ssl_ca             => $foreman::server_ssl_ca,
+      ssl_chain          => $foreman::server_ssl_chain,
+      ssl_cert           => $foreman::server_ssl_cert,
+      ssl_certs_dir      => $foreman::server_ssl_certs_dir,
+      ssl_key            => $foreman::server_ssl_key,
+      ssl_crl            => $foreman::server_ssl_crl,
+      ssl_protocol       => $foreman::server_ssl_protocol,
+      ssl_verify_client  => $foreman::server_ssl_verify_client,
+      user               => $foreman::user,
+      foreman_url        => $foreman::foreman_url,
+      ipa_authentication => $foreman::ipa_authentication,
+      keycloak           => $foreman::keycloak,
+      keycloak_app_name  => $foreman::keycloak_app_name,
+      keycloak_realm     => $foreman::keycloak_realm,
     }
 
     contain foreman::config::apache

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -306,12 +306,6 @@ class foreman (
     timeout => 0,
   }
 
-  if $apache {
-    $foreman_service_bind = 'unix:///run/foreman.sock'
-  } else {
-    $foreman_service_bind = 'tcp://0.0.0.0:3000'
-  }
-
   include foreman::install
   include foreman::config
   include foreman::database

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,17 +11,15 @@ class foreman::install {
     }
   }
 
-  if $foreman::apache and $foreman::passenger and $foreman::passenger_ruby_package {
+  # Foreman 2.5 dropped support for Passenger. On EL7 there was a native package built for SCL that should be absent.
+  if $foreman::passenger_ruby_package {
     package { $foreman::passenger_ruby_package:
-      ensure => installed,
-      before => Class['apache::service'],
+      ensure => absent,
     }
   }
 
-  if $foreman::use_foreman_service {
-    package { 'foreman-service':
-      ensure => installed,
-    }
+  package { 'foreman-service':
+    ensure => installed,
   }
 
   if $foreman::dynflow_manage_services {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,18 +11,12 @@ class foreman::params {
   $unattended_url = undef
   # configure foreman via apache
   $apache         = true
-  # configure apache with passenger
-  $passenger      = false
   # Server name of the VirtualHost
   $servername     = $facts['networking']['fqdn']
   # Server aliases of the VirtualHost
   $serveraliases  = [ 'foreman' ]
   # force SSL (note: requires apache)
   $ssl            = true
-  # further passenger parameters
-  $passenger_prestart = true
-  $passenger_min_instances = 1
-  $passenger_start_timeout = 90
 
   # Advanced configuration
   $app_root          = '/usr/share/foreman'
@@ -94,19 +88,16 @@ class foreman::params {
     'RedHat': {
       # We use system packages except on EL7
       if versioncmp($facts['os']['release']['major'], '8') >= 0 {
-        $passenger_ruby = undef
         $passenger_ruby_package = undef
         $plugin_prefix = 'rubygem-foreman_'
         $configure_scl_repo = false
       } else {
-        $passenger_ruby = '/usr/bin/tfm-ruby'
         $passenger_ruby_package = 'tfm-rubygem-passenger-native'
         $plugin_prefix = 'tfm-rubygem-foreman_'
         $configure_scl_repo = true
       }
     }
     'Debian': {
-      $passenger_ruby = '/usr/bin/foreman-ruby'
       $passenger_ruby_package = undef
       $plugin_prefix = 'ruby-foreman-'
       $configure_scl_repo = false
@@ -114,8 +105,6 @@ class foreman::params {
     'Linux': {
       case $facts['os']['name'] {
         'Amazon': {
-          # add passenger::install::scl as EL uses SCL on Foreman 1.2+
-          $passenger_ruby = '/usr/bin/tfm-ruby'
           $passenger_ruby_package = 'tfm-rubygem-passenger-native'
           $plugin_prefix = 'tfm-rubygem-foreman_'
           $configure_scl_repo = true
@@ -144,7 +133,7 @@ class foreman::params {
 
   $vhost_priority = '05'
 
-  # Set these values if you want Passenger to serve a CA-provided cert instead of puppet's
+  # Set these values if you want Apache to serve a CA-provided cert instead of puppet's
   $server_ssl_ca    = "${puppet_ssldir}/certs/ca.pem"
   $server_ssl_chain = "${puppet_ssldir}/certs/ca.pem"
   $server_ssl_cert  = "${puppet_ssldir}/certs/${lower_fqdn}.pem"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,10 +2,7 @@
 # @api private
 class foreman::service(
   Boolean $apache = $foreman::apache,
-  Boolean $passenger = $foreman::passenger,
-  Stdlib::Absolutepath $app_root = $foreman::app_root,
   Boolean $ssl = $foreman::ssl,
-  Boolean $use_foreman_service = $foreman::use_foreman_service,
   String $foreman_service = $foreman::foreman_service,
   Stdlib::Ensure::Service $foreman_service_ensure = $foreman::foreman_service_ensure,
   Boolean $foreman_service_enable = $foreman::foreman_service_enable,
@@ -29,15 +26,6 @@ class foreman::service(
   }
 
   if $apache {
-    if $passenger {
-      exec {'restart_foreman':
-        command     => "/bin/touch ${app_root}/tmp/restart.txt",
-        refreshonly => true,
-        cwd         => $app_root,
-        path        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
-    }
-
     Class['apache::service'] -> Class['foreman::service']
 
     # Ensure SSL certs from the puppetmaster are available
@@ -47,16 +35,14 @@ class foreman::service(
     }
   }
 
-  if $use_foreman_service {
-    service { "${foreman_service}.socket":
-      ensure => $foreman_service_ensure,
-      enable => $foreman_service_enable,
-    }
+  service { "${foreman_service}.socket":
+    ensure => $foreman_service_ensure,
+    enable => $foreman_service_enable,
+  }
 
-    service { $foreman_service:
-      ensure  => $foreman_service_ensure,
-      enable  => $foreman_service_enable,
-      require => Service["${foreman_service}.socket"],
-    }
+  service { $foreman_service:
+    ensure  => $foreman_service_ensure,
+    enable  => $foreman_service_enable,
+    require => Service["${foreman_service}.socket"],
   }
 }

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -2,7 +2,6 @@
 User=<%= scope['foreman::user'] %>
 Environment=FOREMAN_ENV=<%= scope['foreman::rails_env'] %>
 Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
-Environment=FOREMAN_BIND=<%= scope['foreman::foreman_service_bind'] %>
 Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::foreman_service_puma_threads_min'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
 Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::foreman_service_puma_workers'] %>

--- a/templates/foreman.socket-overrides.erb
+++ b/templates/foreman.socket-overrides.erb
@@ -1,7 +1,5 @@
 [Socket]
 ListenStream=
-ListenStream=<%= @listen_stream %>
-<% if scope['foreman::apache'] -%>
+ListenStream=<%= @listen_socket %>
 SocketUser=<%= scope['apache::user'] %>
 SocketMode=0600
-<% end -%>

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -98,10 +98,3 @@
     :namespace: foreman
 <%   end -%>
 <% end -%>
-<% if scope.lookupvar("foreman::apache") && !scope.lookupvar("foreman::passenger") -%>
-
-# Configure reverse proxy headers
-:ssl_client_dn_env: HTTP_SSL_CLIENT_S_DN
-:ssl_client_verify_env: HTTP_SSL_CLIENT_VERIFY
-:ssl_client_cert_env: HTTP_SSL_CLIENT_CERT
-<% end -%>


### PR DESCRIPTION
With Foreman 2.5, support to run with Passenger (technically mod_passenger) is dropped in favor of using Puma with a reverse proxy.

This also moves the request headers part of settings.yaml to a concat fragment to simplify some code.

It keeps in code to remove tfm-rubygem-passenger-native on EL7 which it previously didn't do, but is nice to do. It doesn't remove mod_passenger itself since that's not managed in this module.