### PR TITLE
fix foreman_rex_cockpit acceptance test

### DIFF
--- a/spec/acceptance/foreman_rex_cockpit_spec.rb
+++ b/spec/acceptance/foreman_rex_cockpit_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper_acceptance'
 
-describe 'Scenario: install foreman with rex cockpit', if: os[:family] == 'centos' do
+describe 'Scenario: install foreman with rex cockpit', if: os[:family] == 'redhat' do
   before(:context) { purge_foreman }
 
-
   it_behaves_like 'an idempotent resource' do
-    let(:pp) do
+    let(:manifest) do
       <<-PUPPET
       include foreman
       include foreman::plugin::remote_execution::cockpit

--- a/spec/support/acceptance/purge.rb
+++ b/spec/support/acceptance/purge.rb
@@ -1,6 +1,7 @@
 def purge_foreman
   case fact('osfamily')
   when 'RedHat'
+    on default, 'rm -f /etc/dnf/protected.d/grub2-tools-minimal.conf'
     on default, 'yum -y remove foreman*'
   when 'Debian'
     on default, 'apt-get purge -y foreman*', { :acceptable_exit_codes => [0, 100] }


### PR DESCRIPTION
1. the family is called `redhat`, not `centos`
2. to apply a manifest, you need to define `manifest` not `pp`
