### PR TITLE
Use Integer type for vhost priority

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -88,7 +88,7 @@
 #   application.
 class foreman::config::apache (
   Stdlib::Absolutepath $app_root = '/usr/share/foreman',
-  String $priority = '05',
+  Integer $priority = 05,
   Stdlib::Fqdn $servername = $facts['networking']['fqdn'],
   Array[Stdlib::Fqdn] $serveraliases = [],
   Stdlib::Port $server_port = 80,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -32,6 +32,6 @@ class foreman::globals (
   Array[String] $user_groups = [],
   Stdlib::Absolutepath $app_root = '/usr/share/foreman',
   String[1] $rails_env = 'production',
-  String[1] $vhost_priority = '05',
+  Integer $vhost_priority = 05,
 ) {
 }


### PR DESCRIPTION
Since
https://github.com/puppetlabs/puppetlabs-apache/commit/f41251e336fa3e7c31c19968ccee74121cf71e47
it is no longer supported to use String type for vhost priority