### PR TITLE
Allow puppetlabs/apache 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 5.5.0 < 8.0.0"
+      "version_requirement": ">= 5.5.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
5a3ddb0add304fa48ab03aaf36508a4911848dd2 already made it compatible. Now that it's officially out it should be marked as compatible.