### PR TITLE
Let systemd relationship handle dynflow restarts

### DIFF
--- a/manifests/dynflow/worker.pp
+++ b/manifests/dynflow/worker.pp
@@ -47,7 +47,7 @@ define foreman::dynflow::worker (
       content => foreman::to_symbolized_yaml($config),
     }
     ~> service { $service:
-      ensure    => running,
+      ensure    => true,
       enable    => true,
       subscribe => Class['foreman::database'],
     }


### PR DESCRIPTION
When all services are stopped, a puppet run of this module (or the installer) will trigger services to start back up. Since I believe Puppet detects this as the start, this results in a restart of Foreman and Dynflow:

[28.25 seconds] /Service[foreman]: 
[27.37 seconds] /Service[dynflow-sidekiq@orchestrator]: 
[26.42 seconds] /Service[dynflow-sidekiq@worker-hosts-queue-1]: 
[26.32 seconds] /Service[dynflow-sidekiq@worker-1]: 

Via systemd relationships, dynflow is already part of Foreman (https://github.com/theforeman/foreman/blob/develop/extras/systemd/dynflow-sidekiq%40.service#L5) which means that anytime `foreman.service` receives a restart the dynflow*  services will also get restarted. By allowing systemd to control this rather than Puppet, we can save ~1.5 minutes on my test system.