### PR TITLE
Allow puppetlabs/apache 13.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 8.0.0 < 13.0.0"
+      "version_requirement": ">= 8.0.0 < 14.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
https://forge.puppet.com/modules/puppetlabs/apache 13.0.0 was released, but our modules only allow "< 13"

Updating upper bound to "< 14" to fix this issue