### PR TITLE
Puppet-lint fixes

### DIFF
--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -18,8 +18,6 @@ define foreman::rake (
   Stdlib::Absolutepath $app_root = $foreman::app_root,
   Variant[Undef, String[1], Array[String[1]]] $unless = undef,
 ) {
-  # https://github.com/rodjek/puppet-lint/issues/327
-  # lint:ignore:arrow_alignment
   exec { "foreman-rake-${title}":
     command     => "/usr/sbin/foreman-rake ${title}",
     user        => $user,
@@ -29,5 +27,4 @@ define foreman::rake (
     timeout     => $timeout,
     unless      => $unless,
   }
-  # lint:endignore
 }

--- a/manifests/rake.pp
+++ b/manifests/rake.pp
@@ -21,7 +21,7 @@ define foreman::rake (
   exec { "foreman-rake-${title}":
     command     => "/usr/sbin/foreman-rake ${title}",
     user        => $user,
-    environment => sort(join_keys_to_values(merge( { 'HOME' => $app_root }, $environment), '=')),
+    environment => sort(join_keys_to_values({ 'HOME' => $app_root } + $environment, '=')),
     logoutput   => 'on_failure',
     refreshonly => $unless =~ Undef,
     timeout     => $timeout,


### PR DESCRIPTION
This makes master pass again. Also removes a workaround that's no longer needed.