### PR TITLE
Allow puppetlabs/apache 12.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 8.0.0 < 12.0.0"
+      "version_requirement": ">= 8.0.0 < 13.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
We need 12.0.3+ for Puppet 8 support due to https://github.com/puppetlabs/puppetlabs-apache/pull/2525