### PR TITLE
Fixes #35524 - Require puppetlabs-apache 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 5.5.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
This is required for SSO to work correctly with Keycloak.