### PR TITLE
Fixes #38228 - Add Hammer CLI for foreman_bootdisk

### DIFF
--- a/manifests/cli/bootdisk.pp
+++ b/manifests/cli/bootdisk.pp
@@ -1,0 +1,8 @@
+# = Hammer foreman_bootdisk plugin
+#
+# This installs the foreman_bootdisk plugin for Hammer CLI
+#
+class foreman::cli::bootdisk {
+  foreman::cli::plugin { 'foreman_bootdisk':
+  }
+}

--- a/spec/acceptance/foreman_cli_plugins_spec.rb
+++ b/spec/acceptance/foreman_cli_plugins_spec.rb
@@ -21,6 +21,7 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
           include foreman::cli::resource_quota
         }
         include foreman::cli::ansible
+        include foreman::cli::bootdisk
         include foreman::cli::discovery
         include foreman::cli::google
         include foreman::cli::puppet
@@ -35,7 +36,7 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
 
     it_behaves_like 'hammer'
 
-    ['ansible', 'discovery', 'google', 'puppet', 'remote_execution', 'ssh', 'tasks', 'templates', 'webhooks'].each do |plugin|
+    ['ansible', 'bootdisk', 'discovery', 'google', 'puppet', 'remote_execution', 'ssh', 'tasks', 'templates', 'webhooks'].each do |plugin|
       package_name = case fact('os.family')
                      when 'RedHat'
                        "rubygem-hammer_cli_foreman_#{plugin}"

--- a/spec/classes/cli_plugins_spec.rb
+++ b/spec/classes/cli_plugins_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 supported = on_supported_os
 
-['ansible', 'azure', 'discovery', 'katello', 'kubevirt', 'openscap', 'remote_execution', 'resource_quota',
+['ansible', 'azure', 'bootdisk', 'discovery', 'katello', 'kubevirt', 'openscap', 'remote_execution', 'resource_quota',
  'ssh', 'tasks', 'templates', 'virt_who_configure', 'webhooks', 'puppet', 'google', 'rh_cloud'].each do |plugin|
   describe "foreman::cli::#{plugin}" do
     supported.each do |os, os_facts|


### PR DESCRIPTION
Based on eadb4edb11ee56e7edcfe4c8e61cc93cfc121af2

https://projects.theforeman.org/issues/38228

Tested locally by cherry-picking on Foreman 3.11; compared the stdout of foreman-installer, dnf, and hammer which all looked sane to me.

Refs https://github.com/theforeman/foreman-installer/pull/1009