### PR TITLE
Fixes #38517 - Ensure Redis is running before db:migrate

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@ class foreman::config {
       include redis
       $dynflow_redis_url = "redis://localhost:${redis::port}/6"
       Class['redis'] -> Service <| tag == 'foreman::dynflow::worker' |>
+      Class['redis'] -> Foreman::Rake <| tag == 'db:migrate' |>
     }
 
     file { '/etc/foreman/dynflow':

--- a/spec/classes/foreman_spec.rb
+++ b/spec/classes/foreman_spec.rb
@@ -131,7 +131,7 @@ describe 'foreman' do
         it { should contain_foreman__rake('db:seed') }
 
         # jobs
-        it { should contain_class('redis') }
+        it { should contain_class('redis').that_comes_before('Foreman::Rake[db:migrate]') }
         it { should contain_redis__instance('default') }
         it { should contain_file('/etc/foreman/dynflow').with_ensure('directory') }
         it {


### PR DESCRIPTION
In some cases a database migration can reach out to Redis. It should fail gracefully if Redis isn't available, but it's better to ensure it is available.