### PR TITLE
Fixes #33214: Set minimum Puma threads equal to maximum puma threads …

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,6 +44,7 @@ class foreman::config {
     content => template('foreman/database.yml.erb'),
   }
 
+  $min_puma_threads = pick($foreman::foreman_service_puma_threads_min, $foreman::foreman_service_puma_threads_max)
   systemd::dropin_file { 'foreman-service':
     filename => 'installer.conf',
     unit     => "${foreman::foreman_service}.service",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,7 +160,9 @@
 #
 # $cors_domains::                 List of domains that show be allowed for Cross-Origin Resource Sharing
 #
-# $foreman_service_puma_threads_min::     Minimum number of threads for every Puma worker
+# $foreman_service_puma_threads_min::     Minimum number of threads for every Puma worker. If no value is specified, this defaults
+#                                         to setting min threads to maximum threads. Setting min threads equal to max threads has
+#                                         been shown to alleviate memory leaks and in some cases produce better performance.
 #
 # $foreman_service_puma_threads_max::     Maximum number of threads for every Puma worker
 #
@@ -272,7 +274,7 @@ class foreman (
   Optional[Redis::RedisUrl] $dynflow_redis_url = $foreman::params::dynflow_redis_url,
   Boolean $hsts_enabled = $foreman::params::hsts_enabled,
   Array[Stdlib::HTTPUrl] $cors_domains = $foreman::params::cors_domains,
-  Integer[0] $foreman_service_puma_threads_min = $foreman::params::foreman_service_puma_threads_min,
+  Optional[Integer[0]] $foreman_service_puma_threads_min = $foreman::params::foreman_service_puma_threads_min,
   Integer[0] $foreman_service_puma_threads_max = $foreman::params::foreman_service_puma_threads_max,
   Integer[0] $foreman_service_puma_workers = $foreman::params::foreman_service_puma_workers,
   Hash[String, Any] $rails_cache_store = $foreman::params::rails_cache_store,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,7 +63,7 @@ class foreman::params inherits foreman::globals {
   $foreman_service = 'foreman'
   $foreman_service_ensure = 'running'
   $foreman_service_enable = true
-  $foreman_service_puma_threads_min = 0
+  $foreman_service_puma_threads_min = undef
   $foreman_service_puma_threads_max = 16
   $foreman_service_puma_workers = 2
 

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -92,7 +92,18 @@ describe 'foreman' do
             .with_content(/^SocketUser=#{apache_user}$/)
         end
 
-        it { should contain_systemd__dropin_file('foreman-service').with_filename('installer.conf').with_unit('foreman.service') }
+        it 'overrides foreman.service systemd service' do
+          should contain_systemd__dropin_file('foreman-service')
+            .with_ensure('present')
+            .with_filename('installer.conf')
+            .with_unit('foreman.service')
+            .with_content(%r{^User=foreman$})
+            .with_content(%r{^Environment=FOREMAN_ENV=production$})
+            .with_content(%r{^Environment=FOREMAN_HOME=/usr/share/foreman$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MIN=16$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MAX=16$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_WORKERS=2$})
+        end
 
         it { should contain_apache__vhost('foreman').without_custom_fragment(/Alias/) }
 

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -2,6 +2,6 @@
 User=<%= scope['foreman::user'] %>
 Environment=FOREMAN_ENV=<%= scope['foreman::rails_env'] %>
 Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
-Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::foreman_service_puma_threads_min'] %>
+Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::config::min_puma_threads'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
 Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::foreman_service_puma_workers'] %>


### PR DESCRIPTION
…by default

This has been shown to prevent memory leaks that can appear in Foreman
when running under Puma. This only changes the default to match and
users must still be aware of this potential when changing the tunings.

Some guidance from Satellite performance team -- https://github.com/RedHatSatellite/satellite-performance-tuning/blob/devel/docs/satellite-configuration-tuning.rst#puma-tuning

Some info from upstream Puma -- https://github.com/puma/puma/issues/2665

There is most likely one or more memory leaks within the application itself leading to this issue. This alleviates the issue for now by pre-allocating the needed memory and preventing spin-up and spin-down of threads that exacerbates the memory leak.