### PR TITLE
Refs #35641 - Add option to configure FOREMAN_PUMA_WORKER_TIMEOUT

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -176,6 +176,10 @@
 #                                         If not set, the value is dynamically calculated based on available number of
 #                                         CPUs and memory.
 #
+# $foreman_service_puma_worker_timeout::         Puma worker timeout in seconds.
+#                                                This is the time within which each worker must check in before considered lost
+#                                                and automatically restarted. This is not a request timeout.
+#
 # $rails_cache_store::            Set rails cache store
 #
 # $register_in_foreman::          Register host in Foreman
@@ -289,6 +293,7 @@ class foreman (
   Optional[Integer[0]] $foreman_service_puma_threads_min = undef,
   Integer[0] $foreman_service_puma_threads_max = 5,
   Optional[Integer[0]] $foreman_service_puma_workers = undef,
+  Optional[Integer[6]] $foreman_service_puma_worker_timeout = undef,
   Hash[String, Any] $rails_cache_store = { 'type' => 'file' },
   Boolean $keycloak = false,
   String[1] $keycloak_app_name = 'foreman-openidc',

--- a/templates/foreman.service-overrides.erb
+++ b/templates/foreman.service-overrides.erb
@@ -5,3 +5,8 @@ Environment=FOREMAN_HOME=<%= scope['foreman::app_root'] %>
 Environment=FOREMAN_PUMA_THREADS_MIN=<%= scope['foreman::config::min_puma_threads'] %>
 Environment=FOREMAN_PUMA_THREADS_MAX=<%= scope['foreman::foreman_service_puma_threads_max'] %>
 Environment=FOREMAN_PUMA_WORKERS=<%= scope['foreman::config::puma_workers'] %>
+<% unless scope['foreman::foreman_service_puma_worker_timeout'].nil? -%>
+# Puma worker_timeout, which specifies the time for each worker to check in
+# before it is assumed hanging and then restarted. This is not a request timeout.
+Environment=FOREMAN_PUMA_WORKER_TIMEOUT=<%= scope['foreman::foreman_service_puma_worker_timeout'] %>
+<% end -%>


### PR DESCRIPTION
This specifies the time before a worker process that has not checked in will be considered lost and automatically restarted. This can be useful to tune if worker timeouts are observed that are not actually due to a hanging process; it is NOT a request timeout. When undefined, it falls back to the default value of 60 seconds.

Requires https://github.com/theforeman/foreman/pull/9485 and co-authored with @jpasqualetto