### PR TITLE
Refs #34089 - Work around Kafo type parsing bug

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -282,7 +282,7 @@ class foreman (
   Optional[Redis::RedisUrl] $dynflow_redis_url = $foreman::params::dynflow_redis_url,
   Boolean $hsts_enabled = $foreman::params::hsts_enabled,
   Array[Stdlib::HTTPUrl] $cors_domains = $foreman::params::cors_domains,
-  Array[Stdlib::IP::Address] $trusted_proxies = $foreman::params::trusted_proxies,
+  Array[String[1]] $trusted_proxies = $foreman::params::trusted_proxies,
   Optional[Integer[0]] $foreman_service_puma_threads_min = $foreman::params::foreman_service_puma_threads_min,
   Integer[0] $foreman_service_puma_threads_max = $foreman::params::foreman_service_puma_threads_max,
   Optional[Integer[0]] $foreman_service_puma_workers = $foreman::params::foreman_service_puma_workers,
@@ -292,6 +292,8 @@ class foreman (
   String[1] $keycloak_realm = $foreman::params::keycloak_realm,
   Boolean $register_in_foreman = $foreman::params::register_in_foreman,
 ) inherits foreman::params {
+  assert_type(Array[Stdlib::IP::Address], $trusted_proxies)
+
   if $db_sslmode == 'UNSET' and $db_root_cert {
     $db_sslmode_real = 'verify-full'
   } else {


### PR DESCRIPTION
Due to a [bug in Kafo](https://projects.theforeman.org/issues/21398), the Stdlib::IP::Address data type can't be used. This [broke the nightly build](https://community.theforeman.org/t/foreman-installer-develop-package-release-1015-failed/26627/3).

By reducing the type to simple `String[1]` and asserting in the body the same guarantee is given, but with a worse UX if it does fail.

Currently our pipelines are broken due to Psych 4 being pulled in by rdoc 6.4 which is incompatible with Puppet.