### PR TITLE
Fixes #36645 - Change the default Redis cache DB to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module using the parameter `rails_cache_store`. The parameter takes a hash
 containing the type and options specfic to the backend.
 
 The default is the file backend, configured via `{'type' => 'file'}`. To
-setup for redis use a hash similar to `{'type' => 'redis', 'urls' => ['localhost:8479/0'], 'options' => {'compress' => 'true', 'namespace' => 'foreman'}}`
+setup for redis use a hash similar to `{'type' => 'redis', 'urls' => ['localhost:8479/4'], 'options' => {'compress' => 'true', 'namespace' => 'foreman'}}`
 where `urls` takes an array of redis urls which get prepended with `redis://`
 and `options` using a hash with options from [rails](https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-store)
 falling back to `{'compress' => 'true', 'namespace' => 'foreman'}` if no
@@ -53,7 +53,7 @@ could look like this:
 class { 'foreman':
   rails_cache_store => {
     'type' => 'redis',
-    'urls' => ['localhost:8479/0'],
+    'urls' => ['localhost:8479/4'],
     'options' => {
       'compress' => 'true',
       'namespace' => 'foreman'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,7 @@ class foreman::config {
       $redis_cache_urls = prefix($foreman::rails_cache_store['urls'], 'redis://')
     } else {
       include redis
-      $redis_cache_urls = ["redis://localhost:${redis::port}/0"]
+      $redis_cache_urls = ["redis://localhost:${redis::port}/4"]
     }
   } else {
     $redis_cache_urls =  undef

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -335,7 +335,7 @@ describe 'foreman' do
         let(:params) { super().merge(rails_cache_store: { type: "redis" }) }
         it 'should set rails_cache_store config' do
           should contain_concat__fragment('foreman_settings+01-header.yaml')
-            .with_content(%r{^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis://localhost:6379/0\n\s+:options:\n\s+:compress:\s*true\n\s+:namespace:\s*foreman$})
+            .with_content(%r{^:rails_cache_store:\n\s+:type:\s*redis\n\s+:urls:\n\s*- redis://localhost:6379/4\n\s+:options:\n\s+:compress:\s*true\n\s+:namespace:\s*foreman$})
         end
         it { is_expected.to contain_package('foreman-redis') }
 


### PR DESCRIPTION
On a typical Katello installation Dynflow uses DB 6 and Pulp uses DB 8. Other applications may also use the default DB. Using DB 4 should not conflict.

@evgeni this is something you raised yesterday.

This probably deserves a release note. We should also consider cleaning up the old DB. By default Redis is configured for persistence so it should remain even after a restart. According to the internet using `redis-cli -n 0 flushdb` should do that. I don't think it's something we want to do automatically. If users don't do this, they will expire eventually anyway and the cache is not that large.