### PR TITLE
Fixes #34308 - Explicitly notify db:seed from db:migrate

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,7 +27,7 @@ class foreman::database(
     foreman::rake { 'db:migrate':
       timeout => $timeout,
       unless  => '/usr/sbin/foreman-rake db:abort_if_pending_migrations',
-      notify  => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache'],
+      notify  => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache', 'db:seed'],
     }
     ~> foreman_config_entry { 'db_pending_seed':
       value => false,


### PR DESCRIPTION
This is similar to a293e0084d3c2d62c12ccc6a13338b5db01fe8cf and the problem is that a transitive notify doesn't always happen. However, if a db:migrate happens a db:seed should always happen. So his may be a redundant specification, but it's better to be explicit than relying on implicit behavior.