### PR TITLE
Mark compatible with puppetlabs/postgresql 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.5.0 < 7.0.0"
+      "version_requirement": ">= 6.5.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
The major version bump was due to dropping Puppet 5 support.