### PR TITLE
Add AlmaLinux 8 & 9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,6 +79,13 @@
         "20.04",
         "22.04"
       ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added AlmaLinux 8 and 9 to the supported operating systems in metadata.json.

These changes ensure that we start testing with AlmaLinux 8 and 9 instead of CentOS 8 Stream. This update is part of our transition to better support AlmaLinux in our Puppet modules.

See, for details: https://github.com/theforeman/foreman-infra/issues/2087