### PR TITLE
Construct foreman_url from servername and drop parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,8 +48,6 @@
 #
 # === Advanced parameters:
 #
-# $foreman_url::                  URL on which foreman is going to run
-#
 # $unattended::                   Should Foreman manage host provisioning as well
 #
 # $unattended_url::               URL hosts will retrieve templates from during build (normally http as many installers don't support https)
@@ -203,7 +201,6 @@
 # $keycloak_realm::               The realm as passed to keycloak-httpd-client-install
 #
 class foreman (
-  Stdlib::HTTPUrl $foreman_url = $foreman::params::foreman_url,
   Boolean $unattended = true,
   Optional[Stdlib::HTTPUrl] $unattended_url = undef,
   Boolean $apache = true,
@@ -302,6 +299,8 @@ class foreman (
   } else {
     $db_sslmode_real = $db_sslmode
   }
+
+  $foreman_url = "https://${servername}"
 
   include foreman::install
   include foreman::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,8 +3,6 @@
 class foreman::params inherits foreman::globals {
   $lower_fqdn = downcase($facts['networking']['fqdn'])
 
-  # Basic configurations
-  $foreman_url      = "https://${lower_fqdn}"
   # Server name of the VirtualHost
   $servername     = $facts['networking']['fqdn']
 

--- a/spec/classes/foreman_cli_spec.rb
+++ b/spec/classes/foreman_cli_spec.rb
@@ -115,7 +115,7 @@ describe 'foreman::cli' do
           class { 'foreman':
             initial_admin_username => 'jane',
             initial_admin_password => 'supersecret',
-            foreman_url            => 'https://foreman.example.com',
+            servername             => 'foreman.example.com',
             server_ssl_chain       => '/etc/puppetlabs/puppet/ssl/certs/ca.pub',
           }
           PUPPET

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -182,7 +182,6 @@ describe 'foreman' do
       describe 'with all parameters' do
         let :params do
           {
-            foreman_url: 'http://localhost',
             unattended: true,
             servername: 'localhost',
             serveraliases: ['foreman'],

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -7,7 +7,7 @@ describe 'foreman::plugin::remote_execution::cockpit' do
       let(:pre_condition) do
         <<-PUPPET
         class {'foreman':
-          foreman_url      => 'https://foreman.example.com',
+          servername       => 'foreman.example.com',
           server_ssl_chain => '/path/to/ca.pem',
           client_ssl_cert  => '/path/to/cert.pem',
           client_ssl_key   => '/path/to/key.pem',


### PR DESCRIPTION
Drops the foreman_url parameter and constructs it from the servername
given to Apache. The foreman_url and servername should match
and this gives one less parameter that needs to be configured to get
a correct installation.

@ekohl I was not sure if this is what you mean tor if there is some nuance of these parameters that I am missing where you would want them to be different. I also realize this is a "breaking" change but if accurate, feels cleaner.