### PR TITLE
Apply version restrictions to all packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,12 +19,12 @@ class foreman::install {
   }
 
   package { 'foreman-service':
-    ensure => installed,
+    ensure => $foreman::version,
   }
 
   if $foreman::dynflow_manage_services {
     package { 'foreman-dynflow-sidekiq':
-      ensure => installed,
+      ensure => $foreman::version,
     }
   }
 
@@ -36,19 +36,19 @@ class foreman::install {
 
   if $foreman::telemetry_statsd_enabled or $foreman::telemetry_prometheus_enabled {
     package { 'foreman-telemetry':
-      ensure => installed,
+      ensure => $foreman::version,
     }
   }
 
   if $foreman::logging_type == 'journald' {
     package { 'foreman-journald':
-      ensure => installed,
+      ensure => $foreman::version,
     }
   }
 
   if $foreman::rails_cache_store['type'] == 'redis' {
     package { 'foreman-redis':
-      ensure => installed,
+      ensure => $foreman::version,
     }
   }
 }

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -162,7 +162,7 @@ describe 'foreman' do
         it { should compile.with_all_deps }
         it { should_not contain_class('foreman::config::apache') }
         it { should_not contain_concat__fragment('foreman_settings+03-reverse-proxy-headers.yaml') }
-        it { should contain_package('foreman-service').with_ensure('installed') }
+        it { should contain_package('foreman-service').with_ensure('present') }
         it 'removes foreman.socket systemd override' do
           should contain_systemd__dropin_file('foreman-socket')
             .with_ensure('absent')
@@ -245,6 +245,9 @@ describe 'foreman' do
         end
 
         it { is_expected.to compile.with_all_deps }
+        it { should contain_package('foreman-postgresql').with_ensure('1.12') }
+        it { should contain_package('foreman-service').with_ensure('1.12') }
+        it { should contain_package('foreman-dynflow-sidekiq').with_ensure('1.12') }
         it do
           is_expected.to contain_class('foreman::config::apache')
             .with_keycloak(true)


### PR DESCRIPTION
As there are packages installed by the module that escape from the version pin that can be set via `foreman::version`, the following situation might occur:

(Assuming `foreman::version` set to `2.4.0-1` and that `2.4.1-1` is the latest version available in the configured repositories)

* Puppet run `n`
  * Puppet installs `foreman-postgresql-2.4.0-1`.
  * Puppet installs `foreman-service` latest (due to `ensure => installed`)
    * DNF installs `foreman-service-2.4.1-1`
    * This triggers the update of `foreman` to `foreman-2.4.1-1` to match `foreman-service`'s requirements.
    * This triggers the update of `foreman-postgresql` to `2.4.1-1` to match `foreman-postgresql`'s dependency on `foreman`.
  * The Puppet run ends leaving the system in an undesired state.

* Puppet run `n+1`:
   * Puppet downgrades `foreman-postgresql` to `2.4.0-1`.
     * This triggers the downgrade of several packages, namely `foreman`, `foreman-service`, `foreman-dynflow-sideqik`, etc. This downgrade operation might or might not succeed :)

By ensuring that all packages are installed with the same version restrictions since the beginning, the unnecessary downgrade and the temporary bad system state explained above can be avoided.

(Internal note: applied locally as `027197f54e704fcab9cc5187193fe2e0009a7510`).

