### PR TITLE
Remove old email.yaml and cronjob cleanups

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,11 +48,6 @@ class foreman::config {
     content => template('foreman/database.yml.erb'),
   }
 
-  # email.yaml support has been removed in 1.16.
-  file { '/etc/foreman/email.yaml':
-    ensure => absent,
-  }
-
   if $foreman::use_foreman_service {
     if $foreman::apache {
       include apache
@@ -108,12 +103,6 @@ class foreman::config {
       gid     => $foreman::group,
       groups  => $foreman::user_groups,
     }
-  }
-
-  # remove crons previously installed here, they've moved to the package's
-  # cron.d file
-  cron { ['clear_session_table', 'expire_old_reports', 'daily summary']:
-    ensure  => absent,
   }
 
   if $foreman::apache  {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,7 +179,7 @@
 #
 # $hsts_enabled::                 Should HSTS enforcement in https requests be enabled
 #
-# $cors_domains::                 List of domains that show be allowed for Cross-Origin Resource Sharing. This requires Foreman 1.22+
+# $cors_domains::                 List of domains that show be allowed for Cross-Origin Resource Sharing
 #
 # $foreman_service_puma_threads_min::     Minimum number of threads for Puma. Relevant only when Puma service is used and ignored when Passenger is used.
 #

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -72,12 +72,7 @@ describe 'foreman' do
           )
         }
 
-        it 'should remove old crons' do
-          should contain_cron('clear_session_table').with_ensure('absent')
-          should contain_cron('expire_old_reports').with_ensure('absent')
-          should contain_cron('daily summary').with_ensure('absent')
-        end
-
+        # apache
         it 'should contain foreman::config::apache' do
           passenger_ruby = if facts[:osfamily] == 'RedHat' && facts[:os]['release']['major'] == '7'
                              '/usr/bin/tfm-ruby'
@@ -392,7 +387,6 @@ describe 'foreman' do
       context 'with email configured for SMTP' do
         let(:params) { super().merge(email_delivery_method: 'smtp') }
 
-        it { should contain_file('/etc/foreman/email.yaml').with_ensure('absent') }
         it { should contain_foreman_config_entry('delivery_method').with_value('smtp') }
         it { should contain_foreman_config_entry('smtp_authentication').with_value('') }
 
@@ -404,7 +398,6 @@ describe 'foreman' do
 
       describe 'with email configured for sendmail' do
         let(:params) { super().merge(email_delivery_method: 'sendmail') }
-        it { should contain_file('/etc/foreman/email.yaml').with_ensure('absent') }
         it { should contain_foreman_config_entry('delivery_method').with_value('sendmail') }
 
         describe 'with sample parameters' do


### PR DESCRIPTION
This removes cleanup of email.yaml introduced in e6ead4595d3008040e56a55cc40a424ee5cb87d7. It also removes cleanup of crons introduced in 14fce641b88c189e06596262d0ce99f859336fe1. Both of them should be deployed long enough that we can assume they're gone.