### PR TITLE
Customisable Yum repository base URL and GPG key path

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -13,17 +13,21 @@
 # @param scl_repo_ensure
 #   The ensure to set on the SCL repo package
 #
+# @param yum_repo_baseurl
+#   The base URL for Yum repositories
 class foreman::repo(
   Optional[Variant[Enum['nightly'], Pattern['^\d+\.\d+$']]] $repo = undef,
   Boolean $gpgcheck = true,
   Boolean $configure_scl_repo = $facts['os']['name'] == 'CentOS' and $facts['os']['release']['major'] == '7',
   String $scl_repo_ensure = 'installed',
+  Stdlib::HTTPUrl $yum_repo_baseurl = 'https://yum.theforeman.org',
 ) {
   if $repo {
     foreman::repos { 'foreman':
-      repo     => $repo,
-      gpgcheck => $gpgcheck,
-      before   => Anchor['foreman::repo'],
+      repo             => $repo,
+      gpgcheck         => $gpgcheck,
+      yum_repo_baseurl => $yum_repo_baseurl,
+      before           => Anchor['foreman::repo'],
     }
 
     if $configure_scl_repo {

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,6 +1,7 @@
 # @summary Set up a repository for foreman
 # @api private
 define foreman::repos(
+  Stdlib::HTTPUrl $yum_repo_baseurl,
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
   Boolean $gpgcheck = true,
 ) {
@@ -16,6 +17,7 @@ define foreman::repos(
         repo     => $repo,
         yumcode  => $yumcode,
         gpgcheck => $gpgcheck,
+        baseurl  => $yum_repo_baseurl,
       }
     }
     'Debian': {

--- a/manifests/repos/yum.pp
+++ b/manifests/repos/yum.pp
@@ -5,7 +5,9 @@ define foreman::repos::yum (
   String $yumcode,
   Boolean $gpgcheck,
   Stdlib::HTTPUrl $baseurl,
+  Optional[String] $keypath = undef,
 ) {
+  $_keypath = pick($keypath, "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman")
   $gpgcheck_enabled_default = $gpgcheck ? {
     false   => '0',
     default => '1',
@@ -18,14 +20,14 @@ define foreman::repos::yum (
     descr    => "Foreman ${repo}",
     baseurl  => "${baseurl}/releases/${repo}/${yumcode}/\$basearch",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman",
+    gpgkey   => $_keypath,
     enabled  => '1',
   }
   yumrepo { "${name}-source":
     descr    => "Foreman ${repo} - source",
     baseurl  => "${baseurl}/releases/${repo}/${yumcode}/source",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman",
+    gpgkey   => $_keypath,
     enabled  => '0',
   }
   yumrepo { "${name}-plugins":

--- a/manifests/repos/yum.pp
+++ b/manifests/repos/yum.pp
@@ -4,6 +4,7 @@ define foreman::repos::yum (
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
   String $yumcode,
   Boolean $gpgcheck,
+  Stdlib::HTTPUrl $baseurl,
 ) {
   $gpgcheck_enabled_default = $gpgcheck ? {
     false   => '0',
@@ -15,27 +16,27 @@ define foreman::repos::yum (
   }
   yumrepo { $name:
     descr    => "Foreman ${repo}",
-    baseurl  => "https://yum.theforeman.org/releases/${repo}/${yumcode}/\$basearch",
+    baseurl  => "${baseurl}/releases/${repo}/${yumcode}/\$basearch",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "https://yum.theforeman.org/releases/${repo}/RPM-GPG-KEY-foreman",
+    gpgkey   => "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman",
     enabled  => '1',
   }
   yumrepo { "${name}-source":
     descr    => "Foreman ${repo} - source",
-    baseurl  => "https://yum.theforeman.org/releases/${repo}/${yumcode}/source",
+    baseurl  => "${baseurl}/releases/${repo}/${yumcode}/source",
     gpgcheck => $gpgcheck_enabled,
-    gpgkey   => "https://yum.theforeman.org/releases/${repo}/RPM-GPG-KEY-foreman",
+    gpgkey   => "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman",
     enabled  => '0',
   }
   yumrepo { "${name}-plugins":
     descr    => "Foreman plugins ${repo}",
-    baseurl  => "https://yum.theforeman.org/plugins/${repo}/${yumcode}/\$basearch",
+    baseurl  => "${baseurl}/plugins/${repo}/${yumcode}/\$basearch",
     gpgcheck => '0',
     enabled  => '1',
   }
   yumrepo { "${name}-plugins-source":
     descr    => "Foreman plugins ${repo} - source",
-    baseurl  => "https://yum.theforeman.org/plugins/${repo}/${yumcode}/source",
+    baseurl  => "${baseurl}/plugins/${repo}/${yumcode}/source",
     gpgcheck => '0',
     enabled  => '0',
   }

--- a/spec/classes/foreman_repo_spec.rb
+++ b/spec/classes/foreman_repo_spec.rb
@@ -23,7 +23,11 @@ describe 'foreman::repo' do
         let(:params) { {repo: 'nightly'} }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_foreman__repos('foreman').with_repo('nightly').with_gpgcheck(true) }
+        it { is_expected.to contain_foreman__repos('foreman')
+          .with_repo('nightly')
+          .with_gpgcheck(true)
+          .with_yum_repo_baseurl('https://yum.theforeman.org')
+        }
 
         it do
           if facts[:operatingsystem] == 'CentOS' && facts[:operatingsystemmajrelease] == '7'
@@ -46,7 +50,8 @@ describe 'foreman::repo' do
         let :params do
           {
             repo: '1.19',
-            configure_scl_repo: false
+            configure_scl_repo: false,
+            yum_repo_baseurl: 'https://example.org'
           }
         end
 
@@ -56,6 +61,7 @@ describe 'foreman::repo' do
           is_expected.to contain_foreman__repos('foreman')
             .with_repo('1.19')
             .with_gpgcheck(true)
+            .with_yum_repo_baseurl('https://example.org')
         end
 
         it { is_expected.not_to contain_package('centos-release-scl-rh') }

--- a/spec/defines/foreman_repos_spec.rb
+++ b/spec/defines/foreman_repos_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'foreman::repos' do
   let(:title) { 'foreman' }
   let(:repo) { '1.18' }
-  let(:params) { { repo: repo } }
+  let(:params) { { repo: repo, yum_repo_baseurl: 'http://example.org' } }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
@@ -23,6 +23,7 @@ describe 'foreman::repos' do
             .with_repo(repo)
             .with_yumcode(yumcode)
             .with_gpgcheck(true)
+            .with_baseurl('http://example.org')
         end
       when 'Debian'
         it { is_expected.to contain_foreman__repos__apt('foreman').with_repo(repo) }

--- a/spec/defines/foreman_repos_yum_spec.rb
+++ b/spec/defines/foreman_repos_yum_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'foreman::repos::yum' do
   let(:title) { 'foreman' }
-  let(:params) { { yumcode: 'el7' } }
+  let(:params) { { yumcode: 'el7', baseurl: 'https://yum.theforeman.org' } }
 
   context 'with repo => nightly' do
     let(:params) { super().merge(repo: 'nightly') }
@@ -10,34 +10,38 @@ describe 'foreman::repos::yum' do
     context 'gpgcheck => true' do
       let(:params) { super().merge(gpgcheck: true) }
 
-      it 'should contain repo, plugins and source repo' do
-        should contain_yumrepo('foreman')
-          .with_descr('Foreman nightly')
-          .with_baseurl('https://yum.theforeman.org/releases/nightly/el7/$basearch')
-          .with_gpgcheck('0')
-          .with_gpgkey('https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman')
-          .with_enabled('1')
+      context 'baseurl => custom' do
+        let(:params) { super().merge(baseurl: 'http://example.org') }
 
-        should contain_yumrepo('foreman-source')
-          .with_descr('Foreman nightly - source')
-          .with_baseurl('https://yum.theforeman.org/releases/nightly/el7/source')
-          .with_gpgcheck('0')
-          .with_gpgkey('https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman')
-          .with_enabled('0')
+        it 'should contain repo, plugins and source repo' do
+          should contain_yumrepo('foreman')
+            .with_descr('Foreman nightly')
+            .with_baseurl('http://example.org/releases/nightly/el7/$basearch')
+            .with_gpgcheck('0')
+            .with_gpgkey('http://example.org/releases/nightly/RPM-GPG-KEY-foreman')
+            .with_enabled('1')
 
-        should contain_yumrepo('foreman-plugins')
-          .with_descr('Foreman plugins nightly')
-          .with_baseurl('https://yum.theforeman.org/plugins/nightly/el7/$basearch')
-          .with_gpgcheck('0')
-          .with_enabled('1')
+          should contain_yumrepo('foreman-source')
+            .with_descr('Foreman nightly - source')
+            .with_baseurl('http://example.org/releases/nightly/el7/source')
+            .with_gpgcheck('0')
+            .with_gpgkey('http://example.org/releases/nightly/RPM-GPG-KEY-foreman')
+            .with_enabled('0')
 
-        should contain_yumrepo('foreman-plugins-source')
-          .with_descr('Foreman plugins nightly - source')
-          .with_baseurl('https://yum.theforeman.org/plugins/nightly/el7/source')
-          .with_gpgcheck('0')
-          .with_enabled('0')
+          should contain_yumrepo('foreman-plugins')
+            .with_descr('Foreman plugins nightly')
+            .with_baseurl('http://example.org/plugins/nightly/el7/$basearch')
+            .with_gpgcheck('0')
+            .with_enabled('1')
 
-        should contain_yumrepo('foreman-rails').with_ensure('absent')
+          should contain_yumrepo('foreman-plugins-source')
+            .with_descr('Foreman plugins nightly - source')
+            .with_baseurl('http://example.org/plugins/nightly/el7/source')
+            .with_gpgcheck('0')
+            .with_enabled('0')
+
+          should contain_yumrepo('foreman-rails').with_ensure('absent')
+        end
       end
     end
 

--- a/spec/defines/foreman_repos_yum_spec.rb
+++ b/spec/defines/foreman_repos_yum_spec.rb
@@ -42,6 +42,20 @@ describe 'foreman::repos::yum' do
 
           should contain_yumrepo('foreman-rails').with_ensure('absent')
         end
+
+        context 'keypath => custom' do
+          let(:params) { super().merge(keypath: 'http://examplekeys.org/GPG-KEY') }
+
+          it 'should contain repo and source with custom GPG key path and same baseurl' do
+            should contain_yumrepo('foreman')
+              .with_baseurl('http://example.org/releases/nightly/el7/$basearch')
+              .with_gpgkey('http://examplekeys.org/GPG-KEY')
+
+            should contain_yumrepo('foreman-source')
+              .with_baseurl('http://example.org/releases/nightly/el7/source')
+              .with_gpgkey('http://examplekeys.org/GPG-KEY')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This patch adds two parameters:
1) `foreman::repo::yum_repo_baseurl` allowing to configure the prefix of the Yum repositories URL. This permits users having mirrors of `http://yum.theforeman.org` to use this module, for instance by setting the variable to `https://enterprise/internal/mirrors/yum.theforeman.org`.

The parameter's interface is pulled up to the public class and passed down to `foreman::repos::yum` via `foreman::repos`. The name might be ambiguous as the value is ultimately used as a component of a `Yumrepo`'s `baseurl`. Happy to give it a better name.

2) `foreman::repos::yum::keypath` allowing to completely customise the location of the GPG public key used to verify the signatures of the packages in the Yum repositories configured by the module. If not set the value before this patch is respected.

In this case I decided not to expose the parameter in the public interface to avoid cluttering the patch and also because perhaps this is something that few people will use. I'd be happy though to move it to `foreman::repo`, the same way as 1) if necessary.

Fixes #942 