### PR TITLE
Allow puppet/systemd 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.1.0 < 7.0.0"
+      "version_requirement": ">= 3.1.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
systemd has moved forward, allow this module to follow along.