### PR TITLE
require puppetlabs/stdlib 9.x 

### DIFF
--- a/manifests/providers.pp
+++ b/manifests/providers.pp
@@ -16,7 +16,7 @@ class foreman::providers (
   String $oauth_package = $foreman::providers::params::oauth_package,
 ) inherits foreman::providers::params {
   if $oauth {
-    ensure_packages([$oauth_package])
+    stdlib::ensure_packages([$oauth_package])
     anchor { 'foreman::providers::oauth': } # lint:ignore:anchor_resource
     Anchor <| title == 'foreman::repo' |> -> Package[$oauth_package] -> Anchor['foreman::providers::oauth']
   }

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/extlib",

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 9.0.0"
+      "version_requirement": ">= 1.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/postgresql",


### PR DESCRIPTION
The `ensure_packages()` function is deprecated. The successor is `stdlib::ensure_packages().