### PR TITLE
Match Foreman user to what packaging creates

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -82,6 +82,7 @@ class foreman::config {
 
     group { $foreman::group:
       ensure => 'present',
+      system => true,
     }
     user { $foreman::user:
       ensure  => 'present',
@@ -90,6 +91,7 @@ class foreman::config {
       home    => $foreman::app_root,
       gid     => $foreman::group,
       groups  => unique($_user_groups),
+      system  => true,
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,7 +86,7 @@ class foreman::config {
     }
     user { $foreman::user:
       ensure  => 'present',
-      shell   => '/bin/false',
+      shell   => $foreman::user_shell,
       comment => 'Foreman',
       home    => $foreman::app_root,
       gid     => $foreman::group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,11 +98,14 @@ class foreman::params {
         $plugin_prefix = 'tfm-rubygem-foreman_'
         $configure_scl_repo = true
       }
+
+      $user_shell = '/sbin/nologin'
     }
     'Debian': {
       $passenger_ruby_package = undef
       $plugin_prefix = 'ruby-foreman-'
       $configure_scl_repo = false
+      $user_shell = '/usr/sbin/nologin'
     }
     'Linux': {
       case $facts['os']['name'] {
@@ -110,6 +113,7 @@ class foreman::params {
           $passenger_ruby_package = 'tfm-rubygem-passenger-native'
           $plugin_prefix = 'tfm-rubygem-foreman_'
           $configure_scl_repo = true
+          $user_shell = '/sbin/nologin'
         }
         default: {
           fail("${facts['networking']['hostname']}: This module does not support operatingsystem ${facts['os']['name']}")

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -62,7 +62,7 @@ describe 'foreman' do
         it {
           should contain_user('foreman').with(
             'ensure' => 'present',
-            'shell' => '/bin/false',
+            'shell' => %r{^(/usr)?/sbin/nologin$},
             'comment' => 'Foreman',
             'gid' => 'foreman',
             'groups' => ['puppet'],


### PR DESCRIPTION
# Match the user shell to packaging

In dcb8a702c68dda775e4c089433039b052e2d86d7 the shell was changed from /sbin/nologin to /bin/false since on Debian it is /usr/sbin/nologin.

Technically we can now always use /usr/sbin/nologin since on EL7 /sbin is a symlink to /usr/sbin, but that doesn't match packaging. Aligning this to packaging means there's one step that no longer needs to happen during installation.

The parameter is not exposed in init.pp since most users won't care about this (in the past 6 years no PR has been submitted to do so).

# Make Foreman a system user and group

This matches what the RPM and Debian packages already do so it should have no effect in reality, but it does align the two.