### PR TITLE
Make database.yml and settings.yaml have consistent headers

### DIFF
--- a/templates/database.yml.erb
+++ b/templates/database.yml.erb
@@ -1,4 +1,7 @@
-<%= ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file)))).result(binding) -%>
+<% @header = ''
+   ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file))), nil, nil, "@header").result(binding) -%>
+---
+<%= @header -%>
 
 <%
   host     = scope.lookupvar("::foreman::db_host")

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -1,7 +1,7 @@
 <% @header = ''
    ERB.new(File.read(File.expand_path("_header.erb",File.dirname(file))), nil, nil, "@header").result(binding) -%>
 ---
-<%= @header %>
+<%= @header -%>
 
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
 <% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::unattended_url")) -%>


### PR DESCRIPTION
This brings the two files in sync with how they include the
_header.erb subtemplate.

Now, you might look at this and think, "what a silly commit."  Possibly, but, I've been having this issue where `database.yml` will have two _header.erb instances if `puppet agent` runs things, and only one _header.erb if I do a `puppet apply`.  `settings.yaml` doesn't do this, it always has one copy of the header.  Of course, if `database.yml` changes, that triggers all sorts of rakes and refreshes, which makes it so I can't tell if the prospective changes I'm testing with 'agent' are noisy or fine.

I then added the triple dash to open the yaml file, since it wasn't there on database.yml.

And I also added a `-` to remove a newline in `settings.yaml`, because otherwise it has a double newline after its header, and if I'm in here talking about consistency I may as well do that too.

Thanks for looking.