### PR TITLE
Fixes #36090 - Support REX cockpit removal

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -44,7 +44,7 @@ define foreman::plugin (
 
   if $config {
     file { $config_file:
-      ensure  => file,
+      ensure  => bool2str($version == 'absent', 'absent', 'file'),
       owner   => $config_file_owner,
       group   => $config_file_group,
       mode    => $config_file_mode,

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -114,6 +114,22 @@ describe 'foreman::plugin::remote_execution::cockpit' do
             .that_notifies('Service[foreman-cockpit]')
         end
       end
+
+      describe 'ensure absent' do
+        let(:params) do
+          {
+            ensure: 'absent',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_class('foreman::plugin::remote_execution') }
+        it { is_expected.to contain_foreman__plugin('remote_execution-cockpit').with_version('absent') }
+        it { is_expected.not_to contain_service('foreman-cockpit') }
+        it { is_expected.to contain_file('/etc/foreman/cockpit/cockpit.conf').with_ensure('absent') }
+        it { is_expected.to contain_file('/etc/foreman/cockpit/foreman-cockpit-session.yml').with_ensure('absent') }
+        it { is_expected.to contain_foreman_config_entry('remote_execution_cockpit_url').with_value('') }
+      end
     end
   end
 end

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -77,6 +77,20 @@ describe 'foreman::plugin' do
             .that_requires('Package[myplugin]')
         end
       end
+
+      context 'ensure absent' do
+        let(:params) do
+          {
+            package: 'myplugin', # fixed to make testing easier
+            version: 'absent',
+            config: 'the config content',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('myplugin').with_ensure('absent') }
+        it { is_expected.to contain_file('/etc/foreman/plugins/foreman_myplugin.yaml').with_ensure('absent') }
+      end
     end
   end
 end


### PR DESCRIPTION
This doesn't deal with the database, but cockpit is a special plugin in that it's a subpackage of the regular Remote Execution plugin.

By default it uses `undef` so you can still set the version globally as well.

While this plugin doesn't use a config file via `foreman::plugin`, I looked at the source and decided to fix that too.