### PR TITLE
Bump puppetlabs/apache to < 10.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-apache/commit/6130c0e9ddb8bc0d50d69d49b545f34c2762430a rev'ed that module to 9.0.0, making metadata.json here be behind the times.

I don't know if there's knock-on effects / things you need to do before landing this, but, wanted to at least note the disconnect.