### PR TITLE
Set postgresql service status command

### DIFF
--- a/spec/acceptance/hieradata/os/Ubuntu/20.04.yaml
+++ b/spec/acceptance/hieradata/os/Ubuntu/20.04.yaml
@@ -1,0 +1,1 @@
+postgresql::globals::service_status: systemctl status postgresql


### PR DESCRIPTION
This is to test out if https://github.com/puppetlabs/puppetlabs-postgresql/pull/1349 could fix our broken Ubuntu 20.04 tests.