### PR TITLE
metadata.json: Use https URL to git repo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "theforeman",
   "summary": "Foreman server configuration",
   "license": "GPL-3.0+",
-  "source": "git://github.com/theforeman/puppet-foreman",
+  "source": "https://github.com/theforeman/puppet-foreman",
   "project_page": "https://github.com/theforeman/puppet-foreman",
   "issues_url": "https://github.com/theforeman/puppet-foreman/issues",
   "description": "Module for configuring Foreman",


### PR DESCRIPTION
using plaintext git URLs isn't supported by GitHub anymore. People might
parse the metadata.json to get the git URL which will then fail.