### PR TITLE
Fixes #36582 - Detect logging layout based on type

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,6 +35,14 @@ class foreman::config {
   $websockets_ssl_cert = pick($foreman::websockets_ssl_cert, $foreman::server_ssl_cert)
   $websockets_ssl_key = pick($foreman::websockets_ssl_key, $foreman::server_ssl_key)
 
+  if $foreman::logging_layout {
+    $logging_layout = $foreman::logging_layout
+  } elsif $foreman::logging_type == 'journald' {
+    $logging_layout = 'pattern'
+  } else {
+    $logging_layout = 'multiline_request_pattern'
+  }
+
   foreman::settings_fragment { 'header.yaml':
     content => template('foreman/settings.yaml.erb'),
     order   => '01',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -261,7 +261,7 @@ class foreman (
   Optional[Stdlib::Absolutepath] $websockets_ssl_cert = undef,
   Enum['debug', 'info', 'warn', 'error', 'fatal'] $logging_level = 'info',
   Enum['file', 'syslog', 'journald'] $logging_type = 'file',
-  Enum['pattern', 'multiline_pattern', 'multiline_request_pattern', 'json'] $logging_layout = 'multiline_request_pattern',
+  Optional[Enum['pattern', 'multiline_pattern', 'multiline_request_pattern', 'json']] $logging_layout = undef,
   Hash[String, Boolean] $loggers = {},
   Optional[Enum['sendmail', 'smtp']] $email_delivery_method = undef,
   Optional[Stdlib::Absolutepath] $email_sendmail_location = undef,

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -38,6 +38,7 @@ describe 'foreman' do
             .with_content(%r{^:ssl_ca_file:\s*/etc/puppetlabs/puppet/ssl/certs/ca.pem$})
             .with_content(%r{^:ssl_priv_key:\s*/etc/puppetlabs/puppet/ssl/private_keys/foo\.example\.com\.pem$})
             .with_content(/^:logging:\n\s*:level:\s*info$/)
+            .with_content(/^\s+:layout:\s+multiline_request_pattern$/)
             .with_content(/^:hsts_enabled:\s*true$/)
 
           should contain_concat('/etc/foreman/settings.yaml')
@@ -278,7 +279,7 @@ describe 'foreman' do
                                             '  :level: info',
                                             '  :production:',
                                             '    :type: journald',
-                                            '    :layout: multiline_request_pattern'
+                                            '    :layout: pattern'
                                           ])
         end
       end

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -34,7 +34,7 @@
   :level: <%= scope.lookupvar("foreman::logging_level") %>
   :production:
     :type: <%= scope.lookupvar("foreman::logging_type") %>
-    :layout: <%= scope.lookupvar("foreman::logging_layout") %>
+    :layout: <%= @logging_layout %>
 
 <% unless scope.lookupvar('foreman::cors_domains').empty? -%>
 # List of domains allowed for Cross-Origin Resource Sharing


### PR DESCRIPTION
When the file logger is used the multiline_request_pattern layout should be used by default, but with journald the request ID is already stored as structured data with the log, so the pattern layout is better. The the best layout for the logging type is now used if no layout is specified.