### PR TITLE
add support for managing individual plugin versions

### DIFF
--- a/manifests/plugin/acd.pp
+++ b/manifests/plugin/acd.pp
@@ -1,8 +1,16 @@
 # Installs foreman_acd plugin
-class foreman::plugin::acd {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::acd (
+  Optional[String[1]] $ensure = undef,
+) {
   include foreman::plugin::tasks
   include foreman::plugin::remote_execution
 
   foreman::plugin { 'acd':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/ansible.pp
+++ b/manifests/plugin/ansible.pp
@@ -1,7 +1,15 @@
 # Installs foreman_ansible plugin
-class foreman::plugin::ansible {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::ansible (
+  Optional[String[1]] $ensure = undef,
+) {
   include foreman::plugin::tasks
 
   foreman::plugin { 'ansible':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/azure.pp
+++ b/manifests/plugin/azure.pp
@@ -1,5 +1,13 @@
 # Installs foreman_azure_rm plugin
-class foreman::plugin::azure {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::azure (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'azure_rm':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/bootdisk.pp
+++ b/manifests/plugin/bootdisk.pp
@@ -1,5 +1,13 @@
 # Installs foreman_bootdisk plugin
-class foreman::plugin::bootdisk {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::bootdisk (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'bootdisk':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/datacenter.pp
+++ b/manifests/plugin/datacenter.pp
@@ -1,4 +1,13 @@
 # Installs foreman_datacenter plugin
-class foreman::plugin::datacenter {
-  foreman::plugin { 'datacenter': }
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::datacenter (
+  Optional[String[1]] $ensure = undef,
+) {
+  foreman::plugin { 'datacenter':
+    version => $ensure,
+  }
 }

--- a/manifests/plugin/default_hostgroup.pp
+++ b/manifests/plugin/default_hostgroup.pp
@@ -1,8 +1,10 @@
 # @summary This class installs the default_hostgroup plugin and optionally manages the configuration file
 #
 # @param hostgroups An array of hashes of hostgroup names and facts to add to the configuration
+# @param ensure Specify the package state, or absent/purged to remove it
 #
 class foreman::plugin::default_hostgroup (
+  Optional[String[1]] $ensure = undef,
   Array[Hash[String, Hash]] $hostgroups = [],
 ) {
   if empty($hostgroups) {
@@ -12,6 +14,7 @@ class foreman::plugin::default_hostgroup (
   }
 
   foreman::plugin { 'default_hostgroup':
+    version     => $ensure,
     config      => $config,
     config_file => "${foreman::plugin_config_dir}/default_hostgroup.yaml",
   }

--- a/manifests/plugin/dhcp_browser.pp
+++ b/manifests/plugin/dhcp_browser.pp
@@ -1,4 +1,13 @@
 # Installs foreman_dhcp_browser plugin
-class foreman::plugin::dhcp_browser {
-  foreman::plugin { 'dhcp_browser': }
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::dhcp_browser (
+  Optional[String[1]] $ensure = undef,
+) {
+  foreman::plugin { 'dhcp_browser':
+    version => $ensure,
+  }
 }

--- a/manifests/plugin/discovery.pp
+++ b/manifests/plugin/discovery.pp
@@ -2,7 +2,15 @@
 #
 # This class installs discovery plugin and images
 #
-class foreman::plugin::discovery {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::discovery (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'discovery':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/dlm.pp
+++ b/manifests/plugin/dlm.pp
@@ -1,5 +1,13 @@
 # Installs foreman_dlm plugin
-class foreman::plugin::dlm {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::dlm (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'dlm':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/expire_hosts.pp
+++ b/manifests/plugin/expire_hosts.pp
@@ -1,5 +1,13 @@
 # Installs foreman_expire_hosts plugin
-class foreman::plugin::expire_hosts {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::expire_hosts (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'expire_hosts':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/git_templates.pp
+++ b/manifests/plugin/git_templates.pp
@@ -2,7 +2,15 @@
 #
 # This class installs git_templates plugin
 #
-class foreman::plugin::git_templates {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::git_templates (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'git_templates':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/google.pp
+++ b/manifests/plugin/google.pp
@@ -1,5 +1,13 @@
 # Installs foreman_google plugin
-class foreman::plugin::google {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::google (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'google':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/hdm.pp
+++ b/manifests/plugin/hdm.pp
@@ -1,6 +1,14 @@
 # @summary Install the Hiera Data Manager (HDM) plugin
 #
-class foreman::plugin::hdm {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::hdm (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'hdm':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/host_extra_validator.pp
+++ b/manifests/plugin/host_extra_validator.pp
@@ -1,5 +1,13 @@
 # Installs foreman_host_extra_validator plugin
-class foreman::plugin::host_extra_validator {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::host_extra_validator (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'host_extra_validator':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/kernel_care.pp
+++ b/manifests/plugin/kernel_care.pp
@@ -1,5 +1,13 @@
 # Installs foreman_kernel_care plugin
-class foreman::plugin::kernel_care {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::kernel_care (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'kernel_care':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/kubevirt.pp
+++ b/manifests/plugin/kubevirt.pp
@@ -1,5 +1,13 @@
 # Installs foreman_kubevirt plugin
-class foreman::plugin::kubevirt {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::kubevirt (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'kubevirt':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/leapp.pp
+++ b/manifests/plugin/leapp.pp
@@ -1,8 +1,16 @@
 # Installs foreman_leapp plugin
-class foreman::plugin::leapp {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::leapp (
+  Optional[String[1]] $ensure = undef,
+) {
   include foreman::plugin::remote_execution
   include foreman::plugin::ansible
 
   foreman::plugin { 'leapp':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/monitoring.pp
+++ b/manifests/plugin/monitoring.pp
@@ -1,5 +1,13 @@
 # Installs foreman_monitoring plugin
-class foreman::plugin::monitoring {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::monitoring (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'monitoring':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/netbox.pp
+++ b/manifests/plugin/netbox.pp
@@ -2,7 +2,15 @@
 #
 # This class installs netbox plugin
 #
-class foreman::plugin::netbox {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::netbox (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'netbox':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/omaha.pp
+++ b/manifests/plugin/omaha.pp
@@ -1,5 +1,13 @@
 # Installs foreman_omaha plugin
-class foreman::plugin::omaha {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::omaha (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'omaha':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/openscap.pp
+++ b/manifests/plugin/openscap.pp
@@ -4,6 +4,15 @@
 #
 # === Parameters:
 #
-class foreman::plugin::openscap {
-  foreman::plugin { 'openscap': }
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::openscap (
+  Optional[String[1]] $ensure = undef,
+) {
+  foreman::plugin { 'openscap':
+    version => $ensure,
+  }
 }

--- a/manifests/plugin/ovirt_provision.pp
+++ b/manifests/plugin/ovirt_provision.pp
@@ -1,6 +1,14 @@
 # @summary install the ovirt_provision plugin
-class foreman::plugin::ovirt_provision {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::ovirt_provision (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'ovirt_provision':
+    version => $ensure,
     package => $foreman::params::plugin_prefix.regsubst(/foreman[_-]/, 'ovirt_provision_plugin'),
   }
 }

--- a/manifests/plugin/proxmox.pp
+++ b/manifests/plugin/proxmox.pp
@@ -1,5 +1,13 @@
 # = Foreman Proxmox plugin
-class foreman::plugin::proxmox {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::proxmox (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'fog_proxmox':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/puppet.pp
+++ b/manifests/plugin/puppet.pp
@@ -2,7 +2,15 @@
 #
 # This class installs puppet plugin
 #
-class foreman::plugin::puppet {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::puppet (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'puppet':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/puppetdb.pp
+++ b/manifests/plugin/puppetdb.pp
@@ -15,7 +15,11 @@
 # @param api_version
 #   PuppetDB API version.
 #
+# @param ensure
+#    Specify the package state, or absent/purged to remove it
+#
 class foreman::plugin::puppetdb (
+  Optional[String[1]] $ensure = undef,
   Stdlib::HTTPUrl $address = 'https://localhost:8081/pdb/cmd/v1',
   String $ssl_ca_file = $foreman::params::client_ssl_ca,
   String $ssl_certificate = $foreman::params::client_ssl_cert,
@@ -23,6 +27,7 @@ class foreman::plugin::puppetdb (
   Enum['1', '3', '4'] $api_version = '4',
 ) inherits foreman::params {
   foreman::plugin { 'puppetdb':
+    version => $ensure,
     package => $foreman::params::plugin_prefix.regsubst(/foreman[_-]/, 'puppetdb_foreman'),
   }
 

--- a/manifests/plugin/remote_execution.pp
+++ b/manifests/plugin/remote_execution.pp
@@ -1,7 +1,15 @@
 # Installs foreman_remote_execution plugin
-class foreman::plugin::remote_execution {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::remote_execution (
+  Optional[String[1]] $ensure = undef,
+) {
   include foreman::plugin::tasks
 
   foreman::plugin { 'remote_execution':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/rescue.pp
+++ b/manifests/plugin/rescue.pp
@@ -1,5 +1,13 @@
 # Installs foreman_rescue plugin
-class foreman::plugin::rescue {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::rescue (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'rescue':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/rh_cloud.pp
+++ b/manifests/plugin/rh_cloud.pp
@@ -1,5 +1,13 @@
 # Installs rh_cloud plugin
-class foreman::plugin::rh_cloud {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::rh_cloud (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'rh_cloud':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/salt.pp
+++ b/manifests/plugin/salt.pp
@@ -1,7 +1,15 @@
 # Installs foreman_salt plugin
-class foreman::plugin::salt {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::salt (
+  Optional[String[1]] $ensure = undef,
+) {
   include foreman::plugin::tasks
 
   foreman::plugin { 'salt':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/scc_manager.pp
+++ b/manifests/plugin/scc_manager.pp
@@ -2,7 +2,15 @@
 #
 # This class installs scc_manager plugin
 #
-class foreman::plugin::scc_manager {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::scc_manager (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'scc_manager':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/snapshot_management.pp
+++ b/manifests/plugin/snapshot_management.pp
@@ -1,5 +1,13 @@
 # Installs foreman_snapshot_management plugin
-class foreman::plugin::snapshot_management {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::snapshot_management (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'snapshot_management':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/statistics.pp
+++ b/manifests/plugin/statistics.pp
@@ -2,7 +2,15 @@
 #
 # This class installs trends and statistics plugin
 #
-class foreman::plugin::statistics {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::statistics (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'statistics':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/supervisory_authority.pp
+++ b/manifests/plugin/supervisory_authority.pp
@@ -28,6 +28,8 @@
 #
 # $metrics_interval::      Specify the interval for reporting metrics to APM Server.
 #
+# $ensure::                Specify the package state, or absent/purged to remove it
+#
 class foreman::plugin::supervisory_authority (
   Stdlib::HTTPUrl              $server_url,
   String                       $secret_token,
@@ -40,6 +42,7 @@ class foreman::plugin::supervisory_authority (
   Integer[0]                   $transaction_max_spans = 500,
   Boolean                      $http_compression      = false,
   String                       $metrics_interval      = '30s',
+  Optional[String[1]]          $ensure                = undef,
 ) {
   $config = {
     foreman_supervisory_authority => {
@@ -58,6 +61,7 @@ class foreman::plugin::supervisory_authority (
   }
 
   foreman::plugin { 'supervisory_authority':
-    config => foreman::to_symbolized_yaml($config),
+    version => $ensure,
+    config  => foreman::to_symbolized_yaml($config),
   }
 }

--- a/manifests/plugin/tasks.pp
+++ b/manifests/plugin/tasks.pp
@@ -9,12 +9,17 @@
 # @param backup
 #   Enable creating a backup of cleaned up tasks in CSV format when automatic_cleanup is enabled
 #
+# @param ensure
+#   Specify the package state, or absent/purged to remove it
+#
 class foreman::plugin::tasks (
+  Optional[String[1]] $ensure = undef,
   Boolean $automatic_cleanup = false,
   String $cron_line = '45 19 * * *',
   Boolean $backup = false,
 ) {
   foreman::plugin { 'tasks':
+    version => $ensure,
     package => $foreman::params::plugin_prefix.regsubst(/foreman[_-]/, 'foreman-tasks'),
   }
   $cron_state = $automatic_cleanup ? {

--- a/manifests/plugin/templates.pp
+++ b/manifests/plugin/templates.pp
@@ -1,5 +1,13 @@
 # Installs foreman_templates plugin
-class foreman::plugin::templates {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::templates (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'templates':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/vault.pp
+++ b/manifests/plugin/vault.pp
@@ -2,7 +2,15 @@
 #
 # This class installs vault plugin
 #
-class foreman::plugin::vault {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::vault (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'vault':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/virt_who_configure.pp
+++ b/manifests/plugin/virt_who_configure.pp
@@ -1,5 +1,13 @@
 # Installs foreman_virt_who_configure plugin
-class foreman::plugin::virt_who_configure {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::virt_who_configure (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'virt_who_configure':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/webhooks.pp
+++ b/manifests/plugin/webhooks.pp
@@ -2,7 +2,15 @@
 #
 # This class installs webhooks plugin
 #
-class foreman::plugin::webhooks {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::webhooks (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'webhooks':
+    version => $ensure,
   }
 }

--- a/manifests/plugin/wreckingball.pp
+++ b/manifests/plugin/wreckingball.pp
@@ -1,5 +1,13 @@
 # Installs foreman_wreckingball plugin
-class foreman::plugin::wreckingball {
+#
+# === Advanced parameters:
+#
+# $ensure::              Specify the package state, or absent/purged to remove it
+#
+class foreman::plugin::wreckingball (
+  Optional[String[1]] $ensure = undef,
+) {
   foreman::plugin { 'wreckingball':
+    version => $ensure,
   }
 }

--- a/spec/classes/plugin/acd_spec.rb
+++ b/spec/classes/plugin/acd_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::acd' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'acd'
   it { should contain_foreman__plugin('tasks') }
   it { should contain_foreman__plugin('remote_execution') }

--- a/spec/classes/plugin/ansible_spec.rb
+++ b/spec/classes/plugin/ansible_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::ansible' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'ansible'
   it { should contain_foreman__plugin('tasks') }
 end

--- a/spec/classes/plugin/azure_spec.rb
+++ b/spec/classes/plugin/azure_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::azure' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'azure_rm'
 end

--- a/spec/classes/plugin/bootdisk_spec.rb
+++ b/spec/classes/plugin/bootdisk_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::bootdisk' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'bootdisk'
 end

--- a/spec/classes/plugin/datacenter.rb
+++ b/spec/classes/plugin/datacenter.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::datacenter' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'datacenter'
 end

--- a/spec/classes/plugin/default_hostgroup_spec.rb
+++ b/spec/classes/plugin/default_hostgroup_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::default_hostgroup' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'default_hostgroup'
 
   context 'with user provided config hash' do

--- a/spec/classes/plugin/dhcp_browser_spec.rb
+++ b/spec/classes/plugin/dhcp_browser_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::dhcp_browser' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'dhcp_browser'
 end

--- a/spec/classes/plugin/discovery_spec.rb
+++ b/spec/classes/plugin/discovery_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::discovery' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'discovery'
 end

--- a/spec/classes/plugin/dlm_spec.rb
+++ b/spec/classes/plugin/dlm_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::dlm' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'dlm'
 end

--- a/spec/classes/plugin/expire_hosts_spec.rb
+++ b/spec/classes/plugin/expire_hosts_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::expire_hosts' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'expire_hosts'
 end

--- a/spec/classes/plugin/git_templates_spec.rb
+++ b/spec/classes/plugin/git_templates_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::git_templates' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'git_templates'
 end

--- a/spec/classes/plugin/google_spec.rb
+++ b/spec/classes/plugin/google_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::google' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'google'
 end

--- a/spec/classes/plugin/hdm_spec.rb
+++ b/spec/classes/plugin/hdm_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::hdm' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'hdm'
 end

--- a/spec/classes/plugin/host_extra_validator_spec.rb
+++ b/spec/classes/plugin/host_extra_validator_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::host_extra_validator' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'host_extra_validator'
 end

--- a/spec/classes/plugin/kernel_care_spec.rb
+++ b/spec/classes/plugin/kernel_care_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::kernel_care' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'kernel_care'
 end

--- a/spec/classes/plugin/kubevirt_spec.rb
+++ b/spec/classes/plugin/kubevirt_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::kubevirt' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'kubevirt'
 end

--- a/spec/classes/plugin/leapp_spec.rb
+++ b/spec/classes/plugin/leapp_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::leapp' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'leapp'
   it { should contain_foreman__plugin('remote_execution') }
   it { should contain_foreman__plugin('ansible') }

--- a/spec/classes/plugin/monitoring_spec.rb
+++ b/spec/classes/plugin/monitoring_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::monitoring' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'monitoring'
 end

--- a/spec/classes/plugin/netbox_spec.rb
+++ b/spec/classes/plugin/netbox_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::netbox' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'netbox'
 end

--- a/spec/classes/plugin/omaha_spec.rb
+++ b/spec/classes/plugin/omaha_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::omaha' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'omaha'
 end

--- a/spec/classes/plugin/proxmox_spec.rb
+++ b/spec/classes/plugin/proxmox_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::proxmox' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'fog_proxmox'
 end

--- a/spec/classes/plugin/puppet_spec.rb
+++ b/spec/classes/plugin/puppet_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::puppet' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'puppet'
 end

--- a/spec/classes/plugin/rescue_spec.rb
+++ b/spec/classes/plugin/rescue_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::rescue' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'rescue'
 end

--- a/spec/classes/plugin/rh_cloud_spec.rb
+++ b/spec/classes/plugin/rh_cloud_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::rh_cloud' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'rh_cloud'
 end

--- a/spec/classes/plugin/salt_spec.rb
+++ b/spec/classes/plugin/salt_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::salt' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'salt'
   it { should contain_foreman__plugin('tasks') }
 end

--- a/spec/classes/plugin/scc_manager_spec.rb
+++ b/spec/classes/plugin/scc_manager_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::scc_manager' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'scc_manager'
 end

--- a/spec/classes/plugin/snapshot_management_spec.rb
+++ b/spec/classes/plugin/snapshot_management_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::snapshot_management' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'snapshot_management'
 end

--- a/spec/classes/plugin/statistics_spec.rb
+++ b/spec/classes/plugin/statistics_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::statistics' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'statistics'
 end

--- a/spec/classes/plugin/templates_spec.rb
+++ b/spec/classes/plugin/templates_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::templates' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'templates'
 end

--- a/spec/classes/plugin/vault_spec.rb
+++ b/spec/classes/plugin/vault_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::vault' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'vault'
 end

--- a/spec/classes/plugin/virt_who_configure_spec.rb
+++ b/spec/classes/plugin/virt_who_configure_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::virt_who_configure' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'virt_who_configure'
 end

--- a/spec/classes/plugin/webhooks_spec.rb
+++ b/spec/classes/plugin/webhooks_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::webhooks' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'webhooks'
 end

--- a/spec/classes/plugin/wreckingball_spec.rb
+++ b/spec/classes/plugin/wreckingball_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe 'foreman::plugin::wreckingball' do
+  let(:params) { {} }
   include_examples 'basic foreman plugin tests', 'wreckingball'
 end

--- a/spec/support/plugin.rb
+++ b/spec/support/plugin.rb
@@ -5,4 +5,15 @@ shared_examples 'basic foreman plugin tests' do |name|
   let(:pre_condition) { 'include foreman' }
   it { should compile.with_all_deps }
   it { should contain_foreman__plugin(name) }
+
+  context 'with ensure = 1.2.3-4' do
+    let(:params) do
+      super().merge(ensure: '1.2.3-4')
+    end
+
+    it do
+      should contain_foreman__plugin(name)
+        .with_version('1.2.3-4')
+    end
+  end
 end


### PR DESCRIPTION
currently on the  remote_execution/cockpit plugin class has support for managing the plugin version. all other plugins are tied to the `foreman::plugin_version`. this change adds the same `ensure` parameter to all plugin classes allowing for granular state management.