### PR TITLE
Only run apipie:cache:index for plugin with an API

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -35,6 +35,6 @@ class foreman::database(
     ~> foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
     }
-    ~> Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache']
+    ~> Foreman::Rake['apipie_dsl:cache']
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -315,10 +315,6 @@ class foreman (
     $db_sslmode_real = $db_sslmode
   }
 
-  foreman::rake { 'apipie:cache:index':
-    timeout => 0,
-  }
-
   foreman::rake { 'apipie_dsl:cache':
     timeout => 0,
   }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -7,7 +7,7 @@
 #   The package to manage
 #
 # @param config
-#   Content of the configg
+#   Content of the config
 #
 # @param config_file
 #   The path to the config file. Only relevant if `config` is given.
@@ -20,7 +20,7 @@
 #
 # @param config_file_group
 #   The mode of the config file. Only relevant if `config` is given.
-define foreman::plugin(
+define foreman::plugin (
   String[1] $version = $foreman::plugin_version,
   String[1] $package = "${foreman::plugin_prefix}${title}",
   Stdlib::Absolutepath $config_file = "${foreman::plugin_config_dir}/foreman_${title}.yaml",

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -4,5 +4,6 @@
 #
 class foreman::plugin::discovery {
   foreman::plugin {'discovery':
+    has_api => true,
   }
 }

--- a/manifests/rake/apipie.pp
+++ b/manifests/rake/apipie.pp
@@ -1,0 +1,9 @@
+# @summary a rake task to ensure a correct apipie cache
+# @api private
+class foreman::rake::apipie {
+  foreman::rake { 'apipie:cache:index':
+    timeout => 0,
+    require => Class['foreman::config'],
+    before  => Class['foreman::database'],
+  }
+}


### PR DESCRIPTION
This is the result of a discussion on IRC with @tbrisker and @ofedoren. Right now it's not clear if this is the right thing, but this captures the general thought.

The idea is that the apipie cache index only needs to be regenerated if a plugin with an API is installed. This saves time on installation.

It also turns out that the DB does not need to be present and will actually prevent warnings about this during db:migrate. Not triggering it after that also makes it much faster.

One thing where this will now introduce a regression is that it no longer (reliably) regenerates the cache on upgrades since no refresh events are triggered. The ideal solution is to stop relying on refreshes and instead have an unless statement that determines if it's really needed.