### PR TITLE
Fixes #32947 - Use Apache module variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,7 +133,7 @@
 #
 # $oauth_consumer_secret::        OAuth consumer secret
 #
-# $http_keytab::                  Path to keytab to be used for Kerberos authentication on the WebUI
+# $http_keytab::                  Path to keytab to be used for Kerberos authentication on the WebUI. If left empty, it will be automatically determined.
 #
 # $pam_service::                  PAM service used for host-based access control in IPA
 #
@@ -257,7 +257,7 @@ class foreman (
   Optional[String] $initial_organization = $foreman::params::initial_organization,
   Optional[String] $initial_location = $foreman::params::initial_location,
   Boolean $ipa_authentication = $foreman::params::ipa_authentication,
-  Stdlib::Absolutepath $http_keytab = $foreman::params::http_keytab,
+  Optional[Stdlib::Absolutepath] $http_keytab = $foreman::params::http_keytab,
   String $pam_service = $foreman::params::pam_service,
   Boolean $ipa_manage_sssd = $foreman::params::ipa_manage_sssd,
   Boolean $websockets_encrypt = $foreman::params::websockets_encrypt,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -165,7 +165,7 @@ class foreman::params {
   $initial_location = undef
 
   $ipa_authentication = false
-  $http_keytab = '/etc/httpd/conf/http.keytab'
+  $http_keytab = undef
   $pam_service = 'foreman'
   $ipa_manage_sssd = true
 

--- a/spec/classes/foreman_config_ipa_spec.rb
+++ b/spec/classes/foreman_config_ipa_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper'
 
 describe 'foreman' do
   on_supported_os.each do |os, facts|
-    context "on #{os}", if: facts[:osfamily] == 'RedHat' do
+    context "on #{os}" do
       let(:facts) { facts.merge(interfaces: '') }
       let(:params) { { ipa_authentication: true } }
+
+      keytab_path = facts[:osfamily] == 'RedHat' ? '/etc/httpd/conf/http.keytab' : '/etc/apache2/http.keytab'
 
       describe 'without apache' do
         let(:params) { super().merge(apache: false) }
@@ -50,7 +52,7 @@ describe 'foreman' do
             should contain_foreman__config__apache__fragment('lookup_identity')
 
             should contain_foreman__config__apache__fragment('auth_gssapi')
-              .with_ssl_content(%r{^\s*GssapiCredStore keytab:/etc/httpd/conf/http.keytab$})
+              .with_ssl_content(%r{^\s*GssapiCredStore keytab:#{keytab_path}$})
               .with_ssl_content(/^\s*require pam-account foreman$/)
           end
 

--- a/templates/auth_gssapi.conf.erb
+++ b/templates/auth_gssapi.conf.erb
@@ -3,7 +3,7 @@
   SSLRequireSSL
   AuthType GSSAPI
   AuthName "GSSAPI Single Sign On Login"
-  GssapiCredStore keytab:<%= scope.lookupvar('foreman::http_keytab') %>
+  GssapiCredStore keytab:<%= @http_keytab %>
   GssapiSSLonly On
   GssapiLocalName On
   # require valid-user


### PR DESCRIPTION
Apache is packaged in different locations between Red Hat and Debian. The user differs (apache vs www-data) and conf dir (/etc/httpd vs /etc/apache2). This changes the code to use variables already defined on the apache module to avoid duplicating this logic.