### PR TITLE
Only install dnf module on EL8

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -21,7 +21,7 @@ class foreman::repo (
       before           => Anchor['foreman::repo'],
     }
 
-    if $facts['os']['family'] == 'RedHat' {
+    if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8' {
       package { 'foreman':
         ensure      => "el${facts['os']['release']['major']}",
         enable_only => true,


### PR DESCRIPTION
We don't intend to use modularity on the initial release, so scope this to only EL8.