### PR TITLE
Fixes #39187 - Ensure PostgreSQL locale on Debian

### DIFF
--- a/manifests/database/postgresql/encoding.pp
+++ b/manifests/database/postgresql/encoding.pp
@@ -3,5 +3,7 @@
 class foreman::database::postgresql::encoding {
   if $facts['os']['family'] == 'RedHat' {
     stdlib::ensure_packages(['glibc-langpack-en'])
+  } elsif $facts['os']['family'] == 'Debian' {
+    stdlib::ensure_packages(['locales-all'])
   }
 }

--- a/spec/classes/foreman_database_spec.rb
+++ b/spec/classes/foreman_database_spec.rb
@@ -8,8 +8,8 @@ describe 'foreman' do
 
       if os_facts[:os]['family'] == 'RedHat'
         it { should contain_package('glibc-langpack-en').that_comes_before('Postgresql::Server::Db[foreman]') }
-      else
-        it { should_not contain_package('glibc-langpack-en') }
+      elsif os_facts[:os]['family'] == 'Debian'
+        it { should contain_package('locales-all').that_comes_before('Postgresql::Server::Db[foreman]') }
       end
 
       describe 'with db_manage set to false' do


### PR DESCRIPTION
## Summary

Ensure the `en_US.utf8` locale is available on Debian-family systems before creating the Foreman PostgreSQL database.

Foreman passes `locale => 'en_US.utf8'` to `postgresql::server::db`. A fresh Debian or Ubuntu installation may not provide that locale, leaving the PostgreSQL role created but the database missing and causing `db:migrate` to fail. Installing `locales-all` follows the recommendation from `puppetlabs-postgresql` and mirrors the existing `glibc-langpack-en` handling on EL.

The reported Apache port 443 symptom is a consequence of the failed catalog: the SSL vhost is written, but the dependent Apache service refresh is skipped. Allowing the initial database setup to finish also allows that refresh to run normally.

Fixes: https://projects.theforeman.org/issues/39187

## Test coverage

- Added a catalog expectation that `locales-all` is installed before `Postgresql::Server::Db[foreman]` on Debian-family systems.
- Ruby syntax and whitespace checks pass locally. The full Puppet test bundle requires a newer Ruby than the available local runtime and is left to upstream CI.

This pull request was assisted by Codex 5.6 Sol High. The resulting changes were reviewed before submitting, and the commit includes an `Assisted-By` trailer.
