### PR TITLE
Fixes #34640 - Drop apipie:cache:index

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -27,7 +27,7 @@ class foreman::database(
     foreman::rake { 'db:migrate':
       timeout => $timeout,
       unless  => '/usr/sbin/foreman-rake db:abort_if_pending_migrations',
-      notify  => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache', 'db:seed'],
+      notify  => Foreman::Rake['apipie_dsl:cache', 'db:seed'],
     }
     ~> foreman_config_entry { 'db_pending_seed':
       value => false,
@@ -35,7 +35,7 @@ class foreman::database(
     }
     ~> foreman::rake { 'db:seed':
       environment => delete_undef_values($seed_env),
-      notify      => Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache'],
+      notify      => Foreman::Rake['apipie_dsl:cache'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -300,10 +300,6 @@ class foreman (
     $db_sslmode_real = $db_sslmode
   }
 
-  foreman::rake { 'apipie:cache:index':
-    timeout => 0,
-  }
-
   foreman::rake { 'apipie_dsl:cache':
     timeout => 0,
   }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -41,7 +41,7 @@ define foreman::plugin(
   package { $real_package:
     ensure => $version,
   }
-  ~> Foreman::Rake['apipie:cache:index', 'apipie_dsl:cache']
+  ~> Foreman::Rake['apipie_dsl:cache']
 
   if $config {
     file { $config_file:

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -14,7 +14,6 @@ describe 'foreman' do
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }
-        it { should contain_foreman__rake('apipie:cache:index') }
         it { should contain_foreman__rake('apipie_dsl:cache') }
       end
 

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -125,7 +125,6 @@ describe 'foreman' do
         it { should contain_foreman__rake('db:migrate') }
         it { should contain_foreman_config_entry('db_pending_seed') }
         it { should contain_foreman__rake('db:seed') }
-        it { should contain_foreman__rake('apipie:cache:index') }
         it { should contain_foreman__rake('apipie_dsl:cache') }
 
         # jobs


### PR DESCRIPTION
Apipie cache has been explicitly disabled in Foreman so don't waste
time generating an index.