### PR TITLE
Convert per_page in foreman::foreman to string

### DIFF
--- a/lib/puppet/functions/foreman/foreman.rb
+++ b/lib/puppet/functions/foreman/foreman.rb
@@ -62,7 +62,7 @@ Puppet::Functions.create_function(:'foreman::foreman') do
     raise Puppet::ParseError, "Foreman: Invalid filter_result: #{filter_result}, must not be boolean true" if filter_result == true
 
     begin
-      path = "/api/#{CGI.escape(item)}?search=#{CGI.escape(search)}&per_page=#{CGI.escape(per_page)}"
+      path = "/api/#{CGI.escape(item)}?search=#{CGI.escape(search)}&per_page=#{CGI.escape(per_page.to_s)}"
 
       req = Net::HTTP::Get.new(path)
       req['Content-Type'] = 'application/json'


### PR DESCRIPTION
CGI.escape can only deal with strings and the function accepts per_page as an integer.