### PR TITLE
Use JSON to parse Foreman API responses

### DIFF
--- a/lib/puppet/functions/foreman/foreman.rb
+++ b/lib/puppet/functions/foreman/foreman.rb
@@ -87,7 +87,7 @@ Puppet::Functions.create_function(:'foreman::foreman') do
         http.use_ssl = true if uri.scheme == 'https'
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
       end
-      results = Timeout::timeout(timeout) { PSON.parse http.request(req).body }
+      results = Timeout::timeout(timeout) { JSON.parse http.request(req).body }
     rescue Exception => e
       raise Puppet::ParseError, "Failed to contact Foreman at #{foreman_url}: #{e}"
     end

--- a/lib/puppet/functions/foreman/smartvar.rb
+++ b/lib/puppet/functions/foreman/smartvar.rb
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:'foreman::smartvar') do
     req['Accept'] = 'application/json'
 
     begin
-      Timeout::timeout(5) { PSON.parse(http.request(req).body)["value"] }
+      Timeout::timeout(5) { JSON.parse(http.request(req).body)["value"] }
     rescue Exception => e
       raise Puppet::ParseError, "Failed to contact Foreman #{e}"
     end


### PR DESCRIPTION
The PSON parser is deprecated and Foreman doesn't actually send PSON; it sends JSON.

See https://www.puppet.com/docs/puppet/8/http_api/pson.html