### PR TITLE
Fixes #34824 - properly restart foreman when puma config changed

### DIFF
--- a/manifests/repos/apt.pp
+++ b/manifests/repos/apt.pp
@@ -2,7 +2,7 @@
 # @api private
 define foreman::repos::apt (
   Variant[Enum['nightly'], Pattern['^\d+\.\d+$']] $repo,
-  String $key = 'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6',
+  String $key = '5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A',
   Stdlib::HTTPUrl $key_location = 'https://deb.theforeman.org/foreman.asc',
   Stdlib::HTTPUrl $location = 'https://deb.theforeman.org/',
 ) {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,8 +41,8 @@ class foreman::service(
   }
 
   service { $foreman_service:
-    ensure  => $foreman_service_ensure,
-    enable  => $foreman_service_enable,
-    require => Service["${foreman_service}.socket"],
+    ensure => $foreman_service_ensure,
+    enable => $foreman_service_enable,
+    before => Service["${foreman_service}.socket"],
   }
 }

--- a/spec/acceptance/foreman_service_spec.rb
+++ b/spec/acceptance/foreman_service_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper_acceptance'
+
+describe 'configures puma worker count', :order => :defined do
+  context 'initial configuration with 2 puma workers' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'foreman':
+          foreman_service_puma_workers => 2,
+        }
+        PUPPET
+      end
+    end
+
+    describe service("foreman") do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe process('puma: cluster worker') do
+      its(:count) { is_expected.to eq 2 }
+    end
+  end
+
+  context 'reconfigure to use 1 puma worker and restart foreman.service' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'foreman':
+          foreman_service_puma_workers => 1,
+        }
+        PUPPET
+      end
+    end
+
+    describe service("foreman") do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe process('puma: cluster worker') do
+      its(:count) { is_expected.to eq 1 }
+    end
+  end
+end

--- a/spec/classes/foreman_service_spec.rb
+++ b/spec/classes/foreman_service_spec.rb
@@ -23,7 +23,7 @@ describe 'foreman::service' do
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_service('foreman.socket').with_ensure('running').with_enable(true) }
-    it { is_expected.to contain_service('foreman').with_ensure('running').with_enable(true) }
+    it { is_expected.to contain_service('foreman').with_ensure('running').with_enable(true).that_comes_before('Service[foreman.socket]') }
   end
 
   context 'with apache' do
@@ -34,7 +34,7 @@ describe 'foreman::service' do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_class('foreman::service').that_requires('Class[apache::service]') }
     it { is_expected.to contain_service('foreman.socket').with_ensure('running').with_enable(true) }
-    it { is_expected.to contain_service('foreman').with_ensure('running').with_enable(true) }
+    it { is_expected.to contain_service('foreman').with_ensure('running').with_enable(true).that_comes_before('Service[foreman.socket]') }
 
     context 'without ssl' do
       let(:params) { super().merge(ssl: false) }

--- a/spec/defines/foreman_repos_apt_spec.rb
+++ b/spec/defines/foreman_repos_apt_spec.rb
@@ -8,7 +8,7 @@ describe 'foreman::repos::apt' do
   end
 
   let(:apt_key) do
-    'AE0AF310E2EA96B6B6F4BD726F8600B9563278F6'
+    '5B7C3E5A735BCB4D615829DC0BDDA991FD7AAC8A'
   end
 
   let(:apt_key_title) do


### PR DESCRIPTION
we need to restart foreman.service *before* a (possible) restart of
foreman.socket, as the later *also* does restart foreman.service which
leads to foreman.socket being *started* instead of *restarted*

    /Service[foreman.socket]: Starting to evaluate the resource (2265 of 2522)
    Executing: '/bin/systemctl is-active -- foreman.socket'
    Executing: '/bin/systemctl restart -- foreman.socket'
    /Service[foreman]: Starting to evaluate the resource (2266 of 2522)
    Executing: '/bin/systemctl is-active -- foreman'
    Executing: '/bin/systemctl show --property=NeedDaemonReload -- foreman'
    Executing: '/bin/systemctl daemon-reload'
    Executing: '/bin/systemctl unmask -- foreman'
    Executing: '/bin/systemctl start -- foreman'
    Executing: '/bin/systemctl is-enabled -- foreman'
    /Stage[main]/Foreman::Service/Service[foreman]/ensure: ensure changed 'stopped' to 'running'

But in this case the now running foreman.service didn't see the changes
to the service file that daemon-reload would have loaded.

(cherry picked from commit 6b7b05e0dbfdc26623422a9b38979524ac9d29d9)