### PR TITLE
Add Ubuntu 20.04 support & drop Ubuntu 18.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -81,7 +81,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "20.04"
       ]
     }
   ]


### PR DESCRIPTION
Foreman 2.5 introduced support for Ubuntu Focal. This should be reflected here.