### PR TITLE
Fixes #38330 - Set foreman_url in settings.yaml

### DIFF
--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -26,6 +26,7 @@ describe 'foreman' do
           should contain_concat__fragment('foreman_settings+00-header.yaml').with_content(/^## Module:\s+'foreman'$/)
 
           should contain_concat__fragment('foreman_settings+01-base.yaml')
+            .with_content(%r{^:foreman_url:\s*https://foo\.example\.com$})
             .with_content(/^:unattended:\s*true$/)
             .without_content(/^:unattended_url:/)
             .with_content(/^:require_ssl:\s*true$/)

--- a/templates/settings.yaml.erb
+++ b/templates/settings.yaml.erb
@@ -1,3 +1,4 @@
+:foreman_url: <%= scope.lookupvar("foreman::foreman_url") %>
 :unattended: <%= scope.lookupvar("foreman::unattended") %>
 <% unless [nil, :undefined, :undef].include?(scope.lookupvar("foreman::unattended_url")) -%>
 :unattended_url: <%= scope.lookupvar("foreman::unattended_url") %>


### PR DESCRIPTION
The foreman_url is already a parameter. It'd be more consistent if we enforced this in settings so users can't override it.

Should this be a backwards incompatible change given we'll override any user setting that previously existed? If so, should it also include a release note?