### PR TITLE
Add packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,7 +34,7 @@ jobs:
       rhel-9:
         additional_repos:
           - https://yum.theforeman.org/releases/nightly/el9/x86_64/
-          - https://yum.puppet.com/puppet8/el/9/x86_64/
+          - https://yum.voxpupuli.org/openvox8/el/9/x86_64/
     module_hotfixes: true
 
 srpm_build_deps:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,47 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: foreman-installer.spec
+
+# add or remove files that should be synced
+files_to_sync:
+  - foreman-installer.spec
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: foreman-installer
+# downstream (Fedora) RPM package name
+downstream_package_name: foreman-installer
+
+upstream_tag_template: "{version}"
+
+actions:
+  post-upstream-clone:
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman-installer/foreman-installer.spec -O foreman-installer.spec"
+    - "git clone https://github.com/theforeman/foreman-installer"
+    - "sed -i '/theforeman.foreman[^_]/ s@:git.*@:git => \"#{__dir__}/../.git\", :ref => \"origin/HEAD\"@' foreman-installer/Puppetfile"
+  get-current-version:
+    - "sed 's/-develop//' foreman-installer/VERSION"
+  create-archive:
+    - bash -c "cd foreman-installer && bundle config set --local path vendor/bundle"
+    - bash -c "cd foreman-installer && bundle config set --local without development:test"
+    - bash -c "cd foreman-installer && bundle install"
+    - bash -c "cd foreman-installer && bundle exec rake pkg:generate_source"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      rhel-9:
+        additional_repos:
+          - https://yum.theforeman.org/releases/nightly/el9/x86_64/
+          - https://yum.puppet.com/puppet8/el/9/x86_64/
+    module_hotfixes: true
+
+srpm_build_deps:
+  - wget
+  - make
+  - gcc
+  - ruby
+  - ruby-devel
+  - rubygem-bundler
+

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,6 +41,7 @@ srpm_build_deps:
   - wget
   - make
   - gcc
+  - libffi-devel
   - ruby
   - ruby-devel
   - rubygem-bundler


### PR DESCRIPTION
Configure packit to build PRs in COPR against foreman-installer, using the foreman packit module workflow that patches foreman-installer to use the local checkout of puppet-foreman for the theforeman/foreman Puppetfile entry.

Based on the same setup in puppet-foreman_proxy.