### PR TITLE
Refs #36319 - Add fog_proxmox plugin support

### DIFF
--- a/manifests/plugin/proxmox.pp
+++ b/manifests/plugin/proxmox.pp
@@ -1,0 +1,5 @@
+# = Foreman Proxmox plugin
+class foreman::plugin::proxmox {
+  foreman::plugin { 'fog_proxmox':
+  }
+}

--- a/spec/classes/plugin/proxmox_spec.rb
+++ b/spec/classes/plugin/proxmox_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'foreman::plugin::proxmox' do
+  include_examples 'basic foreman plugin tests', 'fog_proxmox'
+end


### PR DESCRIPTION
In foreman-documentation, we're in the process of adding documentation on how to use Proxmox as compute resource provider in Foreman. See https://github.com/theforeman/foreman-documentation/pull/2142#issuecomment-1505340750