### PR TITLE
correct sendmail configuration

### DIFF
--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -262,8 +262,8 @@ describe 'foreman' do
 
         it 'should configure certificates in settings.yaml' do
           is_expected.to contain_concat__fragment('foreman_settings+01-header.yaml')
-            .with_content(%r{^:email_sendmail_location: "/usr/bin/mysendmail"$})
-            .with_content(%r{^:email_sendmail_arguments: "--myargument"$})
+            .with_content(%r{^:sendmail_location: "/usr/bin/mysendmail"$})
+            .with_content(%r{^:sendmail_arguments: "--myargument"$})
             .with_content(%r{^:websockets_ssl_key: /etc/ssl/private/snakeoil-ws\.pem$})
             .with_content(%r{^:websockets_ssl_cert: /etc/ssl/certs/snakeoil-ws\.pem$})
         end

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -85,10 +85,10 @@
 
 # Email settings
 <% if scope.lookupvar("foreman::email_sendmail_location") -%>
-:email_sendmail_location: "<%= scope.lookupvar("foreman::email_sendmail_location") %>"
+:sendmail_location: "<%= scope.lookupvar("foreman::email_sendmail_location") %>"
 <% end -%>
 <% if scope.lookupvar("foreman::email_sendmail_arguments") -%>
-:email_sendmail_arguments: "<%= scope.lookupvar("foreman::email_sendmail_arguments") %>"
+:sendmail_arguments: "<%= scope.lookupvar("foreman::email_sendmail_arguments") %>"
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
the `email_` prefix is wrong, the settings have no such prefix

Fixes: 6c902a4f1f484137ebccafe4d3390881fd0b3d61