### PR TITLE
Fixes #33320 - Refer to FQDN instead of "Foreman server" in SmartProx…

### DIFF
--- a/lib/puppet/provider/foreman_resource/rest_v3.rb
+++ b/lib/puppet/provider/foreman_resource/rest_v3.rb
@@ -99,14 +99,16 @@ Puppet::Type.type(:foreman_resource).provide(:rest_v3) do
   end
 
   def error_message(response)
+    fqdn = URI::parse(resource[:base_url]).host
+
     explanations = {
-      '400' => 'Something is wrong with the data sent to Foreman server',
-      '401' => 'Often this is caused by invalid Oauth credentials',
-      '404' => 'The requested resource was not found',
-      '500' => 'Check /var/log/foreman/production.log on Foreman server for detailed information',
-      '502' => 'The webserver received an invalid response from the backend service. Was Foreman unable to handle the request?',
-      '503' => 'The webserver was unable to reach the backend service. Is foreman.service running?',
-      '504' => 'The webserver timed out waiting for a response from the backend service. Is Foreman under unusually heavy load?'
+      '400' => "Something is wrong with the data sent to Foreman at #{fqdn}",
+      '401' => "Often this is caused by invalid Oauth credentials sent to Foreman at #{fqdn}",
+      '404' => "The requested resource was not found in Foreman at #{fqdn}",
+      '500' => "Check /var/log/foreman/production.log on #{fqdn} for detailed information",
+      '502' => "The webserver received an invalid response from the backend service. Was Foreman at #{fqdn} unable to handle the request?",
+      '503' => "The webserver was unable to reach the backend service. Is Foreman running at #{fqdn}?",
+      '504' => "The webserver timed out waiting for a response from the backend service. Is Foreman at #{fqdn} under unusually heavy load?"
     }
 
     if (explanation = explanations[response.code.to_str])

--- a/spec/unit/foreman_resource_rest_v3_spec.rb
+++ b/spec/unit/foreman_resource_rest_v3_spec.rb
@@ -141,6 +141,10 @@ describe provider_class do
   end
 
   describe '#error_message(response)' do
+    before { expect(resource).to receive(:[]).with(:base_url).and_return(base_url) }
+
+    let(:base_url) { 'https://foreman.example.com' }
+
     it 'returns array of errors from JSON' do
       expect(provider.error_message(double(:body => '{"error":{"full_messages":["error1","error2"]}}', :code => 'dummycode'))).to eq('error1 error2')
     end
@@ -150,31 +154,31 @@ describe provider_class do
     end
 
     it 'returns message for 400 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '400', :message => 'Bad Request'))).to eq('Response: 400 Bad Request: Something is wrong with the data sent to Foreman server')
+      expect(provider.error_message(double(:body => '{}', :code => '400', :message => 'Bad Request'))).to eq('Response: 400 Bad Request: Something is wrong with the data sent to Foreman at foreman.example.com')
     end
 
     it 'returns message for 401 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '401', :message => 'Unauthorized Request'))).to eq('Response: 401 Unauthorized Request: Often this is caused by invalid Oauth credentials')
+      expect(provider.error_message(double(:body => '{}', :code => '401', :message => 'Unauthorized Request'))).to eq('Response: 401 Unauthorized Request: Often this is caused by invalid Oauth credentials sent to Foreman at foreman.example.com')
     end
 
     it 'returns message for 404 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '404', :message => 'Not Found'))).to eq('Response: 404 Not Found: The requested resource was not found')
+      expect(provider.error_message(double(:body => '{}', :code => '404', :message => 'Not Found'))).to eq('Response: 404 Not Found: The requested resource was not found in Foreman at foreman.example.com')
     end
 
     it 'returns message for 500 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '500', :message => 'Internal Server Error'))).to eq('Response: 500 Internal Server Error: Check /var/log/foreman/production.log on Foreman server for detailed information')
+      expect(provider.error_message(double(:body => '{}', :code => '500', :message => 'Internal Server Error'))).to eq('Response: 500 Internal Server Error: Check /var/log/foreman/production.log on foreman.example.com for detailed information')
     end
 
     it 'returns message for 502 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '502', :message => 'Bad Gateway'))).to eq('Response: 502 Bad Gateway: The webserver received an invalid response from the backend service. Was Foreman unable to handle the request?')
+      expect(provider.error_message(double(:body => '{}', :code => '502', :message => 'Bad Gateway'))).to eq('Response: 502 Bad Gateway: The webserver received an invalid response from the backend service. Was Foreman at foreman.example.com unable to handle the request?')
     end
 
     it 'returns message for 503 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '503', :message => 'Service Unavailable'))).to eq('Response: 503 Service Unavailable: The webserver was unable to reach the backend service. Is foreman.service running?')
+      expect(provider.error_message(double(:body => '{}', :code => '503', :message => 'Service Unavailable'))).to eq('Response: 503 Service Unavailable: The webserver was unable to reach the backend service. Is Foreman running at foreman.example.com?')
     end
 
     it 'returns message for 504 response' do
-      expect(provider.error_message(double(:body => '{}', :code => '504', :message => 'Gateway Timeout'))).to eq('Response: 504 Gateway Timeout: The webserver timed out waiting for a response from the backend service. Is Foreman under unusually heavy load?')
+      expect(provider.error_message(double(:body => '{}', :code => '504', :message => 'Gateway Timeout'))).to eq('Response: 504 Gateway Timeout: The webserver timed out waiting for a response from the backend service. Is Foreman at foreman.example.com under unusually heavy load?')
     end
   end
 end


### PR DESCRIPTION
…y registration error messages