### PR TITLE
Add hammer-cli-foreman-scc-manager package

### DIFF
--- a/manifests/cli/scc_manager.pp
+++ b/manifests/cli/scc_manager.pp
@@ -1,0 +1,8 @@
+# = Hammer foreman_scc_manager plugin
+#
+# This installs the foreman_scc_manager plugin for Hammer CLI
+#
+class foreman::cli::scc_manager {
+  foreman::cli::plugin { 'foreman_scc_manager':
+  }
+}

--- a/spec/acceptance/foreman_cli_plugins_spec.rb
+++ b/spec/acceptance/foreman_cli_plugins_spec.rb
@@ -19,6 +19,7 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
           include foreman::cli::kubevirt
           include foreman::cli::openscap
           include foreman::cli::resource_quota
+          include foreman::cli::scc_manager
         }
         include foreman::cli::ansible
         include foreman::cli::bootdisk
@@ -52,7 +53,7 @@ describe 'Scenario: install foreman-cli + plugins without foreman' do
     end
 
     if fact('os.family') == 'RedHat'
-      ['azure_rm', 'kubevirt', 'openscap', 'resource_quota'].each do |plugin|
+      ['azure_rm', 'kubevirt', 'openscap', 'resource_quota', 'scc_manager'].each do |plugin|
         describe package("rubygem-hammer_cli_foreman_#{plugin}") do
           it { is_expected.to be_installed }
         end

--- a/spec/classes/cli_plugins_spec.rb
+++ b/spec/classes/cli_plugins_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 supported = on_supported_os
 
 ['ansible', 'azure', 'bootdisk', 'discovery', 'katello', 'kubevirt', 'openscap', 'remote_execution', 'resource_quota',
- 'ssh', 'tasks', 'templates', 'virt_who_configure', 'webhooks', 'puppet', 'google', 'rh_cloud'].each do |plugin|
+ 'scc_manager', 'ssh', 'tasks', 'templates', 'virt_who_configure', 'webhooks', 'puppet', 'google', 'rh_cloud'].each do |plugin|
   describe "foreman::cli::#{plugin}" do
     supported.each do |os, os_facts|
       context "on #{os}" do


### PR DESCRIPTION
Adds the Hammer CLI for foreman_scc_manager: https://github.com/ATIX-AG/hammer-cli-foreman-scc-manager

This package is not built for deb: https://github.com/theforeman/foreman-packaging/tree/deb/develop/dependencies/jammy