### PR TITLE
Fixes #35089 - set NoDelay=false when deploying a UNIX socket

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,5 +7,9 @@ Gemfile:
 spec/spec_helper.rb:
   requires:
     - webmock/rspec
+  custom_facts:
+    - name: service_provider
+      value: systemd
+      source: puppetlabs-stdlib
 spec/spec_helper_acceptance.rb:
   locale_workaround: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'webmock/rspec'
 
 require 'voxpupuli/test/spec_helper'
 
+add_custom_fact :service_provider, "systemd" # puppetlabs-stdlib
+
 def get_content(subject, title)
   is_expected.to contain_file(title)
   content = subject.resource('file', title).send(:parameters)[:content]

--- a/templates/foreman.socket-overrides.erb
+++ b/templates/foreman.socket-overrides.erb
@@ -1,5 +1,6 @@
 [Socket]
 ListenStream=
 ListenStream=<%= @listen_socket %>
+NoDelay=false
 SocketUser=<%= scope['apache::user'] %>
 SocketMode=0600


### PR DESCRIPTION
Upstream foreman.socket uses NoDelay=true with a TCP socket, but on UNIX
sockets this just generates a useless warning. Explicitly setting it
back to false in our override fixes the issue.