### PR TITLE
Fixes #33511 - configure redis before dynflow workers

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,7 @@ class foreman::config {
     } else {
       include redis
       $dynflow_redis_url = "redis://localhost:${redis::port}/6"
+      Class['redis'] -> Service <| tag == 'foreman::dynflow::worker' |>
     }
 
     file { '/etc/foreman/dynflow':

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -149,8 +149,8 @@ describe 'foreman' do
         # service
         it { should contain_class('foreman::service') }
         it { should contain_service('foreman') }
-        it { is_expected.to contain_service('dynflow-sidekiq@orchestrator').with_ensure('running').with_enable(true) }
-        it { is_expected.to contain_service('dynflow-sidekiq@worker-1').with_ensure('running').with_enable(true) }
+        it { is_expected.to contain_service('dynflow-sidekiq@orchestrator').with_ensure('running').with_enable(true).that_requires('Class[redis]') }
+        it { is_expected.to contain_service('dynflow-sidekiq@worker-1').with_ensure('running').with_enable(true).that_requires('Class[redis]') }
 
         # settings
         it { should contain_class('foreman::settings').that_requires('Class[foreman::database]') }


### PR DESCRIPTION
sometimes dynflow workers are started before redis, resulting in ugly
errors in the logs until redis is available