### PR TITLE
Handle duplicate file declaration for foreman::app_root

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,9 +49,11 @@ class foreman::config {
     unit     => "${foreman::foreman_service}.service",
     content  => template('foreman/foreman.service-overrides.erb'),
   }
-
-  file { $foreman::app_root:
-    ensure  => directory,
+  
+  if ! defined(File[$foreman::app_root]) {
+    file { $foreman::app_root:
+      ensure  => directory,
+    }
   }
 
   if $foreman::db_root_cert {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,7 +49,7 @@ class foreman::config {
     unit     => "${foreman::foreman_service}.service",
     content  => template('foreman/foreman.service-overrides.erb'),
   }
-  
+
   if ! defined(File[$foreman::app_root]) {
     file { $foreman::app_root:
       ensure  => directory,


### PR DESCRIPTION
Currently we're using your modul to install and configure Foreman. 
We want to install Foreman in its own filesystem, but the file ressource for $foreman::app_root makes it hard to implement this in puppet - it will always result in duplicate ressource.  Furthermore i'm not sure, if this ressource is necessary or placed in the right class (ordering, first install the package and then create the directory?!).

Testing if this directory is already defined gives other the chance to do some stuff, e.g. creating a filesystem before installing foreman :)