### PR TITLE
Introduce foreman::settings_fragment

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,8 +24,7 @@ class foreman::config {
   $websockets_ssl_cert = pick($foreman::websockets_ssl_cert, $foreman::server_ssl_cert)
   $websockets_ssl_key = pick($foreman::websockets_ssl_key, $foreman::server_ssl_key)
 
-  concat::fragment {'foreman_settings+01-header.yaml':
-    target  => '/etc/foreman/settings.yaml',
+  foreman::settings_fragment { 'header.yaml':
     content => template('foreman/settings.yaml.erb'),
     order   => '01',
   }
@@ -214,8 +213,7 @@ class foreman::config {
         }
       }
 
-      concat::fragment {'foreman_settings+02-authorize_login_delegation.yaml':
-        target  => '/etc/foreman/settings.yaml',
+      foreman::settings_fragment { 'authorize_login_delegation.yaml':
         content => template('foreman/settings-external-auth.yaml.erb'),
         order   => '02',
       }

--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -154,8 +154,7 @@ class foreman::config::apache(
   }
 
   # This sets the headers matching what $vhost_https_internal_options sets
-  concat::fragment { 'foreman_settings+03-reverse-proxy-headers.yaml':
-    target  => '/etc/foreman/settings.yaml',
+  foreman::settings_fragment { 'reverse-proxy-headers.yaml':
     content => file('foreman/settings-reverse-proxy-headers.yaml'),
     order   => '03',
   }

--- a/manifests/settings_fragment.pp
+++ b/manifests/settings_fragment.pp
@@ -1,0 +1,20 @@
+# @summary Add a fragment to settings.yaml
+#
+# This is a thin wrapper around concat::fragment to provide a stable API.
+#
+# @param content
+#   The content to store
+# @param order
+#   The order of the fragment
+#
+# @see concat::fragment
+define foreman::settings_fragment (
+  Variant[String[1], Deferred] $content,
+  String[2, 2] $order,
+) {
+  concat::fragment { "foreman_settings+${order}-${name}":
+    target  => '/etc/foreman/settings.yaml',
+    content => $content,
+    order   => $order,
+  }
+}

--- a/spec/defines/foreman_settings_fragment_spec.rb
+++ b/spec/defines/foreman_settings_fragment_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'foreman::settings_fragment' do
+  let(:title) { 'myfragment' }
+
+  context 'with string' do
+    let(:params) do
+      {
+        content: 'mycontent',
+        order: '42',
+      }
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it do
+      is_expected.to contain_concat__fragment('foreman_settings+42-myfragment')
+        .with_target('/etc/foreman/settings.yaml')
+        .with_content('mycontent')
+        .with_order('42')
+    end
+  end
+end


### PR DESCRIPTION
This provides a stable API to provide fragments to settings.yaml. This means we don't need to create parameters for every single setting.