### PR TITLE
Fixes #33277: Change Puma default workers to 1.5 * CPU, max threads to 5

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,6 +44,17 @@ class foreman::config {
     content => template('foreman/database.yml.erb'),
   }
 
+  # CPU based calculation is based on https://github.com/puma/puma/blob/master/docs/deployment.md#mri
+  # Memory based calculation is based on https://docs.gitlab.com/ee/install/requirements.html#puma-settings
+  $puma_workers = pick(
+    $foreman::foreman_service_puma_workers,
+    floor(
+      min(
+        $facts['processors']['count'] * 1.5,
+        ($facts['memory']['system']['total_bytes']/(1024 * 1024 * 1024)) - 1.5
+      )
+    )
+  )
   $min_puma_threads = pick($foreman::foreman_service_puma_threads_min, $foreman::foreman_service_puma_threads_max)
   systemd::dropin_file { 'foreman-service':
     filename => 'installer.conf',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,9 @@
 #
 # $foreman_service_puma_threads_max::     Maximum number of threads for every Puma worker
 #
-# $foreman_service_puma_workers::         Number of workers for Puma
+# $foreman_service_puma_workers::         Number of workers for Puma.
+#                                         If not set, the value is dynamically calculated based on available number of
+#                                         CPUs and memory.
 #
 # $rails_cache_store::            Set rails cache store
 #
@@ -276,7 +278,7 @@ class foreman (
   Array[Stdlib::HTTPUrl] $cors_domains = $foreman::params::cors_domains,
   Optional[Integer[0]] $foreman_service_puma_threads_min = $foreman::params::foreman_service_puma_threads_min,
   Integer[0] $foreman_service_puma_threads_max = $foreman::params::foreman_service_puma_threads_max,
-  Integer[0] $foreman_service_puma_workers = $foreman::params::foreman_service_puma_workers,
+  Optional[Integer[0]] $foreman_service_puma_workers = $foreman::params::foreman_service_puma_workers,
   Hash[String, Any] $rails_cache_store = $foreman::params::rails_cache_store,
   Boolean $keycloak = $foreman::params::keycloak,
   String[1] $keycloak_app_name = $foreman::params::keycloak_app_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,8 +64,8 @@ class foreman::params inherits foreman::globals {
   $foreman_service_ensure = 'running'
   $foreman_service_enable = true
   $foreman_service_puma_threads_min = undef
-  $foreman_service_puma_threads_max = 16
-  $foreman_service_puma_workers = 2
+  $foreman_service_puma_threads_max = 5
+  $foreman_service_puma_workers = undef
 
   # Define job processing service properties
   $dynflow_manage_services = true

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'foreman' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { override_facts(facts, processors: { count: 3 }, memory: { system: { total_bytes:  10_737_418_240}}) }
       let(:params) { {} }
       let(:apache_user) { facts[:osfamily] == 'Debian' ? 'www-data' : 'apache' }
 
@@ -100,9 +100,9 @@ describe 'foreman' do
             .with_content(%r{^User=foreman$})
             .with_content(%r{^Environment=FOREMAN_ENV=production$})
             .with_content(%r{^Environment=FOREMAN_HOME=/usr/share/foreman$})
-            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MIN=16$})
-            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MAX=16$})
-            .with_content(%r{^Environment=FOREMAN_PUMA_WORKERS=2$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MIN=5$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_THREADS_MAX=5$})
+            .with_content(%r{^Environment=FOREMAN_PUMA_WORKERS=4$})
         end
 
         it { should contain_apache__vhost('foreman').without_custom_fragment(/Alias/) }

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -4,4 +4,4 @@ Environment=FOREMAN_ENV=<%= scope['foreman::rails_env'] %>
 Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
 Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::config::min_puma_threads'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
-Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::foreman_service_puma_workers'] %>
+Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::config::puma_workers'] %>


### PR DESCRIPTION
The Puma documentation recommends for MRI based installations to
start with number of CPUs times 1.5 and defaults to 5 on Ruby MRI.
The previous maximum threads of 16 was based on an incorrect reading
of the Puma documentation and is only the default on non-MRI Ruby.

I am recommending we make these default changes (and consider resetting existing installations that match the old defaults by way of an installer migration) based upon some of the following info:

 * Puma recommendations for MRI: https://github.com/puma/puma/blob/master/docs/deployment.md#mri
 * Puma worker utilization: https://github.com/puma/puma/blob/master/docs/deployment.md#worker-utilization
 * Gitlab's thread guidance: https://docs.gitlab.com/ee/install/requirements.html#puma-threads

