### PR TITLE
Fixes #32827 - Add sendmail config options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@
 #
 # $email_delivery_method::        Email delivery method
 #
+# $email_sendmail_location::      The location of the binary to call when sendmail is the delivery method. Unused when SMTP delivery is used.
+#
+# $email_sendmail_arguments::     The arguments to pass to the sendmail binary. Unused when SMTP delivery is used.
+#
 # $email_smtp_address::           SMTP server hostname, when delivery method is SMTP
 #
 # $email_smtp_port::              SMTP port
@@ -264,6 +268,8 @@ class foreman (
   Enum['pattern', 'multiline_pattern', 'multiline_request_pattern', 'json'] $logging_layout = $foreman::params::logging_layout,
   Hash[String, Boolean] $loggers = $foreman::params::loggers,
   Optional[Enum['sendmail', 'smtp']] $email_delivery_method = $foreman::params::email_delivery_method,
+  Optional[Stdlib::Absolutepath] $email_sendmail_location = $foreman::params::email_sendmail_location,
+  Optional[String[1]] $email_sendmail_arguments = $foreman::params::email_sendmail_arguments,
   Optional[Stdlib::Host] $email_smtp_address = $foreman::params::email_smtp_address,
   Stdlib::Port $email_smtp_port = $foreman::params::email_smtp_port,
   Optional[Stdlib::Fqdn] $email_smtp_domain = $foreman::params::email_smtp_domain,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,8 @@ class foreman::params {
 
   # Configure foreman email settings (database or email.yaml)
   $email_delivery_method     = undef
+  $email_sendmail_location   = undef
+  $email_sendmail_arguments  = undef
   $email_smtp_address        = undef
   $email_smtp_port           = 25
   $email_smtp_domain         = undef

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -225,6 +225,8 @@ describe 'foreman' do
             logging_level: 'info',
             loggers: {},
             email_delivery_method: 'sendmail',
+            email_sendmail_location: '/usr/bin/mysendmail',
+            email_sendmail_arguments: '--myargument',
             email_smtp_address: 'smtp.example.com',
             email_smtp_port: 25,
             email_smtp_domain: 'example.com',
@@ -247,6 +249,8 @@ describe 'foreman' do
 
         it 'should configure certificates in settings.yaml' do
           is_expected.to contain_concat__fragment('foreman_settings+01-header.yaml')
+            .with_content(%r{^:email_sendmail_location: "/usr/bin/mysendmail"$})
+            .with_content(%r{^:email_sendmail_arguments: "--myargument"$})
             .with_content(%r{^:websockets_ssl_key: /etc/ssl/private/snakeoil-ws\.pem$})
             .with_content(%r{^:websockets_ssl_cert: /etc/ssl/certs/snakeoil-ws\.pem$})
         end

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -71,6 +71,16 @@
     :enabled: <%= scope.lookupvar("foreman::telemetry_logger_enabled") %>
     # logging level as in Logger::LEVEL
     :level: '<%= scope.lookupvar("foreman::telemetry_logger_level") %>'
+<% if scope.lookupvar("foreman::email_sendmail_location") || scope.lookupvar("foreman::email_sendmail_arguments") -%>
+
+# Email settings
+<% if scope.lookupvar("foreman::email_sendmail_location") -%>
+:email_sendmail_location: "<%= scope.lookupvar("foreman::email_sendmail_location") %>"
+<% end -%>
+<% if scope.lookupvar("foreman::email_sendmail_arguments") -%>
+:email_sendmail_arguments: "<%= scope.lookupvar("foreman::email_sendmail_arguments") %>"
+<% end -%>
+<% end -%>
 
 <% if scope.lookupvar("foreman::dynflow_manage_services") -%>
 :dynflow:


### PR DESCRIPTION
As part of CVE-2021-3584 the option email_sendmail_location was limited to just 4 choices. This allows admins to set it via settings.yaml. The idea is that if you can edit settings.yaml, you're already compromised while UI could be less protected.

When a setting is present in settings.yaml, the option becomes read-only in the UI.

If the options are not set, they don't show up in settings.yaml.