### PR TITLE
Fixes #37211 - Add ProxyPass for /images to support avatars

### DIFF
--- a/manifests/config/apache.pp
+++ b/manifests/config/apache.pp
@@ -99,7 +99,7 @@ class foreman::config::apache (
   Pattern['^(https?|unix)://'] $proxy_backend = 'unix:///run/foreman.sock',
   Boolean $proxy_add_headers = true,
   Hash $proxy_params = { 'retry' => '0' },
-  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pub', '/icons', '/server-status'],
+  Array[String] $proxy_no_proxy_uris = ['/pulp', '/pub', '/icons', '/images', '/server-status'],
   Boolean $proxy_assets = false,
   Boolean $ssl = false,
   Optional[Stdlib::Absolutepath] $ssl_ca = undef,

--- a/spec/classes/foreman_config_apache_spec.rb
+++ b/spec/classes/foreman_config_apache_spec.rb
@@ -63,7 +63,7 @@ describe 'foreman::config::apache' do
             'unset REMOTE_USER_GROUPS'
           ])
           .with_proxy_pass(
-            "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/server-status', '/webpack', '/assets'],
+            "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/images', '/server-status', '/webpack', '/assets'],
             "path"          => '/',
             "url"           => 'unix:///run/foreman.sock|http://foreman/',
             "params"        => { "retry" => '0' },
@@ -136,7 +136,7 @@ describe 'foreman::config::apache' do
 
         it { should contain_apache__vhost('foreman')
             .with_proxy_pass(
-              "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/server-status'],
+              "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/images', '/server-status'],
               "path"          => '/',
               "url"           => 'unix:///run/foreman.sock|http://foreman/',
               "params"        => { "retry" => '0' },
@@ -200,7 +200,7 @@ describe 'foreman::config::apache' do
             ])
             .with_ssl_proxyengine(true)
             .with_proxy_pass(
-              "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/server-status', '/webpack', '/assets'],
+              "no_proxy_uris" => ['/pulp', '/pub', '/icons', '/images', '/server-status', '/webpack', '/assets'],
               "path"          => '/',
               "url"           => 'unix:///run/foreman.sock|http://foreman/',
               "params"        => { "retry" => '0' },


### PR DESCRIPTION
See https://community.theforeman.org/t/user-avatar-support-in-the-foreman-keep-it-or-drop-it/32271