### PR TITLE
Add fact for remote-execution pubkey

### DIFF
--- a/lib/facter/foreman_remote_execution_pubkey.rb
+++ b/lib/facter/foreman_remote_execution_pubkey.rb
@@ -1,0 +1,9 @@
+Facter.add(:foreman_remote_execution_pubkey) do
+  pubkey = '/var/lib/foreman-proxy/ssh/id_rsa_foreman_proxy.pub'
+  confine do
+    File.exists?(pubkey)
+  end
+  setcode do
+    File.read(pubkey).strip
+  end
+end


### PR DESCRIPTION
This exposes the pubkey from the forman-proxy for remote execution.

```
root@foreman:~# puppet facts show foreman_remote_execution_pubkey --value
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDj/Sz9g2bUlqK5lP0ErpqX5XkDH3gknPPRKYt9rzA7YkVUoIfvpKh8qs4qJDzDEHJobfnDTmL+p2rMXFv2EzUJUNjUhPjm1WzcB2yOKvgAKGi+AN0iJXTbOU+PWR+oqK/xs33SkDGbG5UAFXwkBCI5NRK+QNhCXXoI0FDssMp0oTq1DhGRS9uhr/K3NLRDRfxcjsTJshm+33vYLXi+/GSxpzlpdcRjceqG46WvCeESoFZAqR3+YYCi8UF5ijhqwRRaeHOnumfRA4UzFLpvs9NzQLwvBCYynnyujDhaOQlmcurhMAW5WlWgE+nNjt9YFXlSsKmuyjGWOP8mH62WwxnCAvOnb1HAhDN9IePLEiIqkCrK9IKEx1fEouCsLwPzs6L5xLeSsmbNupQDv1jtCjSsXSy+DHUVZR/g2tkRAUjiR85SlabczwtV+DWhydHhw/A7qyhED/H3GlKNK0K0L5UkNNx1IWoKdg0EndrAxaYFjMog2v/tql3cIWUn0yYIpwE= foreman-proxy@foreman.betadots
```

Afterwards people can use `puppetdb_query()` to place the key on their systems.