### PR TITLE
install oauth gem on puppet agent

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,4 +47,9 @@ class foreman::install {
   if $foreman::register_in_foreman {
     contain foreman::providers
   }
+
+  package { 'oauth':
+    ensure   => installed,
+    provider => 'puppet_gem',
+  }
 }

--- a/spec/classes/foreman_install_spec.rb
+++ b/spec/classes/foreman_install_spec.rb
@@ -6,6 +6,8 @@ describe 'foreman' do
       let(:facts) { facts }
       let(:params) { {} }
 
+      it { is_expected.to contain_package('oauth').with_provider('puppet_gem') }
+
       describe 'with version' do
         let(:params) { super().merge(version: 'latest') }
         it { should_not contain_foreman__repos('foreman') }


### PR DESCRIPTION
puppet6 aio bundles the oauth gem but it is not bundled with puppet7
aio.  Most of the native types in this module require this gem to be
present.