### PR TITLE
Fix postgresql service name in test expectations

### DIFF
--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -138,7 +138,7 @@ describe 'foreman' do
             .with_queues(['dynflow_orchestrator'])
         }
         it {
-          is_expected.to contain_service('postgresqld')
+          is_expected.to contain_service('postgresqld_instance_main')
             .that_notifies('Service[dynflow-sidekiq@orchestrator]')
         }
         it { should contain_foreman__dynflow__worker('worker').with_ensure('absent') }


### PR DESCRIPTION
The puppetlabs/postgresql module has been refactored for multi-instance support. This means the internal implementation detail was changed.