### PR TITLE
Refs #32276: Add Katello hammer plugin

### DIFF
--- a/manifests/cli/katello.pp
+++ b/manifests/cli/katello.pp
@@ -1,0 +1,10 @@
+# = Hammer Katello plugin
+#
+# This installs the Katello plugin for Hammer CLI
+#
+# === Parameters:
+#
+class foreman::cli::katello {
+  foreman::cli::plugin { 'katello':
+  }
+}

--- a/spec/classes/cli_plugins_spec.rb
+++ b/spec/classes/cli_plugins_spec.rb
@@ -2,13 +2,22 @@ require 'spec_helper'
 
 supported = on_supported_os
 
-['ansible', 'azure', 'discovery', 'kubevirt', 'openscap', 'remote_execution', 'tasks', 'templates', 'virt_who_configure'].each do |plugin|
+['ansible', 'azure', 'discovery', 'katello', 'kubevirt', 'openscap', 'remote_execution', 'tasks', 'templates', 'virt_who_configure'].each do |plugin|
   describe "foreman::cli::#{plugin}" do
     supported.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) { os_facts }
         let(:pre_condition) { 'include foreman::cli' }
-        let(:plugin_name) { plugin == 'azure' ? 'foreman_azure_rm' : "foreman_#{plugin}" }
+        let(:plugin_name) do
+          case plugin
+          when 'azure'
+            'foreman_azure_rm'
+          when 'katello'
+            'katello'
+          else
+            "foreman_#{plugin}"
+          end
+        end
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_foreman__cli__plugin(plugin_name) }


### PR DESCRIPTION
Adding this here will allow adding to the foreman-installer similar to all other plugin hammer packages and then allows being able to drop these requirements from the katello meta RPM (https://github.com/theforeman/foreman-packaging/blob/rpm/develop/packages/katello/katello/katello.spec#L34-L36).