### PR TITLE
Fixes #29649 - Drop default_server argument in IPA

### DIFF
--- a/lib/facter/sssd.rb
+++ b/lib/facter/sssd.rb
@@ -1,19 +1,6 @@
 require 'facter/util/sssd'
 
 if defined? Facter::Util::Sssd
-  # == Fact: foreman_ipa
-  Facter.add(:foreman_ipa, :type => :aggregate) do
-    {
-      :default_realm => 'global/realm',
-      :default_server => 'global/server',
-    }.each do |key, path|
-      chunk(key) do
-        val = Facter::Util::Sssd.ipa_value(path)
-        {key => val} if val
-      end
-    end
-  end
-
   # == Fact: foreman_sssd
   Facter.add(:foreman_sssd, :type => :aggregate) do
     {

--- a/lib/facter/util/sssd.rb
+++ b/lib/facter/util/sssd.rb
@@ -11,10 +11,6 @@ begin
       end
     end
 
-    def self.ipa_value(path)
-      aug_value('Puppet.lns', '/etc/ipa/default.conf', path)
-    end
-
     def self.sssd_value(path)
       val = aug_value('Sssd.lns', '/etc/sssd/sssd.conf', path)
       val.split(',').map(&:strip) if val

--- a/spec/classes/foreman_config_ipa_spec.rb
+++ b/spec/classes/foreman_config_ipa_spec.rb
@@ -16,23 +16,9 @@ describe 'foreman' do
       context 'with apache' do
         let(:params) { super().merge(apache: true) }
 
-        describe 'not IPA-enrolled system' do
-          describe 'ipa_server fact missing' do
-            it { should raise_error(Puppet::Error, /The system does not seem to be IPA-enrolled/) }
-          end
-
-          describe 'default_ipa_realm fact missing' do
-            it { should raise_error(Puppet::Error, /The system does not seem to be IPA-enrolled/) }
-          end
-        end
-
         describe 'enrolled system' do
           let(:facts) do
             super().merge(
-              foreman_ipa: {
-                default_server: 'ipa.example.com',
-                default_realm: 'REALM'
-              },
               foreman_sssd: {
                 services: ['ifp']
               }


### PR DESCRIPTION
ipa-getkeytab can figure out the default server on its own[1]. There is no need to specify it and can even break things. For example, DNS can be used to detect servers. Then the fact is empty and it fails while the command would actually pass.

The fact is simplified since it's a major version bump anyway and nothing else should use our foreman_ipa fact.

[1] https://github.com/theforeman/puppet-foreman/pull/880#issuecomment-683902223

Replaces https://github.com/theforeman/puppet-foreman/pull/880