### PR TITLE
properly escape quotes in passwords by calling to_ruby

### DIFF
--- a/templates/database.yml.epp
+++ b/templates/database.yml.epp
@@ -30,6 +30,6 @@
   username: <%= $username %>
 <% } -%>
 <% if $password { -%>
-  password: "<%= $password %>"
+  password: <%= stdlib::to_ruby($password) %>
 <% } -%>
   pool: <%= $db_pool %>


### PR DESCRIPTION
database passwords can contain special characters, especially " and '
so we can't just print the value of the field enclosed by double quotes
as that would break whenever the user uses a literal " in their password

using to_ruby here and not to_yaml, as the former gives us correct escaping
without the whole `---` and `\n` enclosing that to_yaml forces.
using to_yaml would require to pass *the whole* config hash to it
