### PR TITLE
Fixes #36037 - Manage Redis service for Redis cache

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,17 @@ class foreman::config {
     }
   }
 
+  if $foreman::rails_cache_store['type'] == 'redis' {
+    if $foreman::rails_cache_store['urls'] {
+      $redis_cache_urls = prefix($foreman::rails_cache_store['urls'], 'redis://')
+    } else {
+      include redis
+      $redis_cache_urls = ["redis://localhost:${redis::port}/0"]
+    }
+  } else {
+    $redis_cache_urls =  undef
+  }
+
   # Used in the settings template
   $websockets_ssl_cert = pick($foreman::websockets_ssl_cert, $foreman::server_ssl_cert)
   $websockets_ssl_key = pick($foreman::websockets_ssl_key, $foreman::server_ssl_key)

--- a/spec/acceptance/foreman_basic_spec.rb
+++ b/spec/acceptance/foreman_basic_spec.rb
@@ -1,19 +1,38 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman' do
+describe 'Foreman' do
   before(:context) { purge_foreman }
 
-  it_behaves_like 'an idempotent resource' do
-    let(:manifest) { 'include foreman' }
+  describe 'with default options' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) { 'include foreman' }
+    end
+
+    it_behaves_like 'the foreman application'
+
+    describe package('foreman-journald') do
+      it { is_expected.not_to be_installed }
+    end
+
+    describe package('foreman-telemetry') do
+      it { is_expected.not_to be_installed }
+    end
   end
 
-  it_behaves_like 'the foreman application'
+  describe 'with Redis caching' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PUPPET
+        class { 'foreman':
+          rails_cache_store => { 'type' => 'redis' },
+        }
+        PUPPET
+      end
+    end
 
-  describe package('foreman-journald') do
-    it { is_expected.not_to be_installed }
-  end
+    it_behaves_like 'the foreman application'
 
-  describe package('foreman-telemetry') do
-    it { is_expected.not_to be_installed }
+    # TODO: verify it works using the /api/ping endpoint
+    # https://projects.theforeman.org/issues/36113
   end
 end

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -331,12 +331,33 @@ describe 'foreman' do
       end
 
       describe 'with rails_cache_store redis' do
+        let(:params) { super().merge(rails_cache_store: { type: "redis" }) }
+        it 'should set rails_cache_store config' do
+          should contain_concat__fragment('foreman_settings+01-header.yaml')
+            .with_content(%r{^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis://localhost:6379/0\n\s+:options:\n\s+:compress:\s*true\n\s+:namespace:\s*foreman$})
+        end
+        it { is_expected.to contain_package('foreman-redis') }
+
+        describe 'without dynflow managing redis' do
+          let(:params) { super().merge(dynflow_manage_services: false) }
+
+          it { is_expected.to contain_class('redis') }
+        end
+      end
+
+      describe 'with rails_cache_store redis with explicit URL' do
         let(:params) { super().merge(rails_cache_store: { type: "redis", urls: [ "redis.example.com/0" ]}) }
         it 'should set rails_cache_store config' do
           should contain_concat__fragment('foreman_settings+01-header.yaml')
             .with_content(/^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis:\/\/redis.example.com\/0\n\s+:options:\n\s+:compress:\s*true\n\s+:namespace:\s*foreman$/)
         end
         it { is_expected.to contain_package('foreman-redis') }
+
+        describe 'without dynflow managing redis' do
+          let(:params) { super().merge(dynflow_manage_services: false) }
+
+          it { is_expected.not_to contain_class('redis') }
+        end
       end
 
       describe 'with rails_cache_store redis with options' do

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -101,12 +101,8 @@
   :type: <%= scope["foreman::rails_cache_store"]["type"] %>
 <% if scope["foreman::rails_cache_store"]["type"] == "redis" -%>
   :urls:
-<%   if scope["foreman::rails_cache_store"].key?("urls") -%>
-<%     scope["foreman::rails_cache_store"]["urls"].each do |url| -%>
-    - redis://<%= url %>
-<%     end -%>
-<%   else -%>
-    - redis://localhost:8479/0
+<%   @redis_cache_urls.each do |url| -%>
+    - <%= url %>
 <%   end -%>
   :options:
 <%   if scope["foreman::rails_cache_store"].key?("options") -%>


### PR DESCRIPTION
This automatically manages Redis when the cache store type is set to Redis, but no URLs have been provided. It's assumed that when a URL is provided that the service is managed in another way.

This ignores the edge case where the user wants to run it on localhost, but with a different database than 0.

Currently a draft since it doesn't have tests and I haven't verified it yet. The end goal of this is that we can set up Redis caching by default. File based caching is just not the right fit for large deployments, even if it's stored in tmpfs.