### PR TITLE
Avoid dependency cycles with glibc-langpack-en

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -6,11 +6,7 @@ class foreman::database::postgresql {
   }
 
   include postgresql::client, postgresql::server
-
-  if $facts['os']['family'] == 'RedHat' {
-    stdlib::ensure_packages(['glibc-langpack-en'])
-    Package['glibc-langpack-en'] -> Postgresql::Server::Db[$foreman::db_database]
-  }
+  include foreman::database::postgresql::encoding
 
   postgresql::server::db { $foreman::db_database:
     user     => $foreman::db_username,
@@ -18,5 +14,6 @@ class foreman::database::postgresql {
     owner    => $foreman::db_username,
     encoding => 'utf8',
     locale   => 'en_US.utf8',
+    require  => Class['foreman::database::postgresql::encoding'],
   }
 }

--- a/manifests/database/postgresql/encoding.pp
+++ b/manifests/database/postgresql/encoding.pp
@@ -1,0 +1,7 @@
+# @summary Class to ensure the packages for encoding are installed
+# @api private
+class foreman::database::postgresql::encoding {
+  if $facts['os']['family'] == 'RedHat' {
+    stdlib::ensure_packages(['glibc-langpack-en'])
+  }
+}

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
 describe 'foreman' do
-  on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) { os_facts }
       let(:params) { {} }
+
+      if os_facts[:os]['family'] == 'RedHat'
+        it { should contain_package('glibc-langpack-en').that_comes_before('Postgresql::Server::Db[foreman]') }
+      else
+        it { should_not contain_package('glibc-langpack-en') }
+      end
 
       describe 'with db_manage set to false' do
         let(:params) { super().merge(db_manage: false) }


### PR DESCRIPTION
By calling `stdlib::ensure_packages()` in the class itself the resource gets tied to the class. If other packages also depend on the resource, you can get dependency cycles.

In particular, candlepin also does this and that causes a dependency cycle.

By using a class that is included the resource "floats" in the catalog. We then only ensure the package is installed somewhere before we create the database.

Link: https://github.com/theforeman/puppet-candlepin/commit/ca771455713546b6eb216116d546526097d3e71c
Fixes: 768a54ec814d ("Ensure glibc-langpack-en is always installed on EL")