### PR TITLE
Drop server_ssl_certs_dir parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,7 +125,6 @@ class foreman::config {
       ssl_ca             => $foreman::server_ssl_ca,
       ssl_chain          => $foreman::server_ssl_chain,
       ssl_cert           => $foreman::server_ssl_cert,
-      ssl_certs_dir      => $foreman::server_ssl_certs_dir,
       ssl_key            => $foreman::server_ssl_key,
       ssl_crl            => $foreman::server_ssl_crl,
       ssl_protocol       => $foreman::server_ssl_protocol,

--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -24,9 +24,6 @@
 # @param ssl_cert
 #   Location of the SSL certificate file.
 #
-# @param ssl_certs_dir
-#   Location of additional certificates for SSL client authentication.
-#
 # @param ssl_key
 #   Location of the SSL key file.
 #
@@ -104,7 +101,6 @@ class foreman::config::apache(
   Optional[Stdlib::Absolutepath] $ssl_ca = undef,
   Optional[Stdlib::Absolutepath] $ssl_chain = undef,
   Optional[Stdlib::Absolutepath] $ssl_cert = undef,
-  Variant[Undef, Enum[''], Stdlib::Absolutepath] $ssl_certs_dir = undef,
   Optional[Stdlib::Absolutepath] $ssl_key = undef,
   Variant[Undef, Enum[''], Stdlib::Absolutepath] $ssl_crl = undef,
   Optional[String] $ssl_protocol = undef,
@@ -301,7 +297,6 @@ class foreman::config::apache(
       serveraliases         => $serveraliases,
       ssl                   => true,
       ssl_cert              => $ssl_cert,
-      ssl_certs_dir         => $ssl_certs_dir,
       ssl_key               => $ssl_key,
       ssl_chain             => $ssl_chain,
       ssl_ca                => $ssl_ca,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,8 +97,6 @@
 #
 # $server_ssl_cert::              Defines Apache mod_ssl SSLCertificateFile setting in Foreman vhost conf file.
 #
-# $server_ssl_certs_dir::         Defines Apache mod_ssl SSLCACertificatePath setting in Foreman vhost conf file.
-#
 # $server_ssl_key::               Defines Apache mod_ssl SSLCertificateKeyFile setting in Foreman vhost conf file.
 #
 # $server_ssl_crl::               Defines the Apache mod_ssl SSLCARevocationFile setting in Foreman vhost conf file.
@@ -223,7 +221,6 @@ class foreman (
   Stdlib::Absolutepath $server_ssl_ca = $foreman::params::server_ssl_ca,
   Stdlib::Absolutepath $server_ssl_chain = $foreman::params::server_ssl_chain,
   Stdlib::Absolutepath $server_ssl_cert = $foreman::params::server_ssl_cert,
-  Variant[Enum[''], Stdlib::Absolutepath] $server_ssl_certs_dir = $foreman::params::server_ssl_certs_dir,
   Stdlib::Absolutepath $server_ssl_key = $foreman::params::server_ssl_key,
   Variant[Enum[''], Stdlib::Absolutepath] $server_ssl_crl = $foreman::params::server_ssl_crl,
   Optional[String] $server_ssl_protocol = $foreman::params::server_ssl_protocol,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -138,7 +138,6 @@ class foreman::params inherits foreman::globals {
   $server_ssl_ca    = "${puppet_ssldir}/certs/ca.pem"
   $server_ssl_chain = "${puppet_ssldir}/certs/ca.pem"
   $server_ssl_cert  = "${puppet_ssldir}/certs/${lower_fqdn}.pem"
-  $server_ssl_certs_dir = '' # lint:ignore:empty_string_assignment - this must be empty since we override a default
   $server_ssl_key   = "${puppet_ssldir}/private_keys/${lower_fqdn}.pem"
   $server_ssl_crl   = "${puppet_ssldir}/crl.pem"
   $server_ssl_protocol = undef

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -114,7 +114,6 @@ describe 'foreman::config::apache' do
             ssl_crl: '/crl.pem',
             ssl_chain: '/chain.pem',
             ssl_ca: '/ca.pem',
-            ssl_certs_dir: '',
             ssl_protocol: '-all +TLSv1.2',
             ssl_verify_client: 'require',
           }
@@ -136,7 +135,7 @@ describe 'foreman::config::apache' do
             .with_port(443)
             .with_ssl(true)
             .with_ssl_cert('/cert.pem')
-            .with_ssl_certs_dir('')
+            .with_ssl_certs_dir(nil)
             .with_ssl_key('/key.pem')
             .with_ssl_chain('/chain.pem')
             .with_ssl_ca('/ca.pem')
@@ -179,7 +178,6 @@ describe 'foreman::config::apache' do
         describe 'with vhost and ssl, no CRL explicitly' do
           let(:params) do
             super().merge(
-              ssl_certs_dir: '',
               ssl_crl: '',
             )
           end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -198,7 +198,6 @@ describe 'foreman' do
             server_ssl_ca: '/etc/ssl/certs/ca.pem',
             server_ssl_chain: '/etc/ssl/certs/ca.pem',
             server_ssl_cert: '/etc/ssl/certs/snakeoil.pem',
-            server_ssl_certs_dir: '/etc/ssl/certs/',
             server_ssl_key: '/etc/ssl/private/snakeoil.pem',
             server_ssl_crl: '/etc/ssl/certs/ca/crl.pem',
             server_ssl_protocol: '-all +TLSv1.2',


### PR DESCRIPTION
This parameter could be used to configure a directory with CA certificates to be trusted. This parameter is generally not used and `$server_ssl_cert` is preferred.

The parameter was introduced in 08911c3a6c776462fcc1aa99103fe588b8feb365 to override the default in puppetlabs-apache. Prior to version 2.1.0 it used to default to the system store, which created a security problem.  In puppetlabs-apache 2.1.0 [the default was changed to undef](https://github.com/puppetlabs/puppetlabs-apache/commit/7bb35c2293c12ce52329a4391fe1f20389efef06). Since this module depends on >= 5.5.0, it's safe to assume we don't need it.

It can still be set via Hiera:

```yaml
foreman::config::apache::https_vhost_options:
  ssl_certs_dir: /path/to/certs/dir
```