### PR TITLE
Fixes #35356 - Don't proxy /server-status

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -96,7 +96,7 @@ class foreman::config::apache (
   Pattern['^(https?|unix)://'] $proxy_backend = 'unix:///run/foreman.sock',
   Boolean $proxy_add_headers = true,
   Hash $proxy_params = { 'retry' => '0' },
-  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
+  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pulp2', '/streamer', '/pub', '/icons', '/server-status'],
   Boolean $ssl = false,
   Optional[Stdlib::Absolutepath] $ssl_ca = undef,
   Optional[Stdlib::Absolutepath] $ssl_chain = undef,

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -61,7 +61,7 @@ describe 'foreman::config::apache' do
             'unset REMOTE_USER_GROUPS'
           ])
           .with_proxy_pass(
-            "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
+            "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons', '/server-status'],
             "path"          => '/',
             "url"           => 'unix:///run/foreman.sock|http://foreman/',
             "params"        => { "retry" => '0' },
@@ -161,7 +161,7 @@ describe 'foreman::config::apache' do
             ])
             .with_ssl_proxyengine(true)
             .with_proxy_pass(
-              "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons'],
+              "no_proxy_uris" => ['/pulp', '/pulp2', '/streamer', '/pub', '/icons', '/server-status'],
               "path"          => '/',
               "url"           => 'unix:///run/foreman.sock|http://foreman/',
               "params"        => { "retry" => '0' },


### PR DESCRIPTION
This is the default path that Apache uses for the server-status. Right now it's not used by Foreman. If mod_status is present, this allows monitoring of Apache.