### PR TITLE
Fixes #33974 - Change the pool size to threads + 4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,7 +68,15 @@ class foreman::config {
     'database'  => $foreman::db_database,
     'username'  => $foreman::db_username,
     'password'  => $foreman::db_password,
-    'db_pool'   => max($foreman::db_pool, $foreman::foreman_service_puma_threads_max),
+    # Set the pool size to at least the amount of puma threads + 4 threads that are spawned automatically by the process.
+    # db_pool is optional, and undef means "use default" and the second part of the max statement will be set.
+    # The number 4 is for 4 threads that are spawned internally during the execution:
+    # 1. Katello event daemon listener
+    # 2. Katello event monitor poller
+    # 3. Stomp listener (required by Katello)
+    # 4. Puma server listener thread
+    # This means for systems without Katello we can reduce the amount of the pool to puma_threads_max + 1
+    'db_pool'   => pick($foreman::db_pool, $foreman::foreman_service_puma_threads_max + 4),
   }
 
   file { '/etc/foreman/database.yml':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,8 +84,8 @@
 #
 # $db_root_cert::                 Root cert used to verify SSL connection to postgres
 #
-# $db_pool::                      Database 'production' size of connection pool. When running as a reverse proxy,
-#                                 the value of `$foreman_service_puma_threads_max` is used if it's higher than `$db_pool`.
+# $db_pool::                      Database 'production' size of connection pool. If the value is not set, it will be
+#                                 set by default to the amount of puma threads + 4 (for internal system threads)
 #
 # $db_manage_rake::               if enabled, will run rake jobs, which depend on the database
 #
@@ -226,7 +226,7 @@ class foreman (
   String[1] $db_password = $foreman::params::db_password,
   Optional[String[1]] $db_sslmode = undef,
   Optional[String[1]] $db_root_cert = undef,
-  Integer[0] $db_pool = 5,
+  Optional[Integer[0]] $db_pool = undef,
   Boolean $db_manage_rake = true,
   Stdlib::Port $server_port = 80,
   Stdlib::Port $server_ssl_port = 443,

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -199,7 +199,7 @@ describe 'foreman' do
             db_username: 'foreman',
             db_password: 'secret',
             db_sslmode: 'prefer',
-            db_pool: 5,
+            db_pool: 9,
             db_manage_rake: true,
             server_port: 80,
             server_ssl_port: 443,


### PR DESCRIPTION
According to an investigation described in https://community.theforeman.org/t/rails-connection-pool-size-optimizations/36675 foreman process spawns 4 additional threads that consume DB connection during the startup. Hence the amount of acctive DB connections should be the amount of puma threads + 4 additional threads.