### PR TITLE
Fixes #34161 - Run apipie:cache:index after db:migrate

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,6 +27,7 @@ class foreman::database(
     foreman::rake { 'db:migrate':
       timeout => $timeout,
       unless  => '/usr/sbin/foreman-rake db:abort_if_pending_migrations',
+      notify  => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache'],
     }
     ~> foreman_config_entry { 'db_pending_seed':
       value => false,
@@ -34,7 +35,7 @@ class foreman::database(
     }
     ~> foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
+      notify      => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache'],
     }
-    ~> Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache']
   }
 }


### PR DESCRIPTION
With Puppet you can write:

```puppet
Class['A'] ~> Class['B'] ~> Class['C']
```

This implies `Class['A'] ~> Class['C']` and rspec-puppet actually will tell you that chaining is there, but it doesn't actually happen. This was reported in https://github.com/rodjek/rspec-puppet/pull/821.

In this particular case it means that if DB seeding doesn't happen then the apipie caches indexes aren't refreshed. By chaining it to db:migrate there's a much bigger chance it actually happens.

Normally apipie:cache:index needs to run after a package is updated so ideally this would actually be done in packaging, but this is the workaround we've been using for a long time.