### PR TITLE
Use the new GPG key for Debian packages

### DIFF
--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -2,7 +2,7 @@
 # @api private
 define foreman::repos::apt (
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
-  String $key = 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
+  String $key = '5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A',
   Stdlib::HTTPUrl $key_location = 'https://deb.theforeman.org/foreman.asc',
   Stdlib::HTTPUrl $location = 'https://deb.theforeman.org/',
 ) {

--- a/spec/defines/foreman_repos_apt_spec.rb
+++ b/spec/defines/foreman_repos_apt_spec.rb
@@ -8,7 +8,7 @@ describe 'foreman::repos::apt' do
   end
 
   let(:apt_key) do
-    'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6'
+    '5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A'
   end
 
   let(:apt_key_title) do


### PR DESCRIPTION
The old key was created in 2016 and the new one in 2021. Since 2022-03-14 the old key expired and is no longer used.