### PR TITLE
Refs #32885: Add puppet user to user_groups only if server or client certificate contains puppet path

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -74,6 +74,12 @@ class foreman::config {
   }
 
   if $foreman::manage_user {
+    if $foreman::puppet_ssldir in $foreman::server_ssl_key or $foreman::puppet_ssldir in $foreman::client_ssl_key {
+      $_user_groups = $foreman::user_groups + ['puppet']
+    } else {
+      $_user_groups = $foreman::user_groups
+    }
+
     group { $foreman::group:
       ensure => 'present',
     }
@@ -83,7 +89,7 @@ class foreman::config {
       comment => 'Foreman',
       home    => $foreman::app_root,
       gid     => $foreman::group,
-      groups  => $foreman::user_groups,
+      groups  => unique($_user_groups),
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class foreman::params {
   $manage_user       = true
   $user              = 'foreman'
   $group             = 'foreman'
-  $user_groups       = ['puppet']
+  $user_groups       = []
   $rails_env         = 'production'
   $version           = 'present'
   $plugin_version    = 'present'

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -5,4 +5,6 @@ foreman::server_ssl_cert: /etc/foreman-certs/certificate.pem
 foreman::server_ssl_chain: /etc/foreman-certs/certificate.pem
 foreman::server_ssl_crl: ""
 foreman::server_ssl_key: /etc/foreman-certs/key.pem
-foreman::user_groups: []
+foreman::client_ssl_ca: /etc/foreman-certs/certificate.pem
+foreman::client_ssl_cert: /etc/foreman-certs/certificate.pem
+foreman::client_ssl_key: /etc/foreman-certs/key.pem

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -409,6 +409,19 @@ describe 'foreman' do
           it { should_not contain_class('redis::instance') }
         end
       end
+
+      describe 'with non-Puppet SSL certificates' do
+        let(:params) do
+          super().merge(
+            server_ssl_key: '/etc/pki/localhost.key',
+            server_ssl_cert: '/etc/pki/localhost.crt',
+            client_ssl_key: '/etc/pki/localhost.key',
+            client_ssl_cert: '/etc/pki/localhost.crt',
+          )
+        end
+
+        it { should contain_user('foreman').with('groups' => []) }
+      end
     end
   end
 end


### PR DESCRIPTION
Looking for feedback here as I don't know what the exact correct answer is to prevent the following error when setting `puppet::server` to false:

```
2021-04-15 20:08:58 [ERROR ] [configure] Could not set groups on user[foreman]: Execution of '/sbin/usermod -G puppet foreman' returned 6: usermod: group 'puppet' does not exist
2021-04-15 20:08:58 [ERROR ] [configure] /Stage[main]/Foreman::Config/User[foreman]/groups: change from  to 'puppet' failed: Could not set groups on user[foreman]: Execution of '/sbin/usermod -G puppet foreman' returned 6: usermod: group 'puppet' does not exist
```

It feels like a user of the module should not have to explicitly configure the `user_groups` if they are setting `puppet::server` to false and that the module should adjust appropriately.

The puppet-foreman_proxy seems to have a similar failure but different approach: https://github.com/theforeman/puppet-foreman_proxy/blob/941e934a4a27a40e7963bc59f6ab5c14fafb82dc/manifests/config.pp#L33