### PR TITLE
Allow puppet/systemd 5.x and 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.1.0 < 5.0.0"
+      "version_requirement": ">= 3.1.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
5.x dropped Puppet 6 support, which we don't support anyway
6.x dropped Ubuntu 18.04 support, which we should drop soon