### PR TITLE
Fixes #37761 - use ProxyPass and upgrade=websocket where possible

### DIFF
--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -72,11 +72,16 @@ class foreman::plugin::remote_execution::cockpit (
       require        => Class['foreman::database'],
     }
   } else {
-    include apache::mod::rewrite
-    include apache::mod::proxy_wstunnel
     include apache::mod::proxy_http
+    if $foreman::config::apache::proxy_upgrade_websocket {
+      $_apache_template = 'cockpit-apache-ssl.conf.erb'
+    } else {
+      include apache::mod::rewrite
+      include apache::mod::proxy_wstunnel
+      $_apache_template = 'cockpit-apache-ssl-rewrite.conf.erb'
+    }
     foreman::config::apache::fragment { 'cockpit':
-      ssl_content => template('foreman/cockpit-apache-ssl.conf.erb'),
+      ssl_content => template("foreman/${_apache_template}"),
     }
 
     foreman_config_entry { 'remote_execution_cockpit_url':

--- a/templates/cockpit-apache-ssl-rewrite.conf.erb
+++ b/templates/cockpit-apache-ssl-rewrite.conf.erb
@@ -1,0 +1,11 @@
+### File managed with puppet ###
+
+<Location <%= @cockpit_path %>>
+  ProxyPreserveHost On
+
+  RewriteEngine On
+  RewriteCond %{HTTP:Upgrade} =websocket [NC]
+  RewriteRule <%= @cockpit_path %>/(.*)           ws://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>/$1 [P]
+
+  ProxyPass http://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>
+</Location>

--- a/templates/cockpit-apache-ssl.conf.erb
+++ b/templates/cockpit-apache-ssl.conf.erb
@@ -2,10 +2,5 @@
 
 <Location <%= @cockpit_path %>>
   ProxyPreserveHost On
-
-  RewriteEngine On
-  RewriteCond %{HTTP:Upgrade} =websocket [NC]
-  RewriteRule <%= @cockpit_path %>/(.*)           ws://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>/$1 [P]
-  RewriteCond %{HTTP:Upgrade} !=websocket [NC]
-  RewriteRule <%= @cockpit_path %>/(.*)           http://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %>/$1 [P]
+  ProxyPass http://<%= @cockpit_host %>:<%= @cockpit_port %><%= @cockpit_path %> upgrade=websocket
 </Location>


### PR DESCRIPTION
    RewriteRules need special handling of some characters (esp "?"), which
    differs based on Apache version. Instead of going down that way, we can
    switch to using ProxyPass as proxying is the only thing we really need
    here, at least for HTTP.
    
    For WebSockets, we need to allow protocol upgrades, which modern
    (2.4.47+) Apache can do itself via "ProxyPass … upgrade=websocket".
    For older Apache (esp on EL8 and Ubuntu 20.04), we keep the RewriteRules
    in place. To be removed when we drop support for those targets.
    
    Co-Authored-By: Adam Ruzicka <aruzicka@redhat.com>
