### PR TITLE
Allow customising ProxyAddHeaders

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -48,6 +48,10 @@
 # @param user
 #   The user under which the application runs.
 #
+# @param proxy_add_headers
+#   Do not set X-Forwarded-* headers. Useful when having another
+#   balancing layer in front of this Apache instance.
+#
 # @param proxy_backend
 #   The backend service to proxy to
 #
@@ -93,6 +97,7 @@ class foreman::config::apache(
   Stdlib::Port $server_port = 80,
   Stdlib::Port $server_ssl_port = 443,
   Pattern['^(https?|unix)://'] $proxy_backend = 'unix:///run/foreman.sock',
+  Boolean $proxy_add_headers = true,
   Hash $proxy_params = {'retry' => '0'},
   Array[String] $proxy_no_proxy_uris = ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
   Boolean $ssl = false,
@@ -174,7 +179,7 @@ class foreman::config::apache(
 
   $vhost_http_internal_options = {
     'proxy_preserve_host' => true,
-    'proxy_add_headers'   => true,
+    'proxy_add_headers'   => $proxy_add_headers,
     'request_headers'     => $vhost_http_request_headers,
     'proxy_pass'          => {
       'no_proxy_uris' => $proxy_no_proxy_uris,

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -245,6 +245,17 @@ describe 'foreman::config::apache' do
               ])
           }
         end
+
+        describe 'with proxy_add_headers to false' do
+          let(:params) { super().merge(proxy_add_headers: false) }
+
+          it 'all vhosts must have the setting' do
+            should contain_apache__vhost('foreman')
+              .with_proxy_add_headers(false)
+            should contain_apache__vhost('foreman-ssl')
+              .with_proxy_add_headers(false)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When the Apache instance configured by this module is not dealing with user requests directly because there's another proxy in front, it's undesirable that the "local" Apache resets headers like X-Forwarded-Host. When it does, it could happen that links created using Rails _url helpers do not contain the Host initially sent by the client leading to broken links (as they point to backend nodes not reachable by the user).

This patch makes this setting customisable by the administrator by exposing it a parameter.

Fixes #952