### PR TITLE
Autorequire provider in smartproxy type

### DIFF
--- a/lib/puppet/type/foreman_smartproxy.rb
+++ b/lib/puppet/type/foreman_smartproxy.rb
@@ -68,6 +68,10 @@ Puppet::Type.newtype(:foreman_smartproxy) do
     defaultto 500
   end
 
+  autorequire(:anchor) do
+    ['foreman::providers::oauth']
+  end
+
   def refresh
     if @parameters[:ensure].retrieve == :present
       provider.refresh_features! if provider.respond_to?(:refresh_features!)

--- a/manifests/providers.pp
+++ b/manifests/providers.pp
@@ -17,6 +17,7 @@ class foreman::providers(
 ) inherits foreman::providers::params {
   if $oauth {
     ensure_packages([$oauth_package])
-    Anchor <| title == 'foreman::repo' |> -> Package[$oauth_package]
+    anchor { 'foreman::providers::oauth': } # lint:ignore:anchor_resource
+    Anchor <| title == 'foreman::repo' |> -> Package[$oauth_package] -> Anchor['foreman::providers::oauth']
   }
 }

--- a/spec/classes/foreman_providers_spec.rb
+++ b/spec/classes/foreman_providers_spec.rb
@@ -8,7 +8,8 @@ describe 'foreman::providers' do
 
       context 'with defaults' do
         it { should compile.with_all_deps }
-        it { should contain_package(oauth_os) }
+        it { should contain_package(oauth_os).that_comes_before('Anchor[foreman::providers::oauth]') }
+        it { should contain_anchor('foreman::providers::oauth') }
       end
 
       context 'with oauth => false' do
@@ -33,6 +34,13 @@ describe 'foreman::providers' do
 
         it { is_expected.to compile.with_all_deps }
         it { should contain_package(oauth_os).that_comes_before('Class[foreman]') }
+      end
+
+      context 'with foreman_smartproxy' do
+        let(:pre_condition) { "foreman_smartproxy { 'myproxy.example.com': }" }
+
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_package(oauth_os).that_comes_before('Foreman_smartproxy[myproxy.example.com]') }
       end
     end
   end


### PR DESCRIPTION
With this it's sufficient to include foreman::providers where prior to this the caller was responsible for ensuring the correct dependency.