### PR TITLE
Fixes #35832 - set default_domain_suffix in sssd.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -165,6 +165,12 @@ class foreman::config {
           enable  => true,
           require => Package['sssd-dbus'],
         }
+
+        $ipa_config = '/etc/ipa/default.conf'
+        if find_file($ipa_config) {
+          $realm_entry = file($ipa_config).match('^realm\s*=\s*(.*)$')
+          $default_realm = downcase($realm_entry[1])
+        }
       }
 
       file { "/etc/pam.d/${foreman::pam_service}":
@@ -206,7 +212,7 @@ class foreman::config {
 
       if $foreman::ipa_manage_sssd {
         $sssd = pick(fact('foreman_sssd'), {})
-        $sssd_default_domain_suffix = $facts['networking']['domain']
+        $sssd_default_domain_suffix = $default_realm
         $sssd_services = join(unique(pick($sssd['services'], []) + ['ifp']), ', ')
         $sssd_ldap_user_extra_attrs = join(unique(pick($sssd['ldap_user_extra_attrs'], []) + ['email:mail', 'lastname:sn', 'firstname:givenname']), ', ')
         $sssd_allowed_uids = join(unique(pick($sssd['allowed_uids'], []) + [$apache::user, 'root']), ', ')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -206,6 +206,7 @@ class foreman::config {
 
       if $foreman::ipa_manage_sssd {
         $sssd = pick(fact('foreman_sssd'), {})
+        $sssd_default_domain_suffix = $facts['networking']['domain']
         $sssd_services = join(unique(pick($sssd['services'], []) + ['ifp']), ', ')
         $sssd_ldap_user_extra_attrs = join(unique(pick($sssd['ldap_user_extra_attrs'], []) + ['email:mail', 'lastname:sn', 'firstname:givenname']), ', ')
         $sssd_allowed_uids = join(unique(pick($sssd['allowed_uids'], []) + [$apache::user, 'root']), ', ')
@@ -215,6 +216,7 @@ class foreman::config {
           context => '/files/etc/sssd/sssd.conf',
           changes => [
             "set target[.=~regexp('domain/.*')]/ldap_user_extra_attrs '${sssd_ldap_user_extra_attrs}'",
+            "set target[.='sssd']/default_domain_suffix '${sssd_default_domain_suffix}'",
             "set target[.='sssd']/services '${sssd_services}'",
             'set target[.=\'ifp\'] \'ifp\'',
             "set target[.='ifp']/allowed_uids '${sssd_allowed_uids}'",


### PR DESCRIPTION
Setting a default_domain_suffix for IDM based authentication would reduce an effort to type in the @domain while authenticating.

https://docs.theforeman.org/nightly/Administering_Project/index-foreman-el.html#Using_FreeIPA_admin