### PR TITLE
add support for plugin `ensure` stage *purged*

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,7 +1,7 @@
 # @summary Manages a plugin installation and optionally its configuration
 #
 # @param version
-#   The version to ensure
+#   The version to ensure, or absent/purged to remove it
 #
 # @param package
 #   The package to manage
@@ -43,8 +43,10 @@ define foreman::plugin (
   }
 
   if $config {
+    $config_file_absent = $version in ['absent', 'purged']
+
     file { $config_file:
-      ensure  => bool2str($version == 'absent', 'absent', 'file'),
+      ensure  => bool2str($config_file_absent, 'absent', 'file'),
       owner   => $config_file_owner,
       group   => $config_file_group,
       mode    => $config_file_mode,

--- a/manifests/plugin/remote_execution/cockpit.pp
+++ b/manifests/plugin/remote_execution/cockpit.pp
@@ -9,13 +9,15 @@
 #
 # === Advanced parameters:
 #
-# $ensure::              Specify the package state, or absent to remove it
+# $ensure::              Specify the package state, or absent/purged to remove it
 #
 class foreman::plugin::remote_execution::cockpit (
   Optional[String[1]] $ensure = undef,
   Array[Stdlib::HTTPUrl] $origins = [],
 ) {
-  if $ensure != 'absent' {
+  $ensure_absent = $ensure in ['absent', 'purged']
+
+  unless $ensure_absent {
     require foreman::plugin::remote_execution
   }
 
@@ -36,7 +38,7 @@ class foreman::plugin::remote_execution::cockpit (
     version => $ensure,
   }
 
-  if $ensure != 'absent' {
+  unless $ensure_absent {
     service { 'foreman-cockpit':
       ensure    => running,
       enable    => true,
@@ -45,7 +47,7 @@ class foreman::plugin::remote_execution::cockpit (
     }
   }
 
-  $file_ensure = bool2str($ensure == 'absent', 'absent', 'file')
+  $file_ensure = bool2str($ensure_absent, 'absent', 'file')
 
   file { "${config_directory}/cockpit.conf":
     ensure  => $file_ensure,
@@ -65,7 +67,7 @@ class foreman::plugin::remote_execution::cockpit (
     require => Foreman::Plugin['remote_execution-cockpit'],
   }
 
-  if $ensure == 'absent' {
+  if $ensure_absent {
     foreman_config_entry { 'remote_execution_cockpit_url':
       value          => '',
       ignore_missing => true,

--- a/spec/classes/plugin/remote_execution_cockpit_spec.rb
+++ b/spec/classes/plugin/remote_execution_cockpit_spec.rb
@@ -139,6 +139,22 @@ describe 'foreman::plugin::remote_execution::cockpit' do
         it { is_expected.to contain_file('/etc/foreman/cockpit/foreman-cockpit-session.yml').with_ensure('absent') }
         it { is_expected.to contain_foreman_config_entry('remote_execution_cockpit_url').with_value('') }
       end
+
+      describe 'ensure purged' do
+        let(:params) do
+          {
+            ensure: 'purged',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_class('foreman::plugin::remote_execution') }
+        it { is_expected.to contain_foreman__plugin('remote_execution-cockpit').with_version('purged') }
+        it { is_expected.not_to contain_service('foreman-cockpit') }
+        it { is_expected.to contain_file('/etc/foreman/cockpit/cockpit.conf').with_ensure('absent') }
+        it { is_expected.to contain_file('/etc/foreman/cockpit/foreman-cockpit-session.yml').with_ensure('absent') }
+        it { is_expected.to contain_foreman_config_entry('remote_execution_cockpit_url').with_value('') }
+      end
     end
   end
 end

--- a/spec/defines/foreman_plugin_spec.rb
+++ b/spec/defines/foreman_plugin_spec.rb
@@ -91,6 +91,20 @@ describe 'foreman::plugin' do
         it { is_expected.to contain_package('myplugin').with_ensure('absent') }
         it { is_expected.to contain_file('/etc/foreman/plugins/foreman_myplugin.yaml').with_ensure('absent') }
       end
+
+      context 'ensure purged' do
+        let(:params) do
+          {
+            package: 'myplugin', # fixed to make testing easier
+            version: 'purged',
+            config: 'the config content',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('myplugin').with_ensure('purged') }
+        it { is_expected.to contain_file('/etc/foreman/plugins/foreman_myplugin.yaml').with_ensure('absent') }
+      end
     end
   end
 end


### PR DESCRIPTION
the package resource type supports the following values for the `ensure` parameter:

*    present
*    absent
*    purged
*    disabled
*    installed
*    latest
*    /./

this change adds support for *purged* as it has the same effect in the context of this module.