### PR TITLE
Support setting the priority of the Yum repositories

### DIFF
--- a/manifests/repos/yum.pp
+++ b/manifests/repos/yum.pp
@@ -6,6 +6,7 @@ define foreman::repos::yum (
   Boolean $gpgcheck,
   Stdlib::HTTPUrl $baseurl,
   Optional[String] $keypath = undef,
+  Variant[Integer[0, 99], Enum['absent']] $priority = 'absent',
 ) {
   $_keypath = pick($keypath, "${baseurl}/releases/${repo}/RPM-GPG-KEY-foreman")
   $gpgcheck_enabled_default = $gpgcheck ? {
@@ -22,6 +23,7 @@ define foreman::repos::yum (
     gpgcheck => $gpgcheck_enabled,
     gpgkey   => $_keypath,
     enabled  => '1',
+    priority => $priority,
   }
   yumrepo { "${name}-source":
     descr    => "Foreman ${repo} - source",
@@ -29,18 +31,21 @@ define foreman::repos::yum (
     gpgcheck => $gpgcheck_enabled,
     gpgkey   => $_keypath,
     enabled  => '0',
+    priority => $priority,
   }
   yumrepo { "${name}-plugins":
     descr    => "Foreman plugins ${repo}",
     baseurl  => "${baseurl}/plugins/${repo}/${yumcode}/\$basearch",
     gpgcheck => '0',
     enabled  => '1',
+    priority => $priority,
   }
   yumrepo { "${name}-plugins-source":
     descr    => "Foreman plugins ${repo} - source",
     baseurl  => "${baseurl}/plugins/${repo}/${yumcode}/source",
     gpgcheck => '0',
     enabled  => '0',
+    priority => $priority,
   }
   # Foreman 2.0 dropped the separate rails repository
   yumrepo { "${name}-rails":

--- a/spec/defines/foreman_repos_yum_spec.rb
+++ b/spec/defines/foreman_repos_yum_spec.rb
@@ -20,6 +20,7 @@ describe 'foreman::repos::yum' do
             .with_gpgcheck('0')
             .with_gpgkey('http://example.org/releases/nightly/RPM-GPG-KEY-foreman')
             .with_enabled('1')
+            .with_priority('absent')
 
           should contain_yumrepo('foreman-source')
             .with_descr('Foreman nightly - source')
@@ -27,18 +28,21 @@ describe 'foreman::repos::yum' do
             .with_gpgcheck('0')
             .with_gpgkey('http://example.org/releases/nightly/RPM-GPG-KEY-foreman')
             .with_enabled('0')
+            .with_priority('absent')
 
           should contain_yumrepo('foreman-plugins')
             .with_descr('Foreman plugins nightly')
             .with_baseurl('http://example.org/plugins/nightly/el7/$basearch')
             .with_gpgcheck('0')
             .with_enabled('1')
+            .with_priority('absent')
 
           should contain_yumrepo('foreman-plugins-source')
             .with_descr('Foreman plugins nightly - source')
             .with_baseurl('http://example.org/plugins/nightly/el7/source')
             .with_gpgcheck('0')
             .with_enabled('0')
+            .with_priority('absent')
 
           should contain_yumrepo('foreman-rails').with_ensure('absent')
         end
@@ -57,6 +61,23 @@ describe 'foreman::repos::yum' do
           end
         end
       end
+
+      context 'priority => 10' do
+        let(:params) { super().merge(priority: 10) }
+        it 'should contain repo, plugins and source with correct priority' do
+          should contain_yumrepo('foreman')
+            .with_priority(10)
+
+          should contain_yumrepo('foreman-source')
+            .with_priority(10)
+
+          should contain_yumrepo('foreman-plugins')
+            .with_priority(10)
+
+          should contain_yumrepo('foreman-plugins-source')
+            .with_priority(10)
+        end
+      end
     end
 
     context 'gpgcheck => false' do
@@ -69,6 +90,7 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('0')
           .with_gpgkey('https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-source')
           .with_descr('Foreman nightly - source')
@@ -76,18 +98,21 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('0')
           .with_gpgkey('https://yum.theforeman.org/releases/nightly/RPM-GPG-KEY-foreman')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins')
           .with_descr('Foreman plugins nightly')
           .with_baseurl('https://yum.theforeman.org/plugins/nightly/el7/$basearch')
           .with_gpgcheck('0')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins-source')
           .with_descr('Foreman plugins nightly - source')
           .with_baseurl('https://yum.theforeman.org/plugins/nightly/el7/source')
           .with_gpgcheck('0')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-rails').with_ensure('absent')
       end
@@ -107,6 +132,7 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('1')
           .with_gpgkey('https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-source')
           .with_descr('Foreman 1.19 - source')
@@ -114,18 +140,21 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('1')
           .with_gpgkey('https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins')
           .with_descr('Foreman plugins 1.19')
           .with_baseurl('https://yum.theforeman.org/plugins/1.19/el7/$basearch')
           .with_gpgcheck('0')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins-source')
           .with_descr('Foreman plugins 1.19 - source')
           .with_baseurl('https://yum.theforeman.org/plugins/1.19/el7/source')
           .with_gpgcheck('0')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-rails').with_ensure('absent')
       end
@@ -141,6 +170,7 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('0')
           .with_gpgkey('https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-source')
           .with_descr('Foreman 1.19 - source')
@@ -148,18 +178,21 @@ describe 'foreman::repos::yum' do
           .with_gpgcheck('0')
           .with_gpgkey('https://yum.theforeman.org/releases/1.19/RPM-GPG-KEY-foreman')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins')
           .with_descr('Foreman plugins 1.19')
           .with_baseurl('https://yum.theforeman.org/plugins/1.19/el7/$basearch')
           .with_gpgcheck('0')
           .with_enabled('1')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-plugins-source')
           .with_descr('Foreman plugins 1.19 - source')
           .with_baseurl('https://yum.theforeman.org/plugins/1.19/el7/source')
           .with_gpgcheck('0')
           .with_enabled('0')
+          .with_priority('absent')
 
         should contain_yumrepo('foreman-rails').with_ensure('absent')
       end


### PR DESCRIPTION
This patchset adds a new parameter to the defined type `foreman::repos::yum` to allow setting a custom priority for the Yum repositories by doing something like:

```puppet
  Foreman::Repos::Yum {
    priority => 10,
  }
```

Ideally there should be a parameter in the public interface of the module (`foreman::repo`) but, as the usage might be marginal for the time being, perhaps we can live for now with the approach proposed by the patch. As usual, I'd be happy to add a parameter to the public interface if needed.

Fixes #949