### PR TITLE
Refs #35414 - Expect a different message in journal

### DIFF
--- a/spec/acceptance/foreman_journald_spec.rb
+++ b/spec/acceptance/foreman_journald_spec.rb
@@ -24,6 +24,6 @@ describe 'Scenario: install foreman with journald' do
   end
 
   describe command('journalctl -u dynflow-sidekiq@orchestrator') do
-    its(:stdout) { is_expected.to match(%r{Everything ready for world: }) }
+    its(:stdout) { is_expected.to match(%r{orchestrator in passive mode}) }
   end
 end


### PR DESCRIPTION
In Foreman 3.5 the Dynflow startup procedure was changed. It now signals it's ready before it's actually started up. This is because it can run into passive mode, in case there are multiple orchestrators. This changes the expectation so it's reliably testing it.