### PR TITLE
Bump major version to 17.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "theforeman-foreman",
-  "version": "16.1.0",
+  "version": "17.0.0",
   "author": "theforeman",
   "summary": "Foreman server configuration",
   "license": "GPL-3.0+",


### PR DESCRIPTION
67f78b9b45d1b5b8118b6575bf1902056d1978d0 changed the API and is thus a major version.