### PR TITLE
Replace template with to_symbolized_yaml function

### DIFF
--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -46,7 +46,7 @@ class foreman::plugin::remote_execution::cockpit (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => template('foreman/remote_execution_cockpit_session.yml.erb'),
+    content => foreman::to_symbolized_yaml($cockpit_config),
     require => Foreman::Plugin['remote_execution-cockpit'],
     notify  => Service['foreman-cockpit'],
   }

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -55,7 +55,7 @@ describe 'foreman::plugin::remote_execution::cockpit' do
             .with_ensure('file')
             .with_content([
               '---',
-              ':foreman_url: "https://foreman.example.com"',
+              ':foreman_url: https://foreman.example.com',
               ':ssl_ca_file: "/path/to/ca.pem"',
               ':ssl_certificate: "/path/to/cert.pem"',
               ':ssl_private_key: "/path/to/key.pem"',
@@ -105,7 +105,7 @@ describe 'foreman::plugin::remote_execution::cockpit' do
             .with_ensure('file')
             .with_content([
               '---',
-              ':foreman_url: "https://foreman.example.com"',
+              ':foreman_url: https://foreman.example.com',
               ':ssl_ca_file: "/path/to/ca.pem"',
               ':ssl_certificate: "/path/to/cert.pem"',
               ':ssl_private_key: "/path/to/key.pem"',

--- a/templates/remote_execution_cockpit_session.yml.erb
+++ b/templates/remote_execution_cockpit_session.yml.erb
@@ -1,4 +1,0 @@
----
-<% @cockpit_config.each do |key, value| -%>
-:<%= key %>: "<%= value %>"
-<% end -%>


### PR DESCRIPTION
This function can output the same thing and removes the need for a template.

Currently untested but unit tests should cover this.