### PR TITLE
Add $selinux_ignore_defaults parameter with default value true

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,10 +57,11 @@ class foreman::config {
   )
   $min_puma_threads = pick($foreman::foreman_service_puma_threads_min, $foreman::foreman_service_puma_threads_max)
   systemd::dropin_file { 'foreman-service':
-    filename       => 'installer.conf',
-    unit           => "${foreman::foreman_service}.service",
-    content        => template('foreman/foreman.service-overrides.erb'),
-    notify_service => true,
+    filename                => 'installer.conf',
+    unit                    => "${foreman::foreman_service}.service",
+    content                 => template('foreman/foreman.service-overrides.erb'),
+    notify_service          => true,
+    selinux_ignore_defaults => $foreman::selinux_ignore_defaults,
   }
 
   if ! defined(File[$foreman::app_root]) {
@@ -223,10 +224,11 @@ class foreman::config {
   }
 
   systemd::dropin_file { 'foreman-socket':
-    ensure         => bool2str($foreman_socket_override =~ Undef, 'absent', 'present'),
-    filename       => 'installer.conf',
-    unit           => "${foreman::foreman_service}.socket",
-    content        => $foreman_socket_override,
-    notify_service => true,
+    ensure                  => bool2str($foreman_socket_override =~ Undef, 'absent', 'present'),
+    filename                => 'installer.conf',
+    unit                    => "${foreman::foreman_service}.socket",
+    content                 => $foreman_socket_override,
+    notify_service          => true,
+    selinux_ignore_defaults => $foreman::selinux_ignore_defaults,
   }
 }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -24,6 +24,8 @@
 # @param vhost_priority
 #   Defines Apache vhost priority for the Foreman vhost conf file.
 #
+# @param selinux_ignore_defaults
+#   Do not lookup default security context for file resources in catalogue compilation and attempt to manage them; instead defer context lookups to the system itself when the files are actually created. Useful during initial installs, because Puppet can install packages which modify the security policy after the context lookups were performed, which breaks idempotence. This can be disabled after the initial install, to allow Puppet to remedy drift in security context.
 class foreman::globals (
   Optional[String] $plugin_prefix = undef,
   Boolean $manage_user = true,
@@ -33,5 +35,6 @@ class foreman::globals (
   Stdlib::Absolutepath $app_root = '/usr/share/foreman',
   String[1] $rails_env = 'production',
   String[1] $vhost_priority = '05',
+  Boolean $selinux_ignore_defaults = true,
 ) {
 }

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -2,14 +2,6 @@ class { 'foreman::repo':
   repo => 'nightly',
 }
 
-# Needed for idempotency when SELinux is enabled
-if $foreman::repo::configure_scl_repo {
-  package { 'rh-redis5-redis':
-    ensure  => installed,
-    require => Class['foreman::repo'],
-  }
-}
-
 # Not /etc/foreman because purging removes that
 $directory = '/etc/foreman-certs'
 $certificate = "${directory}/certificate.pem"


### PR DESCRIPTION
The idea is that `foreman::selinux_ignore_defaults: true` can be used for initial install so that the system will determine security context for files at the time they are created, and `foreman::selinux_ignore_defaults: false` can be used on subsequent runs to remediate drift from the already installed policy.

This allows foreman-installer to eliminate hooks/pre/32-install_selinux_packages.rb.

The one case this doesn't adequately cover would be the case where `foreman-selinux` package is updated by this module with changes to the policy. This would be solved for foreman_maintain users by having foreman_maintain run the installer with `foreman::selinux_ignore_defaults: false` since packages would always be updated prior to the installer running.