### PR TITLE
Remove Docker, Spacewalk & DigitalOcean plugins

### DIFF
--- a/manifests/plugin/digitalocean.pp
+++ b/manifests/plugin/digitalocean.pp
@@ -1,4 +1,0 @@
-# Installs foreman_digitalocean plugin
-class foreman::plugin::digitalocean {
-  foreman::plugin { 'digitalocean': }
-}

--- a/manifests/plugin/docker.pp
+++ b/manifests/plugin/docker.pp
@@ -1,4 +1,0 @@
-# Installs foreman_docker plugin
-class foreman::plugin::docker {
-  foreman::plugin { 'docker': }
-}

--- a/manifests/plugin/spacewalk.pp
+++ b/manifests/plugin/spacewalk.pp
@@ -1,5 +1,0 @@
-# Installs foreman_spacewalk plugin
-class foreman::plugin::spacewalk {
-  foreman::plugin { 'spacewalk':
-  }
-}

--- a/spec/classes/plugin/digitalocean_spec.rb
+++ b/spec/classes/plugin/digitalocean_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe 'foreman::plugin::digitalocean' do
-  include_examples 'basic foreman plugin tests', 'digitalocean'
-end

--- a/spec/classes/plugin/docker_spec.rb
+++ b/spec/classes/plugin/docker_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe 'foreman::plugin::docker' do
-  include_examples 'basic foreman plugin tests', 'docker'
-end

--- a/spec/classes/plugin/spacewalk_spec.rb
+++ b/spec/classes/plugin/spacewalk_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe 'foreman::plugin::spacewalk' do
-  include_examples 'basic foreman plugin tests', 'spacewalk'
-end


### PR DESCRIPTION
Both have been archived. Docker is already removed from packaging, Spacewalk is still there but should also be dropped.